### PR TITLE
feat: slim memory projections for list endpoints

### DIFF
--- a/docs/superpowers/plans/2026-04-06-slim-memory-projections.md
+++ b/docs/superpowers/plans/2026-04-06-slim-memory-projections.md
@@ -1,0 +1,386 @@
+# Slim Memory Projections Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce token waste by returning only useful fields from list endpoints, while keeping full details available via `memory_get`.
+
+**Architecture:** Add `MemorySummary` and `MemoryDetail` projection types alongside the existing `Memory` interface. Projection functions (`toSummary`, `toDetail`) map `Memory` objects at the service layer before wrapping in `Envelope`. Repository layer unchanged.
+
+**Tech Stack:** TypeScript, Vitest
+
+---
+
+### File Structure
+
+| File                                       | Action | Responsibility                                                                                              |
+| ------------------------------------------ | ------ | ----------------------------------------------------------------------------------------------------------- |
+| `src/types/memory.ts`                      | Modify | Add `MemorySummary`, `MemoryDetail`, derived types, `toSummary()`, `toDetail()`                             |
+| `src/services/memory-service.ts`           | Modify | Apply projections in `search`, `sessionStart`, `list`, `listRecentActivity`, `listStale`, `getWithComments` |
+| `tests/integration/memory-scoping.test.ts` | Modify | Fix assertion that references `project_id` on search result                                                 |
+
+---
+
+### Task 1: Add projection types and functions
+
+**Files:**
+
+- Modify: `src/types/memory.ts`
+
+- [ ] **Step 1: Write the `MemorySummary` interface**
+
+Add after the existing `Memory` interface (after line 38):
+
+```typescript
+// Slim projection for list endpoints — omits internal/DB-only fields
+export interface MemorySummary {
+  id: string;
+  title: string;
+  content: string;
+  type: MemoryType;
+  scope: MemoryScope;
+  tags: string[] | null;
+  author: string;
+  source: string | null;
+  created_at: Date;
+  updated_at: Date;
+  verified_at: Date | null;
+  verified_by: string | null;
+  comment_count: number;
+  last_comment_at: Date | null;
+}
+```
+
+- [ ] **Step 2: Write the `MemoryDetail` interface**
+
+Add after `MemorySummary`:
+
+```typescript
+// Full projection for detail endpoints — everything except embedding internals
+export interface MemoryDetail extends MemorySummary {
+  project_id: string;
+  workspace_id: string | null;
+  version: number;
+  session_id: string | null;
+  metadata: Record<string, unknown> | null;
+  archived_at: Date | null;
+}
+```
+
+- [ ] **Step 3: Write `toSummary` projection function**
+
+Add after the interfaces:
+
+```typescript
+/** Project a full Memory to the slim list representation */
+export function toSummary(memory: Memory): MemorySummary {
+  return {
+    id: memory.id,
+    title: memory.title,
+    content: memory.content,
+    type: memory.type,
+    scope: memory.scope,
+    tags: memory.tags,
+    author: memory.author,
+    source: memory.source,
+    created_at: memory.created_at,
+    updated_at: memory.updated_at,
+    verified_at: memory.verified_at,
+    verified_by: memory.verified_by,
+    comment_count: memory.comment_count,
+    last_comment_at: memory.last_comment_at,
+  };
+}
+```
+
+- [ ] **Step 4: Write `toDetail` projection function**
+
+```typescript
+/** Project a full Memory to the detail representation (strips embedding internals) */
+export function toDetail(memory: Memory): MemoryDetail {
+  return {
+    ...toSummary(memory),
+    project_id: memory.project_id,
+    workspace_id: memory.workspace_id,
+    version: memory.version,
+    session_id: memory.session_id,
+    metadata: memory.metadata,
+    archived_at: memory.archived_at,
+  };
+}
+```
+
+- [ ] **Step 5: Add derived types and update existing ones**
+
+Replace the existing `MemoryWithRelevance` (line 87-89) and `MemoryWithChangeType` (line 59-61):
+
+```typescript
+// Slim variants for list endpoints
+export interface MemorySummaryWithRelevance extends MemorySummary {
+  relevance: number;
+}
+
+export interface MemorySummaryWithChangeType extends MemorySummary {
+  change_type: "created" | "updated" | "commented";
+}
+```
+
+Keep the old `MemoryWithRelevance` and `MemoryWithChangeType` — they extend `Memory` and are still used internally by the repository layer and for intermediate computation. Rename them to clarify:
+
+Actually, no — the repository returns `MemoryWithRelevance` from `search()`. The service receives these, then projects. So keep the old types as-is for internal use. Just add the new `MemorySummary*` variants for the service return types.
+
+- [ ] **Step 6: Update `MemoryGetResponse` to extend `MemoryDetail`**
+
+Replace the existing `MemoryGetResponse` (line 50-56):
+
+```typescript
+// D-72, D-63: Enhanced response for memory_get with comments and capability flags
+export interface MemoryGetResponse extends MemoryDetail {
+  comments: Comment[];
+  can_comment: boolean;
+  can_edit: boolean;
+  can_archive: boolean;
+  can_verify: boolean;
+}
+```
+
+- [ ] **Step 7: Run type check to verify**
+
+Run: `npx tsc --noEmit`
+Expected: PASS (no consumers of the changed `MemoryGetResponse` type should break since `MemoryDetail` has all the same fields as the old `Memory` base minus embedding fields, and nothing accesses embedding fields on `MemoryGetResponse`)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/types/memory.ts
+git commit -m "feat: add MemorySummary and MemoryDetail projection types"
+```
+
+---
+
+### Task 2: Apply projections in service layer
+
+**Files:**
+
+- Modify: `src/services/memory-service.ts`
+
+- [ ] **Step 1: Update imports**
+
+Update the import from `../types/memory.js` to include the new types and functions:
+
+```typescript
+import type {
+  Memory,
+  MemoryCreate,
+  MemoryUpdate,
+  MemoryWithRelevance,
+  Comment,
+  MemoryGetResponse,
+  MemoryWithChangeType,
+  CreateSkipResult,
+  MemorySummary,
+  MemorySummaryWithRelevance,
+  MemorySummaryWithChangeType,
+} from "../types/memory.js";
+import { toSummary, toDetail } from "../types/memory.js";
+```
+
+Note: split the value imports (`toSummary`, `toDetail`) into a separate non-`type` import since they're runtime functions.
+
+- [ ] **Step 2: Update `search()` return type and projection**
+
+Change the return type from `Promise<Envelope<MemoryWithRelevance[]>>` to `Promise<Envelope<MemorySummaryWithRelevance[]>>`.
+
+In the method body, after the `scored.sort(...)` and `const results = scored.slice(0, effectiveLimit);` lines (~line 602), project the results before returning:
+
+```typescript
+const projected: MemorySummaryWithRelevance[] = results.map((r) => ({
+  ...toSummary(r),
+  relevance: r.relevance,
+}));
+
+const timing = Date.now() - start;
+return {
+  data: projected,
+  meta: { count: projected.length, timing },
+};
+```
+
+- [ ] **Step 3: Update `sessionStart()` return type and projection**
+
+Change the return type from `Promise<Envelope<MemoryWithRelevance[]>>` to `Promise<Envelope<MemorySummaryWithRelevance[]>>`.
+
+Update the local `result` variable type (~line 647):
+
+```typescript
+let result: Envelope<MemorySummaryWithRelevance[]>;
+```
+
+The `context` branch calls `this.search()` which now returns projected data — no change needed.
+
+The no-context branch builds `MemoryWithRelevance[]` from `recentMemories`. Update the mapping (~line 670):
+
+```typescript
+const scored: MemorySummaryWithRelevance[] = recentMemories.map((memory) => ({
+  ...toSummary(memory),
+  relevance: computeRelevance(
+    1.0,
+    memory.created_at,
+    memory.verified_at,
+    config.recencyHalfLifeDays,
+  ),
+}));
+```
+
+- [ ] **Step 4: Update `list()` return type and projection**
+
+Change the return type from `Promise<Envelope<Memory[]>>` to `Promise<Envelope<MemorySummary[]>>`.
+
+Project after fetching (~line 780):
+
+```typescript
+const projected = result.memories.map(toSummary);
+
+const timing = Date.now() - start;
+return {
+  data: projected,
+  meta: {
+    count: projected.length,
+    has_more: result.has_more,
+    cursor: result.cursor
+      ? `${result.cursor.created_at}|${result.cursor.id}`
+      : undefined,
+    timing,
+  },
+};
+```
+
+- [ ] **Step 5: Update `listRecentActivity()` return type and projection**
+
+Change the return type from `Promise<Envelope<MemoryWithChangeType[]>>` to `Promise<Envelope<MemorySummaryWithChangeType[]>>`.
+
+Update the mapping (~line 411):
+
+```typescript
+const withChangeType: MemorySummaryWithChangeType[] = recentMemories.map(
+  (memory) => ({
+    ...toSummary(memory),
+    change_type: this.getChangeType(memory, since),
+  }),
+);
+```
+
+- [ ] **Step 6: Update `listStale()` return type and projection**
+
+Change the return type from `Promise<Envelope<Memory[]>>` to `Promise<Envelope<MemorySummary[]>>`.
+
+After the `filtered` line (~line 840), project:
+
+```typescript
+const projected = filtered.map(toSummary);
+
+const timing = Date.now() - start;
+return {
+  data: projected,
+  meta: {
+    count: projected.length,
+    has_more: result.has_more,
+    cursor: result.cursor
+      ? `${result.cursor.created_at}|${result.cursor.id}`
+      : undefined,
+    timing,
+  },
+};
+```
+
+- [ ] **Step 7: Update `getWithComments()` to use `toDetail`**
+
+In the return statement (~line 308), replace `...memory` spread with `...toDetail(memory)`:
+
+```typescript
+return {
+  data: {
+    ...toDetail(memory),
+    comments: commentsList,
+    ...capabilities,
+  },
+  meta: { timing },
+};
+```
+
+- [ ] **Step 8: Run type check**
+
+Run: `npx tsc --noEmit`
+Expected: PASS — or compile errors pointing to test files that reference stripped fields (addressed in Task 3).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/services/memory-service.ts
+git commit -m "feat: apply slim projections in all list and detail endpoints"
+```
+
+---
+
+### Task 3: Fix test that references stripped field
+
+**Files:**
+
+- Modify: `tests/integration/memory-scoping.test.ts:41-44`
+
+- [ ] **Step 1: Update the cross-project search assertion**
+
+The test at line 41-44 currently asserts:
+
+```typescript
+const crossProjectMatch = result.data.find((m) => m.project_id === "project-a");
+expect(crossProjectMatch).toBeUndefined();
+```
+
+`project_id` is no longer on search results. The test's intent is to verify workspace isolation — that searching in `project-b` doesn't return memories from `project-a`. The result set being empty already proves this. Replace with:
+
+```typescript
+// Workspace isolation: searching in project-b should not return project-a's memories
+const crossWorkspaceMatch = result.data.find(
+  (m) => m.content === "Secret project-a knowledge about deployment pipelines",
+);
+expect(crossWorkspaceMatch).toBeUndefined();
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `npm test`
+Expected: All tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/memory-scoping.test.ts
+git commit -m "test: update scoping test to not reference stripped project_id field"
+```
+
+---
+
+### Task 4: Verify end-to-end
+
+- [ ] **Step 1: Run full test suite and type check in parallel**
+
+Run: `npx tsc --noEmit && npm test`
+Expected: All pass, no type errors.
+
+- [ ] **Step 2: Manual smoke test via REST API**
+
+Start the server and call session_start to verify the response shape:
+
+```bash
+curl -s -X POST http://localhost:19898/api/tools/memory_session_start \
+  -H 'Content-Type: application/json' \
+  -d '{"workspace_id":"agent-brain","user_id":"chris","limit":2}' | jq '.data[0] | keys'
+```
+
+Expected keys: `author`, `comment_count`, `content`, `created_at`, `id`, `last_comment_at`, `relevance`, `scope`, `source`, `tags`, `title`, `type`, `updated_at`, `verified_at`, `verified_by`.
+
+Should NOT contain: `project_id`, `workspace_id`, `embedding_model`, `embedding_dimensions`, `version`, `session_id`, `metadata`, `archived_at`.
+
+- [ ] **Step 3: Commit all (if any fixups needed)**
+
+Only if previous tasks needed fixups. Otherwise this step is a no-op.

--- a/docs/superpowers/specs/2026-04-06-slim-memory-projections-design.md
+++ b/docs/superpowers/specs/2026-04-06-slim-memory-projections-design.md
@@ -1,0 +1,84 @@
+# Slim Memory Projections for List vs Detail Endpoints
+
+## Problem
+
+All endpoints return the full `Memory` object (20+ fields), including internal fields like `embedding_model`, `embedding_dimensions`, `version`, `session_id`, and `metadata`. This wastes tokens when memories are injected into agent context at session start, and is unnecessary for list-type responses where the consumer only needs enough to understand and triage.
+
+## Design
+
+Introduce two projection types that sit between the internal `Memory` type and the API consumer:
+
+- **`MemorySummary`** — slim representation for list endpoints
+- **`MemoryDetail`** — full representation (minus embedding internals) for the detail endpoint
+
+### Field mapping
+
+| Field                  | `MemorySummary` | `MemoryDetail` | Never exposed |
+| ---------------------- | --------------- | -------------- | ------------- |
+| `id`                   | yes             | yes            |               |
+| `title`                | yes             | yes            |               |
+| `content`              | yes             | yes            |               |
+| `type`                 | yes             | yes            |               |
+| `scope`                | yes             | yes            |               |
+| `tags`                 | yes             | yes            |               |
+| `author`               | yes             | yes            |               |
+| `source`               | yes             | yes            |               |
+| `created_at`           | yes             | yes            |               |
+| `updated_at`           | yes             | yes            |               |
+| `verified_at`          | yes             | yes            |               |
+| `verified_by`          | yes             | yes            |               |
+| `comment_count`        | yes             | yes            |               |
+| `last_comment_at`      | yes             | yes            |               |
+| `project_id`           |                 | yes            |               |
+| `workspace_id`         |                 | yes            |               |
+| `version`              |                 | yes            |               |
+| `session_id`           |                 | yes            |               |
+| `metadata`             |                 | yes            |               |
+| `archived_at`          |                 | yes            |               |
+| `embedding_model`      |                 |                | yes           |
+| `embedding_dimensions` |                 |                | yes           |
+
+### Derived types
+
+- **`MemorySummaryWithRelevance`** — `MemorySummary` + `relevance: number`. Used by `session_start` and `search`.
+- **`MemorySummaryWithChangeType`** — `MemorySummary` + `change_type: "created" | "updated" | "commented"`. Used by `list_recent`.
+
+### Projection functions
+
+Two functions in `src/types/memory.ts`:
+
+- `toSummary(memory: Memory): MemorySummary` — picks the summary fields
+- `toDetail(memory: Memory): MemoryDetail` — picks everything except embedding fields
+
+All list-returning service methods call `toSummary()` before wrapping in `Envelope`. `getWithComments()` calls `toDetail()`.
+
+## Affected endpoints
+
+### List endpoints (return `MemorySummary` variants)
+
+| Endpoint        | Current return type                | New return type                           |
+| --------------- | ---------------------------------- | ----------------------------------------- |
+| `session_start` | `Envelope<MemoryWithRelevance[]>`  | `Envelope<MemorySummaryWithRelevance[]>`  |
+| `search`        | `Envelope<MemoryWithRelevance[]>`  | `Envelope<MemorySummaryWithRelevance[]>`  |
+| `list`          | `Memory[]` in envelope             | `MemorySummary[]` in envelope             |
+| `list_recent`   | `Envelope<MemoryWithChangeType[]>` | `Envelope<MemorySummaryWithChangeType[]>` |
+| `list_stale`    | `Memory[]` in envelope             | `MemorySummary[]` in envelope             |
+
+### Detail endpoint (returns `MemoryDetail`)
+
+| Endpoint     | Current return type                    | New return type                                    |
+| ------------ | -------------------------------------- | -------------------------------------------------- |
+| `memory_get` | `MemoryGetResponse` (extends `Memory`) | `MemoryDetailGetResponse` (extends `MemoryDetail`) |
+
+### Unchanged
+
+- `memory_create`, `memory_update` — return full `Memory` after write (caller may need `version` for subsequent updates)
+- `memory_archive`, `memory_verify`, `memory_comment` — write responses, unchanged
+- Repository layer — still returns full `Memory` objects internally
+- `Memory` interface — unchanged, remains the internal/DB representation
+- MCP `toolResponse()` / REST `res.json()` — no changes, they serialize whatever the service returns
+- Hook script — no changes, forwards raw JSON (just smaller now)
+
+## Test impact
+
+Existing tests that assert on response shape will need updating to expect the slimmed fields. No behavioral changes.

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -7,7 +7,11 @@ import type {
   MemoryGetResponse,
   MemoryWithChangeType,
   CreateSkipResult,
+  MemorySummary,
+  MemorySummaryWithRelevance,
+  MemorySummaryWithChangeType,
 } from "../types/memory.js";
+import { toSummary, toDetail } from "../types/memory.js";
 import type { Envelope } from "../types/envelope.js";
 import type { EmbeddingProvider } from "../providers/embedding/types.js";
 import type {
@@ -307,7 +311,7 @@ export class MemoryService {
     const timing = Date.now() - start;
     return {
       data: {
-        ...memory,
+        ...toDetail(memory),
         comments: commentsList,
         ...capabilities,
       },
@@ -395,7 +399,7 @@ export class MemoryService {
     since: Date,
     limit: number = 10,
     excludeSelf: boolean = false,
-  ): Promise<Envelope<MemoryWithChangeType[]>> {
+  ): Promise<Envelope<MemorySummaryWithChangeType[]>> {
     const start = Date.now();
 
     const recentMemories = await this.memoryRepo.findRecentActivity({
@@ -408,9 +412,9 @@ export class MemoryService {
     });
 
     // D-37: Determine change_type for each result
-    const withChangeType: MemoryWithChangeType[] = recentMemories.map(
+    const withChangeType: MemorySummaryWithChangeType[] = recentMemories.map(
       (memory) => ({
-        ...memory,
+        ...toSummary(memory),
         change_type: this.getChangeType(memory, since),
       }),
     );
@@ -555,7 +559,7 @@ export class MemoryService {
     user_id: string,
     limit?: number,
     min_similarity?: number,
-  ): Promise<Envelope<MemoryWithRelevance[]>> {
+  ): Promise<Envelope<MemorySummaryWithRelevance[]>> {
     const start = Date.now();
     const effectiveLimit = limit ?? 10;
 
@@ -601,10 +605,15 @@ export class MemoryService {
     scored.sort((a, b) => b.relevance - a.relevance);
     const results = scored.slice(0, effectiveLimit);
 
+    const projected: MemorySummaryWithRelevance[] = results.map((r) => ({
+      ...toSummary(r),
+      relevance: r.relevance,
+    }));
+
     const timing = Date.now() - start;
     return {
-      data: results,
-      meta: { count: results.length, timing },
+      data: projected,
+      meta: { count: projected.length, timing },
     };
   }
 
@@ -613,7 +622,7 @@ export class MemoryService {
     userId: string,
     context?: string,
     limit: number = 10,
-  ): Promise<Envelope<MemoryWithRelevance[]>> {
+  ): Promise<Envelope<MemorySummaryWithRelevance[]>> {
     const start = Date.now();
 
     // D-34: Auto-create workspace
@@ -644,7 +653,7 @@ export class MemoryService {
       previousSession ??
       new Date(Date.now() - FIRST_SESSION_FALLBACK_DAYS * 24 * 60 * 60 * 1000);
 
-    let result: Envelope<MemoryWithRelevance[]>;
+    let result: Envelope<MemorySummaryWithRelevance[]>;
     if (context) {
       // D-14: With context, use semantic search with composite scoring
       // D-15: Always search both scopes
@@ -667,8 +676,8 @@ export class MemoryService {
       });
 
       // Apply composite scoring with similarity = 1.0 (neutral baseline)
-      const scored: MemoryWithRelevance[] = recentMemories.map((memory) => ({
-        ...memory,
+      const scored: MemorySummaryWithRelevance[] = recentMemories.map((memory) => ({
+        ...toSummary(memory),
         relevance: computeRelevance(
           1.0, // neutral similarity -- recency dominates
           memory.created_at,
@@ -773,16 +782,18 @@ export class MemoryService {
     };
   }
 
-  async list(options: ListOptions): Promise<Envelope<Memory[]>> {
+  async list(options: ListOptions): Promise<Envelope<MemorySummary[]>> {
     const start = Date.now();
 
     const result = await this.memoryRepo.list(options);
 
+    const projected = result.memories.map(toSummary);
+
     const timing = Date.now() - start;
     return {
-      data: result.memories,
+      data: projected,
       meta: {
-        count: result.memories.length,
+        count: projected.length,
         has_more: result.has_more,
         cursor: result.cursor
           ? `${result.cursor.created_at}|${result.cursor.id}`
@@ -825,7 +836,7 @@ export class MemoryService {
     threshold_days: number,
     limit?: number,
     cursor?: { created_at: string; id: string },
-  ): Promise<Envelope<Memory[]>> {
+  ): Promise<Envelope<MemorySummary[]>> {
     const start = Date.now();
 
     const result = await this.memoryRepo.findStale({
@@ -839,11 +850,13 @@ export class MemoryService {
     // D-16: Filter out user-scoped memories not owned by requesting user
     const filtered = result.memories.filter((m) => this.canAccess(m, userId));
 
+    const projected = filtered.map(toSummary);
+
     const timing = Date.now() - start;
     return {
-      data: filtered,
+      data: projected,
       meta: {
-        count: filtered.length,
+        count: projected.length,
         has_more: result.has_more,
         cursor: result.cursor
           ? `${result.cursor.created_at}|${result.cursor.id}`

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -5,7 +5,6 @@ import type {
   MemoryWithRelevance,
   Comment,
   MemoryGetResponse,
-  MemoryWithChangeType,
   CreateSkipResult,
   MemorySummary,
   MemorySummaryWithRelevance,

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -9,6 +9,7 @@ import type {
   MemorySummary,
   MemorySummaryWithRelevance,
   MemorySummaryWithChangeType,
+  ChangeType,
 } from "../types/memory.js";
 import { toSummary, toDetail } from "../types/memory.js";
 import type { Envelope } from "../types/envelope.js";
@@ -429,7 +430,7 @@ export class MemoryService {
   private getChangeType(
     memory: Memory,
     since: Date,
-  ): "created" | "updated" | "commented" {
+  ): ChangeType {
     if (memory.created_at >= since) return "created";
     if (
       memory.last_comment_at &&

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -102,12 +102,12 @@ export function toDetail(memory: Memory): MemoryDetail {
 }
 
 // Slim variants for list endpoints
-// Forward-declared for use in service layer list endpoints (Task 2)
+// Slim list endpoint result with relevance score — used by search and session_start
 export interface MemorySummaryWithRelevance extends MemorySummary {
   relevance: number;
 }
 
-// Forward-declared for use in service layer list endpoints (Task 2)
+// Slim list endpoint result with change classification — used by list_recent
 export interface MemorySummaryWithChangeType extends MemorySummary {
   change_type: ChangeType;
 }
@@ -128,11 +128,6 @@ export interface MemoryGetResponse extends MemoryDetail {
   can_edit: boolean;
   can_archive: boolean;
   can_verify: boolean;
-}
-
-// D-37: Memory with change type for memory_list_recent
-export interface MemoryWithChangeType extends Memory {
-  change_type: ChangeType;
 }
 
 // Input type for creating a memory

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -37,6 +37,76 @@ export interface Memory {
   verified_by: string | null; // D-19: who verified
 }
 
+// Slim projection for list endpoints — omits internal/DB-only fields
+export interface MemorySummary {
+  id: string;
+  title: string;
+  content: string;
+  type: MemoryType;
+  scope: MemoryScope;
+  tags: string[] | null;
+  author: string;
+  source: string | null;
+  created_at: Date;
+  updated_at: Date;
+  verified_at: Date | null;
+  verified_by: string | null;
+  comment_count: number;
+  last_comment_at: Date | null;
+}
+
+// Full projection for detail endpoints — everything except embedding internals
+export interface MemoryDetail extends MemorySummary {
+  project_id: string;
+  workspace_id: string | null;
+  version: number;
+  session_id: string | null;
+  metadata: Record<string, unknown> | null;
+  archived_at: Date | null;
+}
+
+/** Project a full Memory to the slim list representation */
+export function toSummary(memory: Memory): MemorySummary {
+  return {
+    id: memory.id,
+    title: memory.title,
+    content: memory.content,
+    type: memory.type,
+    scope: memory.scope,
+    tags: memory.tags,
+    author: memory.author,
+    source: memory.source,
+    created_at: memory.created_at,
+    updated_at: memory.updated_at,
+    verified_at: memory.verified_at,
+    verified_by: memory.verified_by,
+    comment_count: memory.comment_count,
+    last_comment_at: memory.last_comment_at,
+  };
+}
+
+/** Project a full Memory to the detail representation (strips embedding internals) */
+export function toDetail(memory: Memory): MemoryDetail {
+  return {
+    ...toSummary(memory),
+    project_id: memory.project_id,
+    workspace_id: memory.workspace_id,
+    version: memory.version,
+    session_id: memory.session_id,
+    metadata: memory.metadata,
+    archived_at: memory.archived_at,
+  };
+}
+
+// Slim variants for list endpoints
+export interface MemorySummaryWithRelevance extends MemorySummary {
+  relevance: number;
+}
+
+export interface MemorySummaryWithChangeType extends MemorySummary {
+  change_type: "created" | "updated" | "commented";
+}
+
 // D-47: Comment on a memory by a team member
 export interface Comment {
   id: string;
@@ -47,7 +117,7 @@ export interface Comment {
 }
 
 // D-72, D-63: Enhanced response for memory_get with comments and capability flags
-export interface MemoryGetResponse extends Memory {
+export interface MemoryGetResponse extends MemoryDetail {
   comments: Comment[];
   can_comment: boolean;
   can_edit: boolean;

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -11,6 +11,9 @@ export type MemoryType =
 // workspace = scoped to a workspace, user = private, project = cross-workspace within deployment
 export type MemoryScope = "workspace" | "user" | "project";
 
+// D-37, D-62: Change type union for tracking what changed on a memory (used in list endpoints)
+export type ChangeType = "created" | "updated" | "commented";
+
 // Full memory object as stored (without embedding vector per D-44)
 export interface Memory {
   id: string;
@@ -99,12 +102,14 @@ export function toDetail(memory: Memory): MemoryDetail {
 }
 
 // Slim variants for list endpoints
+// Forward-declared for use in service layer list endpoints (Task 2)
 export interface MemorySummaryWithRelevance extends MemorySummary {
   relevance: number;
 }
 
+// Forward-declared for use in service layer list endpoints (Task 2)
 export interface MemorySummaryWithChangeType extends MemorySummary {
-  change_type: "created" | "updated" | "commented";
+  change_type: ChangeType;
 }
 
 // D-47: Comment on a memory by a team member
@@ -127,7 +132,7 @@ export interface MemoryGetResponse extends MemoryDetail {
 
 // D-37: Memory with change type for memory_list_recent
 export interface MemoryWithChangeType extends Memory {
-  change_type: "created" | "updated" | "commented";
+  change_type: ChangeType;
 }
 
 // Input type for creating a memory

--- a/tests/integration/memory-scoping.test.ts
+++ b/tests/integration/memory-scoping.test.ts
@@ -38,10 +38,11 @@ describe("Memory scoping integration tests", () => {
       "alice",
     );
 
-    const crossProjectMatch = result.data.find(
-      (m) => m.project_id === "project-a",
+    // Workspace isolation: searching in project-b should not return project-a's memories
+    const crossWorkspaceMatch = result.data.find(
+      (m) => m.content === "Secret project-a knowledge about deployment pipelines",
     );
-    expect(crossProjectMatch).toBeUndefined();
+    expect(crossWorkspaceMatch).toBeUndefined();
   });
 
   it("user-scoped memory visible across projects (SCOP-02)", async () => {


### PR DESCRIPTION
## Summary

- Add `MemorySummary` and `MemoryDetail` projection types that strip internal/DB-only fields (`embedding_model`, `embedding_dimensions`, `version`, `session_id`, `metadata`, etc.)
- Apply slim projections in all list endpoints (`session_start`, `search`, `list`, `list_recent`, `list_stale`) and full detail projection in `memory_get`
- Write endpoints (`create`, `update`, `archive`, `verify`, `comment`) unchanged

## Test Plan

- [x] All 190 tests passing
- [x] Zero TypeScript type errors
- [x] Session start response no longer includes `embedding_model`, `embedding_dimensions`, `project_id`, `version`, `session_id`, `metadata`, `archived_at`

🤖 Generated with [Claude Code](https://claude.com/claude-code)