### PR TITLE
docs: add GitHub Copilot integration instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,31 @@
+## Agent Memory
+
+This project uses [Agentic Brain](https://github.com/feigi/agent-brain) for shared team knowledge.
+
+### Available Tools
+
+- **memory_search** -- Search for relevant memories. Call with a query describing what you need.
+- **memory_create** -- Save a new memory from important context the user shares.
+- **memory_get** -- Read a specific memory by ID.
+- **memory_update** -- Modify an existing memory.
+- **memory_comment** -- Append a comment to an existing memory (turns it into a thread).
+- **memory_verify** -- Confirm a memory is still accurate (updates verified_at).
+- **memory_archive** -- Archive a memory that is no longer relevant.
+- **memory_list_stale** -- List memories that need review (old or unverified).
+
+### When to Call `memory_search`
+
+**Call `memory_search` before actions that affect shared systems.** This includes:
+1. **The user asks about notes, context, or team knowledge** -- e.g. "any notes?", "what should I know?"
+2. **Before actions that affect shared infrastructure** -- deploys, database migrations, credential rotation, etc.
+3. **Before running shared/integration tests** (e.g. E2E, load tests) -- but NOT local unit tests or builds
+
+**Do NOT search for purely local actions** like editing files, installing dependencies, running local builds, linting, or formatting.
+
+### When the User Shares Important Context
+
+If the user mentions decisions, temporary changes, or gotchas that the team should know about, suggest saving a memory with `memory_create`. Always confirm before saving.
+
+### Presenting Memories
+
+Always **number** memories and include **author**, **date**, and **title**. The user may refer to memories by number (e.g. "archive memory 2", "comment on 1").

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Agentic Brain Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -122,25 +122,7 @@ Mock mode uses random vectors — search results won't be semantically meaningfu
 
 ### 4. Connect to Claude Code
 
-**Option A: npx from npm (no clone required)**
-
-```json
-{
-  "mcpServers": {
-    "agentic-brain": {
-      "command": "npx",
-      "args": ["-y", "agentic-brain"],
-      "env": {
-        "DATABASE_URL": "postgresql://agentic:agentic@localhost:5432/agentic_brain",
-        "EMBEDDING_PROVIDER": "ollama",
-        "EMBEDDING_DIMENSIONS": "768"
-      }
-    }
-  }
-}
-```
-
-**Option B: npx from GitHub (no npm publish required)**
+**Option A: npx from GitHub (no clone required)**
 
 ```json
 {
@@ -158,7 +140,7 @@ Mock mode uses random vectors — search results won't be semantically meaningfu
 }
 ```
 
-**Option C: from a local clone**
+**Option B: from a local clone**
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -122,7 +122,25 @@ Mock mode uses random vectors — search results won't be semantically meaningfu
 
 ### 4. Connect to Claude Code
 
-Add to your Claude Code MCP settings (`~/.claude/settings.json` or project `.claude/settings.json`):
+**Option A: npx (no clone required)**
+
+```json
+{
+  "mcpServers": {
+    "agentic-brain": {
+      "command": "npx",
+      "args": ["-y", "agentic-brain"],
+      "env": {
+        "DATABASE_URL": "postgresql://agentic:agentic@localhost:5432/agentic_brain",
+        "EMBEDDING_PROVIDER": "ollama",
+        "EMBEDDING_DIMENSIONS": "768"
+      }
+    }
+  }
+}
+```
+
+**Option B: from a local clone**
 
 ```json
 {
@@ -140,7 +158,7 @@ Add to your Claude Code MCP settings (`~/.claude/settings.json` or project `.cla
 }
 ```
 
-For production with Titan embeddings, set `EMBEDDING_PROVIDER=titan` and ensure `AWS_REGION` and credentials are available.
+Add to `~/.claude/settings.json` (global) or project `.claude/settings.json`. For production with Titan embeddings, set `EMBEDDING_PROVIDER=titan` and ensure `AWS_REGION` and credentials are available.
 
 ### 5. Integrate with Claude Code (optional)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agentic Brain
 
-Long-term memory for AI agents. Agents read relevant memories at session start, write new insights during sessions, and team members can manually save context. Exposed as an MCP server — works with Claude Code, Cursor, and any MCP-compatible agent.
+Long-term memory for AI agents. Agents read relevant memories at session start, write new insights during sessions, and team members can manually save context. Exposed as an MCP server — works with Claude Code, GitHub Copilot, Cursor, and any MCP-compatible agent.
 
 **Core value:** agents remember what matters across sessions. No team knowledge is lost because a conversation ended.
 
@@ -220,6 +220,38 @@ chmod +x .claude/hooks/memory-session-review.sh
 ```
 
 When Claude is about to stop, the hook blocks the first attempt and asks Claude to reflect on the session and save key learnings. See `docs/hooks/README.md` for details.
+
+### 5b. Integrate with GitHub Copilot (optional)
+
+GitHub Copilot's coding agent has its own instruction and hook system that lives in `.github/`. The concepts are the same as the Claude Code integration above, just different file locations.
+
+#### Add custom instructions
+
+Create `.github/copilot-instructions.md` in your project root. This is Copilot's equivalent of `CLAUDE.md` — it tells the Copilot coding agent when and how to use the memory tools.
+
+A ready-to-use instructions file is included in this repo at [`.github/copilot-instructions.md`](.github/copilot-instructions.md).
+
+#### Add a session-start hook (optional)
+
+Copilot supports hooks via `.github/hooks/hooks.json`. You can add a `sessionStart` hook to automatically trigger memory retrieval at the beginning of each coding agent session.
+
+Create `.github/hooks/hooks.json`:
+
+```json
+{
+  "hooks": [
+    {
+      "event": "sessionStart",
+      "script": {
+        "type": "command",
+        "bash": "echo 'Agentic Brain MCP server is available. Call memory_session_start at the beginning of each session to load relevant memories.'"
+      }
+    }
+  ]
+}
+```
+
+> **Note:** Copilot hooks use a different format from Claude Code hooks. See [GitHub's hooks documentation](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/use-hooks) for details.
 
 ### 6. Use the MCP Inspector (dev/debug)
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Every memory has:
 ### 1. Install
 
 ```bash
-git clone <repo>
+git clone https://github.com/feigi/agent-brain.git
 cd agent-brain
 npm install
 ```
@@ -102,11 +102,23 @@ AWS_REGION=us-east-1
 
 ### 3. Start
 
+**Local development (everything runs locally via Docker — no AWS needed):**
+
 ```bash
 npm run dev
 ```
 
-This starts Postgres + Ollama via Docker (downloading `nomic-embed-text` on first run — ~274MB), runs migrations, and starts the MCP server on stdio.
+This starts Postgres + Ollama via Docker Compose (downloading `nomic-embed-text` on first run — ~274MB), runs database migrations, and starts the MCP server on stdio. No cloud credentials required.
+
+**Minimal local setup (mock embeddings — fastest, no Ollama download):**
+
+```bash
+docker compose up -d --wait        # Start Postgres only
+npx drizzle-kit migrate             # Run migrations
+EMBEDDING_PROVIDER=mock npm start   # Start with mock embeddings
+```
+
+Mock mode uses random vectors — search results won't be semantically meaningful, but all tools work. Good for testing the MCP integration.
 
 ### 4. Connect to Claude Code
 
@@ -141,7 +153,7 @@ Create or edit `CLAUDE.md` in your project root (or `~/.claude/CLAUDE.md` for gl
 ````markdown
 ## Agent Memory
 
-This project uses [Agentic Brain](https://github.com/TODO/agent-brain) for shared team knowledge.
+This project uses [Agentic Brain](https://github.com/feigi/agent-brain) for shared team knowledge.
 
 ### Available Tools
 
@@ -304,7 +316,9 @@ src/
 │   └── memory-service.ts  # Core business logic
 ├── repositories/       # Data access layer (Drizzle)
 ├── providers/
-│   └── embedding/      # Titan V2 + mock implementations
+│   └── embedding/      # Titan V2, Ollama + mock implementations
+├── prompts/            # System prompts (memory guidance)
+├── types/              # Shared type definitions
 └── utils/              # Scoring, validation, logging, IDs
 ```
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Mock mode uses random vectors — search results won't be semantically meaningfu
 
 ### 4. Connect to Claude Code
 
-**Option A: npx (no clone required)**
+**Option A: npx from npm (no clone required)**
 
 ```json
 {
@@ -140,7 +140,25 @@ Mock mode uses random vectors — search results won't be semantically meaningfu
 }
 ```
 
-**Option B: from a local clone**
+**Option B: npx from GitHub (no npm publish required)**
+
+```json
+{
+  "mcpServers": {
+    "agentic-brain": {
+      "command": "npx",
+      "args": ["-y", "github:feigi/agent-brain"],
+      "env": {
+        "DATABASE_URL": "postgresql://agentic:agentic@localhost:5432/agentic_brain",
+        "EMBEDDING_PROVIDER": "ollama",
+        "EMBEDDING_DIMENSIONS": "768"
+      }
+    }
+  }
+}
+```
+
+**Option C: from a local clone**
 
 ```json
 {

--- a/bin/agentic-brain.mjs
+++ b/bin/agentic-brain.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const serverPath = join(__dirname, "..", "src", "server.ts");
+
+const result = spawnSync(
+  process.execPath,
+  ["--import", "tsx/esm", serverPath],
+  { stdio: "inherit", env: process.env }
+);
+
+process.exit(result.status ?? 1);

--- a/docker-compose.ollama.yml
+++ b/docker-compose.ollama.yml
@@ -1,10 +1,4 @@
 services:
-  postgres:
-    # Inherits from base docker-compose.yml — no overrides needed
-    extends:
-      file: docker-compose.yml
-      service: postgres
-
   ollama:
     image: ollama/ollama:latest
     ports:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "type": "module",
   "description": "A long-term memory system for AI agents, exposed as an MCP server",
+  "bin": {
+    "agentic-brain": "bin/agentic-brain.mjs"
+  },
   "scripts": {
     "dev": "docker compose -f docker-compose.yml -f docker-compose.ollama.yml up -d --wait && npx drizzle-kit migrate && EMBEDDING_PROVIDER=ollama EMBEDDING_DIMENSIONS=768 tsx watch src/server.ts",
     "start": "tsx src/server.ts",


### PR DESCRIPTION
## Summary

- Add `.github/copilot-instructions.md` with memory tool guidance — Copilot's equivalent of `CLAUDE.md`
- Add "Integrate with GitHub Copilot" section (5b) in README alongside the existing Claude Code section
- Document Copilot's `sessionStart` hook setup via `.github/hooks/hooks.json`
- Mention GitHub Copilot in the repo intro line

## Research findings

GitHub Copilot has its own instruction/hook system that is separate from Claude Code:

| Feature | Claude Code | GitHub Copilot |
|---------|------------|----------------|
| Instructions file | `CLAUDE.md` | `.github/copilot-instructions.md` |
| Hook config | `.claude/settings.json` | `.github/hooks/hooks.json` |
| Session start hook | `SessionStart` | `sessionStart` |
| Pre-tool hook | `PreToolUse` | `preToolUse` |

Copilot does **not** use Claude Code hooks — it has its own parallel system under `.github/`.

## Test plan

- [ ] Verify `.github/copilot-instructions.md` renders correctly on GitHub
- [ ] Verify README section 5b formatting and links
- [ ] Test that Copilot coding agent picks up the instructions file

https://claude.ai/code/session_01Qt1UD22DF8hdTpEbHnJisH