### PR TITLE
fix: use config value for max flags per session

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -98,6 +98,7 @@ async function main() {
     sessionLifecycleRepo,
     auditService,
     flagService,
+    config.consolidationMaxFlagsPerSession,
   );
 
   // Initialize consolidation scheduler (opt-in via config)

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -45,6 +45,7 @@ export class MemoryService {
     private readonly sessionLifecycleRepo?: SessionRepository,
     private readonly auditService?: AuditService,
     private readonly flagService?: FlagService,
+    private readonly maxFlagsPerSession: number = 5,
   ) {}
 
   // D-11: Workspace/Project=shared, User=owner only
@@ -719,8 +720,10 @@ export class MemoryService {
       | undefined;
 
     if (this.flagService) {
-      // TODO: use config.consolidationMaxFlagsPerSession when added in Task 10
-      const openFlags = await this.flagService.getOpenFlags(workspaceId, 5);
+      const openFlags = await this.flagService.getOpenFlags(
+        workspaceId,
+        this.maxFlagsPerSession,
+      );
       if (openFlags.length > 0) {
         const enriched = [];
         for (const f of openFlags) {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -96,6 +96,7 @@ export function createTestServiceWithAudit(
 export function createTestServiceWithFlags(
   flagService: FlagService,
   auditService: AuditService,
+  maxFlagsPerSession?: number,
 ): MemoryService {
   const testDb = getTestDb();
   const memoryRepo = new DrizzleMemoryRepository(testDb);
@@ -113,6 +114,7 @@ export function createTestServiceWithFlags(
     undefined, // sessionLifecycleRepo
     auditService,
     flagService,
+    maxFlagsPerSession,
   );
 }
 


### PR DESCRIPTION
## Summary
- Thread `consolidationMaxFlagsPerSession` from config through `MemoryService` constructor instead of hardcoding the limit to `5`
- Remove the TODO comment that referenced this fix
- Update test helper `createTestServiceWithFlags` to accept optional `maxFlagsPerSession` param

## Test plan
- [ ] All existing 189 tests continue to pass
- [ ] Default behavior unchanged (defaults to 5 when not specified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)