### PR TITLE
fix: prevent duplicate flag accumulation in consolidation engine

### DIFF
--- a/src/repositories/flag-repository.ts
+++ b/src/repositories/flag-repository.ts
@@ -1,7 +1,7 @@
 import { eq, and, isNull, desc, sql } from "drizzle-orm";
 import type { Database } from "../db/index.js";
 import { flags, memories } from "../db/schema.js";
-import type { Flag, FlagResolution } from "../types/flag.js";
+import type { Flag, FlagResolution, FlagType } from "../types/flag.js";
 import type { FlagRepository } from "./types.js";
 
 export class DrizzleFlagRepository implements FlagRepository {
@@ -101,5 +101,31 @@ export class DrizzleFlagRepository implements FlagRepository {
       .where(and(eq(flags.memory_id, memoryId), isNull(flags.resolved_at)))
       .returning({ id: flags.id });
     return result.length;
+  }
+
+  async hasOpenFlag(
+    memoryId: string,
+    flagType: FlagType,
+    relatedMemoryId?: string,
+  ): Promise<boolean> {
+    const conditions = [
+      eq(flags.memory_id, memoryId),
+      eq(flags.flag_type, sql`${flagType}::flag_type`),
+      isNull(flags.resolved_at),
+    ];
+
+    if (relatedMemoryId) {
+      conditions.push(
+        sql`${flags.details}->>'related_memory_id' = ${relatedMemoryId}`,
+      );
+    }
+
+    const result = await this.db
+      .select({ exists: sql`1` })
+      .from(flags)
+      .where(and(...conditions))
+      .limit(1);
+
+    return result.length > 0;
   }
 }

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -1,6 +1,6 @@
 import type { Memory, MemoryWithRelevance, Comment } from "../types/memory.js";
 import type { AuditEntry } from "../types/audit.js";
-import type { Flag, FlagResolution } from "../types/flag.js";
+import type { Flag, FlagResolution, FlagType } from "../types/flag.js";
 
 // INFR-02: Repository interfaces -- abstract storage layer
 
@@ -171,6 +171,11 @@ export interface FlagRepository {
   ): Promise<Flag | null>;
   findByMemoryId(memoryId: string): Promise<Flag[]>;
   autoResolveByMemoryId(memoryId: string): Promise<number>;
+  hasOpenFlag(
+    memoryId: string,
+    flagType: FlagType,
+    relatedMemoryId?: string,
+  ): Promise<boolean>;
 }
 
 export interface RecentActivityOptions {

--- a/src/services/consolidation-service.ts
+++ b/src/services/consolidation-service.ts
@@ -213,6 +213,13 @@ export class ConsolidationService {
           archivedIds.add(olderMemoryId);
           result.archived++;
         } else if (classification === "flag_duplicate") {
+          const alreadyFlagged = await this.flagService.hasOpenFlag(
+            pair.memory_b_id,
+            "duplicate",
+            pair.memory_a_id,
+          );
+          if (alreadyFlagged) continue;
+
           await this.flagService.createFlag({
             memoryId: pair.memory_b_id,
             flagType: "duplicate",
@@ -225,6 +232,13 @@ export class ConsolidationService {
           });
           result.flagged++;
         } else if (classification === "flag_contradiction") {
+          const alreadyFlagged = await this.flagService.hasOpenFlag(
+            pair.memory_b_id,
+            "contradiction",
+            pair.memory_a_id,
+          );
+          if (alreadyFlagged) continue;
+
           await this.flagService.createFlag({
             memoryId: pair.memory_b_id,
             flagType: "contradiction",
@@ -289,12 +303,18 @@ export class ConsolidationService {
             classification === "flag_superseded" ||
             classification === "flag_override"
           ) {
+            const flagType =
+              classification === "flag_superseded" ? "superseded" : "override";
+            const alreadyFlagged = await this.flagService.hasOpenFlag(
+              wsMem.id,
+              flagType,
+              dup.id,
+            );
+            if (alreadyFlagged) continue;
+
             await this.flagService.createFlag({
               memoryId: wsMem.id,
-              flagType:
-                classification === "flag_superseded"
-                  ? "superseded"
-                  : "override",
+              flagType,
               severity: "needs_review",
               details: {
                 related_memory_id: dup.id,
@@ -352,6 +372,13 @@ export class ConsolidationService {
 
         const allDups = [...wsDups, ...projDups];
         for (const dup of allDups) {
+          const alreadyFlagged = await this.flagService.hasOpenFlag(
+            userMem.id,
+            "superseded",
+            dup.id,
+          );
+          if (alreadyFlagged) continue;
+
           await this.flagService.createFlag({
             memoryId: userMem.id,
             flagType: "superseded",
@@ -389,11 +416,9 @@ export class ConsolidationService {
 
     for (const memory of staleResult.memories) {
       try {
-        const existingFlags = await this.flagService.getFlagsByMemoryId(
+        const hasOpenVerify = await this.flagService.hasOpenFlag(
           memory.id,
-        );
-        const hasOpenVerify = existingFlags.some(
-          (f) => f.flag_type === "verify" && f.resolved_at === null,
+          "verify",
         );
         if (hasOpenVerify) continue;
 

--- a/src/services/flag-service.ts
+++ b/src/services/flag-service.ts
@@ -84,4 +84,12 @@ export class FlagService {
   async autoResolveByMemoryId(memoryId: string): Promise<number> {
     return this.flagRepo.autoResolveByMemoryId(memoryId);
   }
+
+  async hasOpenFlag(
+    memoryId: string,
+    flagType: FlagType,
+    relatedMemoryId?: string,
+  ): Promise<boolean> {
+    return this.flagRepo.hasOpenFlag(memoryId, flagType, relatedMemoryId);
+  }
 }

--- a/tests/integration/consolidation.test.ts
+++ b/tests/integration/consolidation.test.ts
@@ -215,31 +215,33 @@ describe("consolidation full run", () => {
 
   it("does not create duplicate flags for the same memory pair", async () => {
     // 1. Create two memories
-    const m1 = await service.create({
+    const m1Result = await service.create({
       workspace_id: "test-ws",
       content: "always use snake_case for database columns",
       type: "decision",
       author: "alice",
     });
-    assertMemory(m1.data);
-    const m2 = await service.create({
+    assertMemory(m1Result.data);
+    const m1 = m1Result.data;
+    const m2Result = await service.create({
       workspace_id: "test-ws",
       content: "always use snake_case for db columns",
       type: "decision",
       author: "alice",
     });
-    assertMemory(m2.data);
+    assertMemory(m2Result.data);
+    const m2 = m2Result.data;
 
     // 2. Manually create a needs_review duplicate flag for this pair
     const db = getTestDb();
     await db.insert(flags).values({
       id: generateId(),
       project_id: "test-project",
-      memory_id: m2.data.id,
+      memory_id: m2.id,
       flag_type: "duplicate",
       severity: "needs_review",
       details: {
-        related_memory_id: m1.data.id,
+        related_memory_id: m1.id,
         similarity: 0.92,
         reason: "Probable duplicate",
       },
@@ -249,11 +251,10 @@ describe("consolidation full run", () => {
     await consolidationService.run();
 
     // 4. Verify no additional duplicate flag was created for that pair
-    const memoryFlags = await flagRepo.findByMemoryId(m2.data.id);
+    const memoryFlags = await flagRepo.findByMemoryId(m2.id);
     const dupFlags = memoryFlags.filter(
       (f) =>
-        f.flag_type === "duplicate" &&
-        f.details.related_memory_id === m1.data.id,
+        f.flag_type === "duplicate" && f.details.related_memory_id === m1.id,
     );
     expect(dupFlags).toHaveLength(1);
   });

--- a/tests/integration/consolidation.test.ts
+++ b/tests/integration/consolidation.test.ts
@@ -13,8 +13,9 @@ import { DrizzleAuditRepository } from "../../src/repositories/audit-repository.
 import { AuditService } from "../../src/services/audit-service.js";
 import { FlagService } from "../../src/services/flag-service.js";
 import { ConsolidationService } from "../../src/services/consolidation-service.js";
-import { memories } from "../../src/db/schema.js";
+import { memories, flags } from "../../src/db/schema.js";
 import { eq } from "drizzle-orm";
+import { generateId } from "../../src/utils/id.js";
 import type { MemoryService } from "../../src/services/memory-service.js";
 
 describe("consolidation repository support", () => {
@@ -210,6 +211,51 @@ describe("consolidation full run", () => {
     const memoryFlags = await flagRepo.findByMemoryId(created.data.id);
     const verifyFlags = memoryFlags.filter((f) => f.flag_type === "verify");
     expect(verifyFlags).toHaveLength(1);
+  });
+
+  it("does not create duplicate flags for the same memory pair", async () => {
+    // 1. Create two memories
+    const m1 = await service.create({
+      workspace_id: "test-ws",
+      content: "always use snake_case for database columns",
+      type: "decision",
+      author: "alice",
+    });
+    assertMemory(m1.data);
+    const m2 = await service.create({
+      workspace_id: "test-ws",
+      content: "always use snake_case for db columns",
+      type: "decision",
+      author: "alice",
+    });
+    assertMemory(m2.data);
+
+    // 2. Manually create a needs_review duplicate flag for this pair
+    const db = getTestDb();
+    await db.insert(flags).values({
+      id: generateId(),
+      project_id: "test-project",
+      memory_id: m2.data.id,
+      flag_type: "duplicate",
+      severity: "needs_review",
+      details: {
+        related_memory_id: m1.data.id,
+        similarity: 0.92,
+        reason: "Probable duplicate",
+      },
+    });
+
+    // 3. Run consolidation
+    await consolidationService.run();
+
+    // 4. Verify no additional duplicate flag was created for that pair
+    const memoryFlags = await flagRepo.findByMemoryId(m2.data.id);
+    const dupFlags = memoryFlags.filter(
+      (f) =>
+        f.flag_type === "duplicate" &&
+        f.details.related_memory_id === m1.data.id,
+    );
+    expect(dupFlags).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `hasOpenFlag(memoryId, flagType, relatedMemoryId?)` to FlagRepository, FlagService, and the FlagRepository interface to efficiently check for existing unresolved flags (SELECT 1 ... LIMIT 1)
- Guards all flag-creation paths in ConsolidationService (`consolidateScope`, `crossScopeCheck`, `userScopeCheck`, `flagVerificationCandidates`) with idempotency checks before creating duplicate/contradiction/superseded/override/verify flags
- Refactors the existing verify-flag idempotency check from fetching all flags + JS filtering to the new single-row query
- Adds integration test verifying that pre-existing flags prevent duplicate flag creation on subsequent consolidation runs

## Test plan
- [x] All 190 tests pass (189 existing + 1 new)
- [x] New test: "does not create duplicate flags for the same memory pair" — creates two memories, manually inserts a duplicate flag, runs consolidation, asserts only one flag exists for the pair

🤖 Generated with [Claude Code](https://claude.com/claude-code)