### PR TITLE
fix: make flagService parameter required in registerAllTools

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -17,7 +17,7 @@ import { registerMemoryResolveFlag } from "./memory-resolve-flag.js";
 export function registerAllTools(
   server: McpServer,
   memoryService: MemoryService,
-  flagService?: FlagService,
+  flagService: FlagService,
 ): void {
   registerMemoryCreate(server, memoryService);
   registerMemoryGet(server, memoryService);
@@ -30,7 +30,5 @@ export function registerAllTools(
   registerMemorySessionStart(server, memoryService);
   registerMemoryComment(server, memoryService);
   registerMemoryListRecent(server, memoryService);
-  if (flagService) {
-    registerMemoryResolveFlag(server, flagService);
-  }
+  registerMemoryResolveFlag(server, flagService);
 }


### PR DESCRIPTION
## Summary
- Removed misleading optional typing (`?`) from `flagService` parameter in `registerAllTools` — the caller (`server.ts`) always passes it
- Removed the unnecessary `if (flagService)` guard around `registerMemoryResolveFlag` registration

## Test plan
- [x] All 189 unit tests pass
- [x] No other callers of `registerAllTools` exist that omit `flagService`

🤖 Generated with [Claude Code](https://claude.com/claude-code)