### PR TITLE
perf: pre-compute normalized strings in content subset detection

### DIFF
--- a/src/services/consolidation-service.ts
+++ b/src/services/consolidation-service.ts
@@ -135,16 +135,18 @@ export class ConsolidationService {
     const archivedIds = new Set<string>();
 
     // Tier 1a: Content subset check (normalized substring match)
+    const normalized = active.map((m) =>
+      m.content.toLowerCase().replace(/\s+/g, " ").trim(),
+    );
+
     for (let i = 0; i < active.length; i++) {
       if (archivedIds.has(active[i].id)) continue;
-      const normI = active[i].content.toLowerCase().replace(/\s+/g, " ").trim();
       for (let j = 0; j < active.length; j++) {
         if (i === j || archivedIds.has(active[j].id)) continue;
-        const normJ = active[j].content
-          .toLowerCase()
-          .replace(/\s+/g, " ")
-          .trim();
-        if (normJ.includes(normI) && normI.length < normJ.length) {
+        if (
+          normalized[j].includes(normalized[i]) &&
+          normalized[i].length < normalized[j].length
+        ) {
           await this.memoryRepo.archive([active[i].id]);
           await this.auditService.logArchive(
             active[i].id,


### PR DESCRIPTION
## Summary
- Pre-computes normalized content strings (lowercase + whitespace collapse + trim) once before the O(n^2) nested loop in `consolidateScope()`
- Eliminates redundant re-normalization on every inner-loop iteration, reducing normalization calls from O(n^2) to O(n)

## Test plan
- [x] All 189 unit tests pass
- [x] Code review via simplify skill confirmed no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)