### PR TITLE
feat: batch query endpoints for reduced agent tool calls

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ dist/
 .worktrees/
 drizzle/
 coverage/
+iac/

--- a/docs/superpowers/plans/2026-04-08-batch-query-endpoints.md
+++ b/docs/superpowers/plans/2026-04-08-batch-query-endpoints.md
@@ -1,0 +1,1392 @@
+# Batch Query Endpoints Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce agent tool calls for read operations by supporting arrays in `memory_list` (scope), `memory_get` (ids + optional includes), `memory_relationships` (memory_ids), and `memory_search` (scope).
+
+**Architecture:** In-place schema evolution of four MCP tools. Add `flag_count` and `relationship_count` correlated subqueries to `memoryColumns()`. New `getMany()` service method with optional batch joins for comments, flags, and relationships. Repository methods updated to accept arrays where they previously took single values.
+
+**Tech Stack:** TypeScript, Zod, Drizzle ORM, PostgreSQL, MCP SDK
+
+---
+
+### Task 1: Add `flag_count` and `relationship_count` to `memoryColumns()`
+
+**Files:**
+
+- Modify: `src/types/memory.ts:18-41` (Memory interface)
+- Modify: `src/types/memory.ts:44-59` (MemorySummary interface)
+- Modify: `src/repositories/memory-repository.ts:57-64` (rowToMemory)
+- Modify: `src/repositories/memory-repository.ts:71-79` (memoryColumns)
+- Test: `tests/integration/memory-crud.test.ts`
+
+- [ ] **Step 1: Write failing test for flag_count and relationship_count**
+
+In `tests/integration/memory-crud.test.ts`, add a test after the existing tests:
+
+```typescript
+it("returns flag_count and relationship_count on get", async () => {
+  const { memoryService, relationshipService } =
+    createTestServiceWithRelationships();
+
+  const m1 = await memoryService.create({
+    workspace_id: "test-project",
+    content: "Memory with counts",
+    type: "fact",
+    author: "alice",
+  });
+  assertMemory(m1.data);
+
+  const m2 = await memoryService.create({
+    workspace_id: "test-project",
+    content: "Related memory for counting",
+    type: "fact",
+    author: "alice",
+  });
+  assertMemory(m2.data);
+
+  // Create a relationship
+  await relationshipService.create({
+    sourceId: m1.data.id,
+    targetId: m2.data.id,
+    type: "refines",
+    userId: "alice",
+  });
+
+  const fetched = await memoryService.get(m1.data.id, "alice");
+  expect(fetched.data.flag_count).toBe(0);
+  expect(fetched.data.relationship_count).toBe(1);
+  expect(fetched.data.comment_count).toBe(0);
+});
+```
+
+Add the `createTestServiceWithRelationships` import if not already present.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/integration/memory-crud.test.ts -t "returns flag_count and relationship_count"`
+Expected: FAIL — `flag_count` and `relationship_count` do not exist on Memory
+
+- [ ] **Step 3: Add flag_count and relationship_count to Memory and MemorySummary types**
+
+In `src/types/memory.ts`, add to the `Memory` interface after `comment_count`:
+
+```typescript
+flag_count: number; // computed via COUNT of open flags
+relationship_count: number; // computed via COUNT of active relationships
+```
+
+Add to `MemorySummary` after `comment_count`:
+
+```typescript
+flag_count: number;
+relationship_count: number;
+```
+
+Update `toSummary()` to include the new fields:
+
+```typescript
+export function toSummary(memory: Memory): MemorySummary {
+  return {
+    id: memory.id,
+    title: memory.title,
+    content: memory.content,
+    type: memory.type,
+    scope: memory.scope,
+    tags: memory.tags,
+    author: memory.author,
+    source: memory.source,
+    created_at: memory.created_at,
+    updated_at: memory.updated_at,
+    verified_at: memory.verified_at,
+    verified_by: memory.verified_by,
+    comment_count: memory.comment_count,
+    flag_count: memory.flag_count,
+    relationship_count: memory.relationship_count,
+    last_comment_at: memory.last_comment_at,
+  };
+}
+```
+
+- [ ] **Step 4: Add correlated subqueries to memoryColumns()**
+
+In `src/repositories/memory-repository.ts`, update `memoryColumns()`:
+
+```typescript
+  private memoryColumns() {
+    return {
+      ...baseMemoryColumns,
+      comment_count:
+        sql<number>`(SELECT COUNT(*)::int FROM comments WHERE comments.memory_id = memories.id)`.as(
+          "comment_count",
+        ),
+      flag_count:
+        sql<number>`(SELECT COUNT(*)::int FROM flags WHERE flags.memory_id = memories.id AND flags.resolved_at IS NULL)`.as(
+          "flag_count",
+        ),
+      relationship_count:
+        sql<number>`(SELECT COUNT(*)::int FROM relationships WHERE (relationships.source_id = memories.id OR relationships.target_id = memories.id) AND relationships.archived_at IS NULL)`.as(
+          "relationship_count",
+        ),
+    };
+  }
+```
+
+Add `flags` and `relationships` to the schema import at the top of the file:
+
+```typescript
+import { memories, comments, flags, relationships } from "../db/schema.js";
+```
+
+- [ ] **Step 5: Update rowToMemory to parse the new counts**
+
+In `src/repositories/memory-repository.ts`, update `rowToMemory`:
+
+```typescript
+function rowToMemory(row: Record<string, unknown>): Memory {
+  const result = { ...row } as unknown as Memory;
+  // Ensure counts are numbers (PostgreSQL COUNT can return string via bigint)
+  const rawCommentCount = (row as Record<string, unknown>).comment_count;
+  result.comment_count =
+    rawCommentCount !== undefined && rawCommentCount !== null
+      ? Number(rawCommentCount)
+      : 0;
+  const rawFlagCount = (row as Record<string, unknown>).flag_count;
+  result.flag_count =
+    rawFlagCount !== undefined && rawFlagCount !== null
+      ? Number(rawFlagCount)
+      : 0;
+  const rawRelCount = (row as Record<string, unknown>).relationship_count;
+  result.relationship_count =
+    rawRelCount !== undefined && rawRelCount !== null ? Number(rawRelCount) : 0;
+  return result;
+}
+```
+
+- [ ] **Step 6: Fix create() to set new counts to 0**
+
+In `src/repositories/memory-repository.ts`, update the `create` method's return to include the new counts:
+
+```typescript
+return rowToMemory({
+  ...result[0],
+  comment_count: 0,
+  flag_count: 0,
+  relationship_count: 0,
+});
+```
+
+Also update the `MemoryService.create()` in `src/services/memory-service.ts` where it builds `memoryData`:
+
+```typescript
+      comment_count: 0,
+      flag_count: 0,
+      relationship_count: 0,
+```
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `npx vitest run tests/integration/memory-crud.test.ts -t "returns flag_count and relationship_count"`
+Expected: PASS
+
+- [ ] **Step 8: Run full test suite to check for regressions**
+
+Run: `npx vitest run`
+Expected: All tests pass. Some tests may need `flag_count` and `relationship_count` added to assertions if they do exact object matching.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/types/memory.ts src/repositories/memory-repository.ts src/services/memory-service.ts tests/integration/memory-crud.test.ts
+git commit -m "feat: add flag_count and relationship_count correlated subqueries"
+```
+
+---
+
+### Task 2: `memory_list` — scope as array
+
+**Files:**
+
+- Modify: `src/utils/validation.ts:33` (memoryScopeEnum)
+- Modify: `src/repositories/types.ts:11` (ListOptions.scope)
+- Modify: `src/repositories/memory-repository.ts:284-389` (list method)
+- Modify: `src/services/memory-service.ts:853-872` (list method)
+- Modify: `src/tools/memory-list.ts` (tool schema + description)
+- Modify: `src/routes/api-schemas.ts:60-70` (toolSchemas.memory_list)
+- Test: `tests/integration/memory-scoping.test.ts`
+
+- [ ] **Step 1: Write failing test for multi-scope list**
+
+In `tests/integration/memory-scoping.test.ts`, add:
+
+```typescript
+it("lists memories across multiple scopes", async () => {
+  const service = createTestService();
+
+  // Create workspace-scoped memory
+  const ws = await service.create({
+    workspace_id: "test-project",
+    content: "Workspace memory for multi-scope test",
+    type: "fact",
+    author: "alice",
+  });
+  assertMemory(ws.data);
+
+  // Create user-scoped memory
+  const user = await service.create({
+    workspace_id: "test-project",
+    content: "User memory for multi-scope test",
+    type: "fact",
+    author: "alice",
+    scope: "user",
+  });
+  assertMemory(user.data);
+
+  // List with both scopes
+  const result = await service.list({
+    project_id: "test-project",
+    workspace_id: "test-project",
+    scope: ["workspace", "user"],
+    user_id: "alice",
+  });
+
+  expect(result.data.length).toBe(2);
+  const scopes = result.data.map((m) => m.scope);
+  expect(scopes).toContain("workspace");
+  expect(scopes).toContain("user");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/integration/memory-scoping.test.ts -t "lists memories across multiple scopes"`
+Expected: FAIL — `scope` expects a string, not an array
+
+- [ ] **Step 3: Update ListOptions.scope to accept array**
+
+In `src/repositories/types.ts`, change `ListOptions`:
+
+```typescript
+export interface ListOptions {
+  project_id: string;
+  workspace_id?: string;
+  scope: Array<"workspace" | "user" | "project">;
+  user_id?: string;
+  type?: string;
+  tags?: string[];
+  sort_by?: "created_at" | "updated_at";
+  order?: "asc" | "desc";
+  cursor?: { created_at: string; id: string };
+  limit?: number;
+}
+```
+
+- [ ] **Step 4: Update repository list() for multi-scope**
+
+In `src/repositories/memory-repository.ts`, replace the scope-filtering block in `list()` (lines 298-315) with:
+
+```typescript
+// Scope-based filtering: build OR conditions for each requested scope
+const scopeConditions: SQL[] = [];
+for (const s of options.scope) {
+  if (s === "workspace") {
+    if (!options.workspace_id) {
+      throw new ValidationError(
+        "workspace_id is required for workspace-scoped list",
+      );
+    }
+    scopeConditions.push(
+      and(
+        eq(memories.workspace_id, options.workspace_id),
+        eq(memories.scope, "workspace"),
+      )!,
+    );
+  } else if (s === "project") {
+    scopeConditions.push(eq(memories.scope, "project"));
+  } else {
+    // user scope
+    if (!options.user_id) {
+      throw new ValidationError("user_id is required for user-scoped list");
+    }
+    scopeConditions.push(
+      and(eq(memories.author, options.user_id), eq(memories.scope, "user"))!,
+    );
+  }
+}
+// Combine scope conditions with OR; always include project-scoped if any non-project scope requested
+const hasNonProjectScope = options.scope.some((s) => s !== "project");
+if (hasNonProjectScope && !options.scope.includes("project")) {
+  scopeConditions.push(eq(memories.scope, "project"));
+}
+if (scopeConditions.length === 1) {
+  conditions.push(scopeConditions[0]);
+} else {
+  conditions.push(or(...scopeConditions)!);
+}
+```
+
+- [ ] **Step 5: Update service list() to pass scope as array**
+
+The `MemoryService.list()` method at `src/services/memory-service.ts:853` already passes `options` straight through to the repository, so no changes needed as long as the `ListOptions` type is updated.
+
+- [ ] **Step 6: Update memory_list tool schema**
+
+In `src/tools/memory-list.ts`, replace the `scope` field:
+
+```typescript
+        scope: z
+          .array(memoryScopeEnum)
+          .min(1)
+          .catch(["workspace"])
+          .describe(
+            'Scopes to include, e.g. ["workspace", "user"]. Defaults to ["workspace"]. Project-scoped memories are always included.',
+          ),
+```
+
+Update the import to include `memoryScopeEnum` from validation (already imported).
+
+Update the tool description:
+
+```typescript
+      description:
+        'Browse memories with filtering, sorting, and pagination. Supports multiple scopes in one call, e.g. scope: ["workspace", "user"]. Project-scoped memories are always included. Example: memory_list({ workspace_id: "my-project", user_id: "alice", scope: ["workspace", "user"] })',
+```
+
+- [ ] **Step 7: Update api-schemas.ts**
+
+In `src/routes/api-schemas.ts`, update the `memory_list` schema:
+
+```typescript
+  memory_list: z.object({
+    workspace_id: slugSchema.optional(),
+    scope: z.array(memoryScopeEnum).min(1).default(["workspace"]),
+    user_id: slugSchema,
+    type: memoryTypeEnum.optional(),
+    tags: z.array(z.string()).optional(),
+    sort_by: z.enum(["created_at", "updated_at"]).default("created_at"),
+    order: z.enum(["asc", "desc"]).default("desc"),
+    cursor: z.string().optional(),
+    limit: z.number().int().min(1).max(100).default(20),
+  }),
+```
+
+Add `memoryScopeEnum` to the imports from validation.ts if not already there.
+
+- [ ] **Step 8: Fix all callers that pass scope as a string**
+
+Search the codebase for all places that call `service.list()` or `memoryRepo.list()` with `scope: "string"` and change to `scope: ["string"]`. Key locations:
+
+- `src/services/memory-service.ts` — any internal calls to `this.memoryRepo.list()`
+- `tests/integration/memory-scoping.test.ts` — existing test calls
+- `tests/integration/memory-crud.test.ts` — existing test calls
+- Any other test files that call `service.list()`
+
+- [ ] **Step 9: Run test to verify multi-scope test passes**
+
+Run: `npx vitest run tests/integration/memory-scoping.test.ts -t "lists memories across multiple scopes"`
+Expected: PASS
+
+- [ ] **Step 10: Run full test suite**
+
+Run: `npx vitest run`
+Expected: All tests pass
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/repositories/types.ts src/repositories/memory-repository.ts src/services/memory-service.ts src/tools/memory-list.ts src/routes/api-schemas.ts tests/
+git commit -m "feat: memory_list accepts scope as array for multi-scope queries"
+```
+
+---
+
+### Task 3: `memory_get` — batch IDs with optional includes
+
+**Files:**
+
+- Modify: `src/repositories/comment-repository.ts` (add `findByMemoryIds`)
+- Modify: `src/repositories/types.ts` (CommentRepository interface)
+- Modify: `src/services/flag-service.ts` or `src/repositories/flag-repository.ts` (add `findByMemoryIds`)
+- Modify: `src/repositories/types.ts` (FlagRepository interface)
+- Modify: `src/services/memory-service.ts` (add `getMany()`)
+- Modify: `src/tools/memory-get.ts` (tool schema + description)
+- Modify: `src/routes/api-schemas.ts:30-33` (toolSchemas.memory_get)
+- Test: `tests/integration/memory-crud.test.ts`
+
+- [ ] **Step 1: Write failing test for batch get with counts only**
+
+In `tests/integration/memory-crud.test.ts`, add:
+
+```typescript
+it("batch gets multiple memories with counts", async () => {
+  const { memoryService, relationshipService } =
+    createTestServiceWithRelationships();
+
+  const m1 = await memoryService.create({
+    workspace_id: "test-project",
+    content: "Batch get memory one",
+    type: "fact",
+    author: "alice",
+  });
+  assertMemory(m1.data);
+
+  const m2 = await memoryService.create({
+    workspace_id: "test-project",
+    content: "Batch get memory two",
+    type: "decision",
+    author: "alice",
+  });
+  assertMemory(m2.data);
+
+  const result = await memoryService.getMany([m1.data.id, m2.data.id], "alice");
+
+  expect(result.data).toHaveLength(2);
+  expect(result.data[0].comment_count).toBe(0);
+  expect(result.data[0].flag_count).toBe(0);
+  expect(result.data[0].relationship_count).toBe(0);
+  // Without include, should not have comments/flags/relationships arrays
+  expect(result.data[0]).not.toHaveProperty("comments");
+  expect(result.data[0]).not.toHaveProperty("flags");
+  expect(result.data[0]).not.toHaveProperty("relationships");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/integration/memory-crud.test.ts -t "batch gets multiple memories"`
+Expected: FAIL — `getMany` does not exist
+
+- [ ] **Step 3: Write failing test for batch get with includes**
+
+In `tests/integration/memory-crud.test.ts`, add:
+
+```typescript
+it("batch gets with include returns full data for specified joins", async () => {
+  const { memoryService, relationshipService } =
+    createTestServiceWithRelationships();
+
+  const m1 = await memoryService.create({
+    workspace_id: "test-project",
+    content: "Memory with relationship for include test",
+    type: "fact",
+    author: "alice",
+  });
+  assertMemory(m1.data);
+
+  const m2 = await memoryService.create({
+    workspace_id: "test-project",
+    content: "Related memory for include test",
+    type: "fact",
+    author: "alice",
+  });
+  assertMemory(m2.data);
+
+  await relationshipService.create({
+    sourceId: m1.data.id,
+    targetId: m2.data.id,
+    type: "refines",
+    userId: "alice",
+  });
+
+  const result = await memoryService.getMany([m1.data.id], "alice", [
+    "relationships",
+  ]);
+
+  expect(result.data).toHaveLength(1);
+  // relationships included as array
+  expect(result.data[0].relationships).toHaveLength(1);
+  expect(result.data[0].relationships![0].type).toBe("refines");
+  // comments and flags still counts
+  expect(result.data[0].comment_count).toBe(0);
+  expect(result.data[0].flag_count).toBe(0);
+  expect(result.data[0]).not.toHaveProperty("comments");
+  expect(result.data[0]).not.toHaveProperty("flags");
+});
+```
+
+- [ ] **Step 4: Add batch findByMemoryIds to CommentRepository**
+
+In `src/repositories/comment-repository.ts`, add after `findByMemoryId`:
+
+```typescript
+  async findByMemoryIds(memoryIds: string[]): Promise<Comment[]> {
+    if (memoryIds.length === 0) return [];
+    const result = await this.db
+      .select()
+      .from(comments)
+      .where(inArray(comments.memory_id, memoryIds))
+      .orderBy(asc(comments.created_at));
+
+    return result.map((row) => ({
+      id: row.id,
+      memory_id: row.memory_id,
+      author: row.author,
+      content: row.content,
+      created_at: row.created_at,
+    }));
+  }
+```
+
+Add `inArray` to the drizzle-orm imports. Update the `CommentRepository` interface in `src/repositories/types.ts`:
+
+```typescript
+export interface CommentRepository {
+  create(comment: {
+    id: string;
+    memory_id: string;
+    author: string;
+    content: string;
+  }): Promise<Comment>;
+  findByMemoryId(memoryId: string): Promise<Comment[]>;
+  findByMemoryIds(memoryIds: string[]): Promise<Comment[]>;
+  countByMemoryId(memoryId: string): Promise<number>;
+}
+```
+
+- [ ] **Step 5: Add batch findByMemoryIds to FlagRepository**
+
+In `src/repositories/flag-repository.ts`, add after `findByMemoryId`:
+
+```typescript
+  async findByMemoryIds(memoryIds: string[]): Promise<Flag[]> {
+    if (memoryIds.length === 0) return [];
+    return (await this.db
+      .select()
+      .from(flags)
+      .where(inArray(flags.memory_id, memoryIds))
+      .orderBy(desc(flags.created_at))) as Flag[];
+  }
+```
+
+Add `inArray` to the drizzle-orm imports. Update the `FlagRepository` interface in `src/repositories/types.ts`:
+
+```typescript
+  findByMemoryIds(memoryIds: string[]): Promise<Flag[]>;
+```
+
+Add this line after `findByMemoryId` in the interface.
+
+- [ ] **Step 6: Define MemoryGetManyResponse type**
+
+In `src/types/memory.ts`, add after `MemoryGetResponse`:
+
+```typescript
+// Response type for batch memory_get — detail with counts, optionally expanded joins
+export interface MemoryGetManyItem extends MemoryDetail {
+  flag_count: number;
+  relationship_count: number;
+  can_comment: boolean;
+  can_edit: boolean;
+  can_archive: boolean;
+  can_verify: boolean;
+  // Optional: populated when requested via include parameter
+  comments?: Comment[];
+  flags?: Array<{
+    flag_id: string;
+    flag_type: string;
+    related_memory?: {
+      id: string;
+      title: string;
+      content: string;
+      scope: string;
+    } | null;
+    reason: string;
+  }>;
+  relationships?: import("./relationship.js").RelationshipWithMemory[];
+}
+```
+
+- [ ] **Step 7: Implement getMany() in MemoryService**
+
+In `src/services/memory-service.ts`, add after the existing `getWithComments` method:
+
+```typescript
+  async getMany(
+    ids: string[],
+    userId: string,
+    include?: Array<"comments" | "flags" | "relationships">,
+  ): Promise<Envelope<MemoryGetManyItem[]>> {
+    const start = Date.now();
+
+    const allMemories = await this.memoryRepo.findByIds(ids);
+
+    // Filter by project isolation and access control
+    const accessible = allMemories.filter(
+      (m) => m.project_id === this.projectId && canAccessMemory(m, userId),
+    );
+
+    const accessibleIds = accessible.map((m) => m.id);
+    const includeSet = new Set(include ?? []);
+
+    // Batch-fetch optional joins
+    const [commentsByMemory, flagsByMemory, relsByMemory] = await Promise.all([
+      includeSet.has("comments") && this.commentRepo
+        ? this.commentRepo
+            .findByMemoryIds(accessibleIds)
+            .then((cs) => this.groupBy(cs, "memory_id"))
+        : Promise.resolve(new Map<string, Comment[]>()),
+      includeSet.has("flags") && this.flagService
+        ? this.batchFetchFlags(accessibleIds)
+        : Promise.resolve(
+            new Map<
+              string,
+              MemoryGetManyItem["flags"]
+            >(),
+          ),
+      includeSet.has("relationships") && this.relationshipService
+        ? this.batchFetchRelationships(accessibleIds, userId)
+        : Promise.resolve(new Map<string, RelationshipWithMemory[]>()),
+    ]);
+
+    const items: MemoryGetManyItem[] = accessible.map((memory) => {
+      const isOwner = memory.author === userId;
+      const isShared =
+        memory.scope === "workspace" || memory.scope === "project";
+      const capabilities = {
+        can_edit: canAccessMemory(memory, userId),
+        can_archive: canAccessMemory(memory, userId),
+        can_verify: canAccessMemory(memory, userId),
+        can_comment: isShared && !isOwner,
+      };
+
+      const item: MemoryGetManyItem = {
+        ...toDetail(memory),
+        flag_count: memory.flag_count,
+        relationship_count: memory.relationship_count,
+        ...capabilities,
+      };
+
+      if (includeSet.has("comments")) {
+        item.comments = commentsByMemory.get(memory.id) ?? [];
+      }
+      if (includeSet.has("flags")) {
+        item.flags = flagsByMemory.get(memory.id) ?? [];
+      }
+      if (includeSet.has("relationships")) {
+        item.relationships = relsByMemory.get(memory.id) ?? [];
+      }
+
+      return item;
+    });
+
+    const timing = Date.now() - start;
+    return { data: items, meta: { count: items.length, timing } };
+  }
+
+  private groupBy<T>(items: T[], key: keyof T & string): Map<string, T[]> {
+    const map = new Map<string, T[]>();
+    for (const item of items) {
+      const k = item[key] as string;
+      const arr = map.get(k);
+      if (arr) {
+        arr.push(item);
+      } else {
+        map.set(k, [item]);
+      }
+    }
+    return map;
+  }
+
+  private async batchFetchFlags(
+    memoryIds: string[],
+  ): Promise<Map<string, MemoryGetManyItem["flags"]>> {
+    if (!this.flagService) return new Map();
+    const flagRepo = (this.flagService as { flagRepo?: FlagRepository })
+      .flagRepo;
+    // Use the flag service's repository to batch-fetch
+    // We need to add a method to FlagService or access the repo directly
+    // For now, fetch flags per memory via the existing service method
+    const allFlags: Flag[] = [];
+    for (const id of memoryIds) {
+      const flags = await this.flagService.getFlagsByMemoryId(id);
+      allFlags.push(...flags);
+    }
+
+    const map = new Map<string, MemoryGetManyItem["flags"]>();
+    for (const f of allFlags) {
+      if (f.resolved_at) continue;
+      let relatedMem = null;
+      if (f.details.related_memory_id) {
+        const related = await this.memoryRepo.findById(
+          f.details.related_memory_id,
+        );
+        if (related) {
+          relatedMem = {
+            id: related.id,
+            title: related.title,
+            content: related.content,
+            scope: related.scope,
+          };
+        }
+      }
+      const entry = {
+        flag_id: f.id,
+        flag_type: f.flag_type,
+        related_memory: relatedMem,
+        reason: f.details.reason,
+      };
+      const arr = map.get(f.memory_id);
+      if (arr) {
+        arr.push(entry);
+      } else {
+        map.set(f.memory_id, [entry]);
+      }
+    }
+    return map;
+  }
+
+  private async batchFetchRelationships(
+    memoryIds: string[],
+    userId: string,
+  ): Promise<Map<string, RelationshipWithMemory[]>> {
+    if (!this.relationshipService) return new Map();
+
+    const map = new Map<string, RelationshipWithMemory[]>();
+    // Fetch relationships for each memory — leverages existing access control logic
+    await Promise.all(
+      memoryIds.map(async (id) => {
+        try {
+          const rels = await this.relationshipService!.listForMemory(
+            id,
+            "both",
+            userId,
+          );
+          if (rels.length > 0) {
+            map.set(id, rels);
+          }
+        } catch {
+          // Memory may have been archived/deleted between fetch and relationship lookup
+        }
+      }),
+    );
+    return map;
+  }
+```
+
+Add `MemoryGetManyItem` to the imports from `../types/memory.js`. Add `Flag` type import from `../types/flag.js`. Add `FlagRepository` type import if needed.
+
+- [ ] **Step 8: Run tests to verify getMany works**
+
+Run: `npx vitest run tests/integration/memory-crud.test.ts -t "batch gets"`
+Expected: Both batch get tests pass
+
+- [ ] **Step 9: Update memory_get tool to accept ids array + include**
+
+In `src/tools/memory-get.ts`:
+
+```typescript
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { MemoryService } from "../services/memory-service.js";
+import { slugSchema } from "../utils/validation.js";
+import { toolResponse, withErrorHandling } from "./tool-utils.js";
+
+export function registerMemoryGet(
+  server: McpServer,
+  memoryService: MemoryService,
+): void {
+  server.registerTool(
+    "memory_get",
+    {
+      description:
+        'Retrieve one or more memories by ID. Returns full details with comment_count, flag_count, and relationship_count. Use the include parameter to get full comments, flags, or relationships arrays instead of counts. With include: ["relationships"], there is no need to call memory_relationships separately. For the common "get all memories" flow: memory_list → memory_get. Example: memory_get({ ids: ["abc123"], user_id: "alice", include: ["comments", "relationships"] })',
+      inputSchema: {
+        ids: z
+          .array(z.string().min(1))
+          .min(1)
+          .describe("Memory IDs to retrieve"),
+        user_id: slugSchema.describe(
+          "User identifier (e.g., 'alice'). Required for access control and capability computation.",
+        ),
+        include: z
+          .array(z.enum(["comments", "flags", "relationships"]))
+          .optional()
+          .describe(
+            'Optional: expand these fields to full arrays instead of counts. E.g. ["comments", "relationships"]',
+          ),
+      },
+    },
+    async (params) => {
+      return withErrorHandling(async () => {
+        const result = await memoryService.getMany(
+          params.ids,
+          params.user_id,
+          params.include,
+        );
+        return toolResponse(result);
+      });
+    },
+  );
+}
+```
+
+- [ ] **Step 10: Update api-schemas.ts for memory_get**
+
+In `src/routes/api-schemas.ts`:
+
+```typescript
+  memory_get: z.object({
+    ids: z.array(z.string().min(1)).min(1),
+    user_id: slugSchema,
+    include: z.array(z.enum(["comments", "flags", "relationships"])).optional(),
+  }),
+```
+
+- [ ] **Step 11: Update api-tools.ts handler for memory_get**
+
+Check `src/routes/api-tools.ts` — the handler for `memory_get` calls `memoryService.getWithComments(params.id, params.user_id)`. Update it to call `memoryService.getMany(params.ids, params.user_id, params.include)`.
+
+- [ ] **Step 12: Fix any tests that call memory_get with the old single-id schema**
+
+Search for `memory_get` usage in tests and update from `{ id: "...", user_id: "..." }` to `{ ids: ["..."], user_id: "..." }`.
+
+- [ ] **Step 13: Run full test suite**
+
+Run: `npx vitest run`
+Expected: All tests pass
+
+- [ ] **Step 14: Commit**
+
+```bash
+git add src/repositories/comment-repository.ts src/repositories/flag-repository.ts src/repositories/types.ts src/types/memory.ts src/services/memory-service.ts src/tools/memory-get.ts src/routes/api-schemas.ts src/routes/api-tools.ts tests/
+git commit -m "feat: memory_get accepts ids array with optional include for batch queries"
+```
+
+---
+
+### Task 4: `memory_relationships` — batch memory IDs
+
+**Files:**
+
+- Modify: `src/repositories/relationship-repository.ts:38-73` (findByMemoryId → findByMemoryIds)
+- Modify: `src/repositories/types.ts:187-192` (RelationshipRepository interface)
+- Modify: `src/services/relationship-service.ts:172-219` (listForMemory → listForMemories)
+- Modify: `src/tools/memory-relationships.ts` (tool schema)
+- Modify: `src/routes/api-schemas.ts:114-119` (toolSchemas.memory_relationships)
+- Test: `tests/integration/relationships.test.ts`
+
+- [ ] **Step 1: Write failing test for batch relationship query**
+
+In `tests/integration/relationships.test.ts`, add:
+
+```typescript
+it("lists relationships for multiple memories in one call", async () => {
+  // Create 3 memories
+  const m1 = await memoryService.create({
+    workspace_id: "test-project",
+    content: "Batch rel memory one",
+    type: "fact",
+    author: "alice",
+  });
+  assertMemory(m1.data);
+
+  const m2 = await memoryService.create({
+    workspace_id: "test-project",
+    content: "Batch rel memory two",
+    type: "fact",
+    author: "alice",
+  });
+  assertMemory(m2.data);
+
+  const m3 = await memoryService.create({
+    workspace_id: "test-project",
+    content: "Batch rel memory three",
+    type: "fact",
+    author: "alice",
+  });
+  assertMemory(m3.data);
+
+  // Create relationships: m1→m2 and m3→m1
+  await relationshipService.create({
+    sourceId: m1.data.id,
+    targetId: m2.data.id,
+    type: "refines",
+    userId: "alice",
+  });
+  await relationshipService.create({
+    sourceId: m3.data.id,
+    targetId: m1.data.id,
+    type: "implements",
+    userId: "alice",
+  });
+
+  // Query relationships for m1 and m3
+  const result = await relationshipService.listForMemories(
+    [m1.data.id, m3.data.id],
+    "both",
+    "alice",
+  );
+
+  // m1 has 2 relationships (outgoing to m2, incoming from m3)
+  // m3 has 1 relationship (outgoing to m1)
+  // Total: 3 (but m3→m1 appears in both m1's incoming and m3's outgoing, so deduped = 2 unique relationships)
+  expect(result.length).toBeGreaterThanOrEqual(2);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/integration/relationships.test.ts -t "lists relationships for multiple memories"`
+Expected: FAIL — `listForMemories` does not exist
+
+- [ ] **Step 3: Add findByMemoryIds to RelationshipRepository**
+
+In `src/repositories/relationship-repository.ts`, add after `findByMemoryId`:
+
+```typescript
+  async findByMemoryIds(
+    projectId: string,
+    memoryIds: string[],
+    direction: "outgoing" | "incoming" | "both",
+    type?: string,
+  ): Promise<Relationship[]> {
+    if (memoryIds.length === 0) return [];
+    const conditions = [
+      eq(relationships.project_id, projectId),
+      isNull(relationships.archived_at),
+    ];
+
+    if (direction === "outgoing") {
+      conditions.push(inArray(relationships.source_id, memoryIds));
+    } else if (direction === "incoming") {
+      conditions.push(inArray(relationships.target_id, memoryIds));
+    } else {
+      conditions.push(
+        or(
+          inArray(relationships.source_id, memoryIds),
+          inArray(relationships.target_id, memoryIds),
+        )!,
+      );
+    }
+
+    if (type) {
+      conditions.push(eq(relationships.type, type));
+    }
+
+    const rows = await this.db
+      .select()
+      .from(relationships)
+      .where(and(...conditions))
+      .orderBy(relationships.created_at);
+
+    return rows as Relationship[];
+  }
+```
+
+Update the `RelationshipRepository` interface in `src/repositories/types.ts`:
+
+```typescript
+  findByMemoryIds(
+    projectId: string,
+    memoryIds: string[],
+    direction: "outgoing" | "incoming" | "both",
+    type?: string,
+  ): Promise<Relationship[]>;
+```
+
+- [ ] **Step 4: Add listForMemories to RelationshipService**
+
+In `src/services/relationship-service.ts`, add after `listForMemory`:
+
+```typescript
+  async listForMemories(
+    memoryIds: string[],
+    direction: "outgoing" | "incoming" | "both",
+    userId: string,
+    type?: string,
+  ): Promise<RelationshipWithMemory[]> {
+    if (memoryIds.length === 0) return [];
+
+    // Verify access to all anchor memories
+    const anchorMemories = await this.memoryRepo.findByIds(memoryIds);
+    const accessibleAnchors = anchorMemories.filter(
+      (m) => m.project_id === this.projectId && canAccessMemory(m, userId),
+    );
+    const anchorIds = new Set(accessibleAnchors.map((m) => m.id));
+    if (anchorIds.size === 0) return [];
+
+    const relationships = await this.relationshipRepo.findByMemoryIds(
+      this.projectId,
+      [...anchorIds],
+      direction,
+      type,
+    );
+
+    // Collect related memory IDs (the "other end" of each relationship)
+    const relatedIds = new Set<string>();
+    for (const rel of relationships) {
+      if (anchorIds.has(rel.source_id)) relatedIds.add(rel.target_id);
+      if (anchorIds.has(rel.target_id)) relatedIds.add(rel.source_id);
+    }
+    // Remove anchor IDs from related (they may reference each other)
+    for (const id of anchorIds) relatedIds.delete(id);
+
+    // Batch-fetch related + anchor memories for lookup
+    const allNeededIds = [...relatedIds];
+    const relatedMemories = await this.memoryRepo.findByIds(allNeededIds);
+    const memoryMap = new Map(
+      [...accessibleAnchors, ...relatedMemories].map((m) => [m.id, m]),
+    );
+
+    const result: RelationshipWithMemory[] = [];
+    for (const rel of relationships) {
+      // Determine which anchor this belongs to and what the "other end" is
+      const isSourceAnchor = anchorIds.has(rel.source_id);
+      const isTargetAnchor = anchorIds.has(rel.target_id);
+
+      if (isSourceAnchor) {
+        const related = memoryMap.get(rel.target_id);
+        if (!related || !canAccessMemory(related, userId)) continue;
+        result.push(this.toRelationshipWithMemory(rel, "outgoing", related));
+      }
+      if (isTargetAnchor && !isSourceAnchor) {
+        // Only add incoming if we didn't already add as outgoing from another anchor
+        const related = memoryMap.get(rel.source_id);
+        if (!related || !canAccessMemory(related, userId)) continue;
+        result.push(this.toRelationshipWithMemory(rel, "incoming", related));
+      }
+    }
+    return result;
+  }
+```
+
+- [ ] **Step 5: Update memory_relationships tool**
+
+In `src/tools/memory-relationships.ts`:
+
+```typescript
+export function registerMemoryRelationships(
+  server: McpServer,
+  relationshipService: RelationshipService,
+): void {
+  server.registerTool(
+    "memory_relationships",
+    {
+      description:
+        'List relationships for one or more memories. Returns all relationships in the requested direction, optionally filtered by type. Example: memory_relationships({ memory_ids: ["abc123", "def456"], user_id: "alice", direction: "both" })',
+      inputSchema: {
+        memory_ids: z
+          .array(z.string().min(1))
+          .min(1)
+          .describe("Memory IDs to list relationships for"),
+        direction: z
+          .enum(["outgoing", "incoming", "both"])
+          .default("both")
+          .describe(
+            'Direction to filter: "outgoing" (memory is source), "incoming" (memory is target), or "both" (default)',
+          ),
+        type: z
+          .string()
+          .optional()
+          .describe("Optional relationship type filter"),
+        user_id: slugSchema.describe(
+          "User identifier (required for access control)",
+        ),
+      },
+    },
+    async (params) => {
+      return withErrorHandling(async () => {
+        const results = await relationshipService.listForMemories(
+          params.memory_ids,
+          params.direction,
+          params.user_id,
+          params.type,
+        );
+        return toolResponse({ data: results, meta: { count: results.length } });
+      });
+    },
+  );
+}
+```
+
+- [ ] **Step 6: Update api-schemas.ts for memory_relationships**
+
+```typescript
+  memory_relationships: z.object({
+    memory_ids: z.array(z.string().min(1)).min(1),
+    direction: z.enum(["outgoing", "incoming", "both"]).default("both"),
+    type: z.string().optional(),
+    user_id: slugSchema,
+  }),
+```
+
+- [ ] **Step 7: Update api-tools.ts handler**
+
+Update the `memory_relationships` handler in `src/routes/api-tools.ts` to use `params.memory_ids` and call `listForMemories`.
+
+- [ ] **Step 8: Fix existing tests using old memory_id parameter**
+
+Search for `memory_relationships` and `memory_id` usage in tests, update to `memory_ids: [...]`.
+
+- [ ] **Step 9: Run tests**
+
+Run: `npx vitest run tests/integration/relationships.test.ts`
+Expected: All relationship tests pass
+
+- [ ] **Step 10: Run full test suite**
+
+Run: `npx vitest run`
+Expected: All tests pass
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/repositories/relationship-repository.ts src/repositories/types.ts src/services/relationship-service.ts src/tools/memory-relationships.ts src/routes/api-schemas.ts src/routes/api-tools.ts tests/
+git commit -m "feat: memory_relationships accepts memory_ids array for batch queries"
+```
+
+---
+
+### Task 5: `memory_search` — scope as array
+
+**Files:**
+
+- Modify: `src/repositories/types.ts:21-29` (SearchOptions.scope)
+- Modify: `src/repositories/memory-repository.ts:206-281` (search method)
+- Modify: `src/services/memory-service.ts:608-671` (search method signature)
+- Modify: `src/tools/memory-search.ts` (tool schema + description)
+- Modify: `src/routes/api-schemas.ts:51-58` (toolSchemas.memory_search)
+- Test: `tests/integration/memory-search.test.ts`
+
+- [ ] **Step 1: Write failing test for multi-scope search**
+
+In `tests/integration/memory-search.test.ts`, add:
+
+```typescript
+it("searches across multiple scopes with array", async () => {
+  const service = createTestService();
+
+  await service.create({
+    workspace_id: "test-project",
+    content: "Workspace search target multi-scope",
+    type: "fact",
+    author: "alice",
+  });
+
+  await service.create({
+    workspace_id: "test-project",
+    content: "User search target multi-scope",
+    type: "fact",
+    author: "alice",
+    scope: "user",
+  });
+
+  const result = await service.search(
+    "search target multi-scope",
+    "test-project",
+    ["workspace", "user"],
+    "alice",
+  );
+
+  expect(result.data.length).toBe(2);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/integration/memory-search.test.ts -t "searches across multiple scopes"`
+Expected: FAIL — scope parameter type mismatch
+
+- [ ] **Step 3: Update SearchOptions.scope to array**
+
+In `src/repositories/types.ts`, change `SearchOptions`:
+
+```typescript
+export interface SearchOptions {
+  embedding: number[];
+  project_id: string;
+  workspace_id: string;
+  scope: Array<"workspace" | "user" | "project">;
+  user_id?: string;
+  limit?: number;
+  min_similarity?: number;
+}
+```
+
+- [ ] **Step 4: Update repository search() for multi-scope**
+
+In `src/repositories/memory-repository.ts`, replace the scope-filtering block in `search()` (lines 222-256) with:
+
+```typescript
+// Build scope conditions from array
+const scopeConditions: SQL[] = [];
+for (const s of options.scope) {
+  if (s === "workspace") {
+    scopeConditions.push(
+      and(
+        eq(memories.workspace_id, options.workspace_id),
+        eq(memories.scope, "workspace"),
+      )!,
+    );
+  } else if (s === "user") {
+    if (!options.user_id) {
+      throw new ValidationError("user_id is required for user-scoped search");
+    }
+    scopeConditions.push(
+      and(eq(memories.author, options.user_id), eq(memories.scope, "user"))!,
+    );
+  } else {
+    scopeConditions.push(eq(memories.scope, "project"));
+  }
+}
+// Always include project-scoped if any non-project scope requested
+const hasNonProjectScope = options.scope.some((s) => s !== "project");
+if (hasNonProjectScope && !options.scope.includes("project")) {
+  scopeConditions.push(eq(memories.scope, "project"));
+}
+if (scopeConditions.length === 1) {
+  conditions.push(scopeConditions[0]);
+} else {
+  conditions.push(or(...scopeConditions)!);
+}
+```
+
+- [ ] **Step 5: Update service search() signature**
+
+In `src/services/memory-service.ts`, change the `search` method signature:
+
+```typescript
+  async search(
+    query: string,
+    workspace_id: string,
+    scope: Array<"workspace" | "user" | "project">,
+    user_id: string,
+    limit?: number,
+    min_similarity?: number,
+  ): Promise<Envelope<MemorySummaryWithRelevance[]>> {
+```
+
+The body passes `scope` through to the repository, so no other changes needed in the method body.
+
+- [ ] **Step 6: Update memory_search tool**
+
+In `src/tools/memory-search.ts`, update the schema:
+
+```typescript
+        scope: z
+          .array(memoryScopeEnum)
+          .min(1)
+          .catch(["workspace"])
+          .describe(
+            'Scopes to search, e.g. ["workspace", "user"]. Defaults to ["workspace"]. Project-scoped memories are always included.',
+          ),
+```
+
+Update the description:
+
+```typescript
+      description:
+        'Search memories by semantic similarity. Supports multiple scopes, e.g. scope: ["workspace", "user"]. Project-scoped memories are always included. Example: memory_search({ workspace_id: "my-project", query: "database migration", user_id: "alice", scope: ["workspace", "user"] })',
+```
+
+Add `memoryScopeEnum` import from `../utils/validation.js`.
+
+- [ ] **Step 7: Update api-schemas.ts for memory_search**
+
+```typescript
+  memory_search: z.object({
+    query: z.string().min(1),
+    workspace_id: slugSchema,
+    scope: z.array(memoryScopeEnum).min(1).default(["workspace"]),
+    user_id: slugSchema,
+    limit: z.number().int().min(1).max(100).default(10),
+    min_similarity: z.number().min(0).max(1).default(0.3),
+  }),
+```
+
+- [ ] **Step 8: Fix all callers that pass scope as a string**
+
+Search for `service.search(` in tests and update scope from `"workspace"` / `"user"` / `"both"` to `["workspace"]` / `["user"]` / `["workspace", "user"]`.
+
+Also update the `search` call in `src/services/memory-service.ts` `sessionStart()` method — it calls `this.search(...)` internally with `"both"`. Change to `["workspace", "user"]`.
+
+- [ ] **Step 9: Run tests**
+
+Run: `npx vitest run tests/integration/memory-search.test.ts`
+Expected: All search tests pass
+
+- [ ] **Step 10: Run full test suite**
+
+Run: `npx vitest run`
+Expected: All tests pass
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/repositories/types.ts src/repositories/memory-repository.ts src/services/memory-service.ts src/tools/memory-search.ts src/routes/api-schemas.ts tests/
+git commit -m "feat: memory_search accepts scope as array, drop 'both' option"
+```
+
+---
+
+### Task 6: Final integration test + cleanup
+
+**Files:**
+
+- Test: `tests/integration/memory-crud.test.ts`
+- Modify: Any remaining test files with old parameter shapes
+
+- [ ] **Step 1: Write end-to-end test for the 2-call pattern**
+
+In `tests/integration/memory-crud.test.ts`, add:
+
+```typescript
+it("supports the 2-call list→get pattern", async () => {
+  const { memoryService, relationshipService } =
+    createTestServiceWithRelationships();
+
+  // Create memories across scopes
+  const m1 = await memoryService.create({
+    workspace_id: "test-project",
+    content: "E2E test workspace memory",
+    type: "fact",
+    author: "alice",
+  });
+  assertMemory(m1.data);
+
+  const m2 = await memoryService.create({
+    workspace_id: "test-project",
+    content: "E2E test user memory",
+    type: "decision",
+    author: "alice",
+    scope: "user",
+  });
+  assertMemory(m2.data);
+
+  // Step 1: List across scopes
+  const listResult = await memoryService.list({
+    project_id: "test-project",
+    workspace_id: "test-project",
+    scope: ["workspace", "user"],
+    user_id: "alice",
+  });
+  expect(listResult.data.length).toBe(2);
+
+  // Step 2: Get full details for all listed IDs
+  const ids = listResult.data.map((m) => m.id);
+  const getResult = await memoryService.getMany(ids, "alice", [
+    "relationships",
+  ]);
+  expect(getResult.data.length).toBe(2);
+  expect(getResult.data[0]).toHaveProperty("can_edit");
+  expect(getResult.data[0]).toHaveProperty("relationships");
+  expect(getResult.data[0]).toHaveProperty("flag_count");
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `npx vitest run tests/integration/memory-crud.test.ts -t "supports the 2-call list"`
+Expected: PASS
+
+- [ ] **Step 3: Run full test suite one final time**
+
+Run: `npx vitest run`
+Expected: All tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/
+git commit -m "test: add end-to-end test for list→get batch query pattern"
+```

--- a/docs/superpowers/specs/2026-04-08-batch-query-endpoints-design.md
+++ b/docs/superpowers/specs/2026-04-08-batch-query-endpoints-design.md
@@ -1,0 +1,100 @@
+# Batch Query Endpoints
+
+**Date:** 2026-04-08
+**Status:** Draft
+
+## Problem
+
+Agents make excessive sequential tool calls for common read patterns. A "give me all memories" request results in N `memory_get` calls + N `memory_relationships` calls instead of 2 calls. Additionally, `memory_list` only accepts a single scope per call, requiring multiple calls to query across workspace and user scopes.
+
+Contributing factor: the `memory_get` tool description doesn't mention that relationships are already included in the response, leading agents to make redundant `memory_relationships` calls.
+
+## Design
+
+### 1. `memory_list` — scope as array
+
+**Before:** `scope: "workspace" | "user" | "project"` (single string)
+**After:** `scope: string[]` (e.g. `["workspace", "user"]`)
+**Default:** `["workspace"]`
+
+Repository change: the WHERE clause iterates the scope array and ORs the per-scope conditions together. The existing `scope = 'project'` inclusion is deduplicated when multiple scopes would each add it.
+
+Pagination, sorting, and response shape are unchanged. Each memory carries its `scope` property.
+
+### 2. `memory_get` — batch IDs with optional includes
+
+**Before:** `id: string` — returns full detail with comments, flags, relationships, capabilities
+**After:**
+
+```
+ids: string[]
+include?: ("comments" | "flags" | "relationships")[]
+```
+
+**Without `include`:** Returns memory detail with `comment_count`, `flag_count`, and `relationship_count` as numbers. No join overhead.
+
+**With `include`:** Specified joins return full data arrays; the rest remain as counts. Example: `include: ["comments"]` returns full `comments` array but `flag_count` and `relationship_count` as numbers.
+
+Capabilities (`can_edit`, `can_archive`, `can_verify`, `can_comment`) are always included per memory.
+
+**Service layer:** New `getMany(ids, userId, include?)` method that:
+
+- Batch-fetches memories via existing `findByIds(ids)`
+- Filters by project isolation and access control (inaccessible memories silently omitted)
+- Conditionally batch-fetches comments, flags, and/or relationships for the surviving IDs
+- Maps results per memory
+
+**Response shape:**
+
+```typescript
+{
+  data: MemoryGetResponse[],  // array
+  meta: { count: number, timing: number }
+}
+```
+
+### 3. `memory_relationships` — batch memory IDs
+
+**Before:** `memory_id: string`
+**After:** `memory_ids: string[]`
+
+Repository change: `findByMemoryIds` uses `IN (...)` instead of `= ?` for source/target ID filtering. Direction and type filters apply across all memories.
+
+Response shape unchanged — flat list of `RelationshipWithMemory`.
+
+### 4. `memory_search` — scope alignment
+
+**Before:** `scope: "workspace" | "user" | "both"` (single string, `"both"` is special)
+**After:** `scope: string[]` (e.g. `["workspace", "user"]`)
+**Default:** `["workspace"]`
+
+The `"both"` option is removed. `["workspace", "user"]` replaces it. The repository search query builds OR conditions per scope, same pattern as `memory_list`.
+
+### 5. New correlated subqueries in `memoryColumns()`
+
+Add alongside existing `comment_count`:
+
+- **`flag_count`**: `SELECT COUNT(*) FROM flags WHERE flags.memory_id = memories.id AND flags.resolved_at IS NULL` (open flags only)
+- **`relationship_count`**: `SELECT COUNT(*) FROM relationships WHERE (relationships.source_id = memories.id OR relationships.target_id = memories.id) AND relationships.archived_at IS NULL`
+
+All counted foreign keys are indexed:
+
+- `flags.memory_id` — `flags_memory_id_idx`
+- `relationships.source_id` — `relationships_source_idx`
+- `relationships.target_id` — `relationships_target_idx`
+
+### 6. Tool descriptions
+
+Update all four tool descriptions to:
+
+- Document array parameters with examples
+- Mention `include` parameter and counts-only default on `memory_get`
+- Explicitly state that `memory_get` with `include: ["relationships"]` eliminates the need for a separate `memory_relationships` call
+- Guide agents toward the optimal 2-call pattern: `memory_list` → `memory_get`
+
+## Non-goals
+
+- No new tools — all changes are in-place schema evolution
+- No backward compatibility shims — single consumer, clean break
+- No changes to write/mutation endpoints
+- No changes to `memory_list_stale` or `memory_list_recent` (fixed workspace scope is fine)

--- a/src/repositories/comment-repository.ts
+++ b/src/repositories/comment-repository.ts
@@ -1,4 +1,4 @@
-import { eq, asc, sql } from "drizzle-orm";
+import { eq, asc, sql, inArray } from "drizzle-orm";
 import type { Database } from "../db/index.js";
 import { comments, memories } from "../db/schema.js";
 import type { Comment } from "../types/memory.js";
@@ -52,6 +52,23 @@ export class DrizzleCommentRepository implements CommentRepository {
       .select()
       .from(comments)
       .where(eq(comments.memory_id, memoryId))
+      .orderBy(asc(comments.created_at));
+
+    return result.map((row) => ({
+      id: row.id,
+      memory_id: row.memory_id,
+      author: row.author,
+      content: row.content,
+      created_at: row.created_at,
+    }));
+  }
+
+  async findByMemoryIds(memoryIds: string[]): Promise<Comment[]> {
+    if (memoryIds.length === 0) return [];
+    const result = await this.db
+      .select()
+      .from(comments)
+      .where(inArray(comments.memory_id, memoryIds))
       .orderBy(asc(comments.created_at));
 
     return result.map((row) => ({

--- a/src/repositories/flag-repository.ts
+++ b/src/repositories/flag-repository.ts
@@ -1,4 +1,4 @@
-import { eq, and, isNull, desc, sql } from "drizzle-orm";
+import { eq, and, isNull, desc, sql, inArray } from "drizzle-orm";
 import type { Database } from "../db/index.js";
 import { flags, memories } from "../db/schema.js";
 import type { Flag, FlagResolution, FlagType } from "../types/flag.js";
@@ -90,6 +90,15 @@ export class DrizzleFlagRepository implements FlagRepository {
       .select()
       .from(flags)
       .where(eq(flags.memory_id, memoryId))
+      .orderBy(desc(flags.created_at))) as Flag[];
+  }
+
+  async findByMemoryIds(memoryIds: string[]): Promise<Flag[]> {
+    if (memoryIds.length === 0) return [];
+    return (await this.db
+      .select()
+      .from(flags)
+      .where(inArray(flags.memory_id, memoryIds))
       .orderBy(desc(flags.created_at))) as Flag[];
   }
 

--- a/src/repositories/memory-repository.ts
+++ b/src/repositories/memory-repository.ts
@@ -240,42 +240,46 @@ export class DrizzleMemoryRepository implements MemoryRepository {
 
     // SCOP-01: workspace scope queries workspace_id
     // SCOP-02: user scope queries author + scope column
-    // SCOP-03: cross-scope ('both') uses OR for workspace + user memories
+    // SCOP-03: array scope uses OR for each requested scope
     // All search modes also include project-scoped memories (cross-workspace)
-    if (options.scope === "workspace") {
-      conditions.push(
-        or(
-          eq(memories.workspace_id, options.workspace_id),
-          eq(memories.scope, "project"),
-        )!,
-      );
-    } else if (options.scope === "user") {
-      if (!options.user_id) {
-        throw new ValidationError("user_id is required for user-scoped search");
-      }
-      conditions.push(
-        or(
-          and(eq(memories.author, options.user_id), eq(memories.scope, "user")),
-          eq(memories.scope, "project"),
-        )!,
-      );
-    } else {
-      // scope === 'both' (D-10: single SQL query with OR)
-      if (!options.user_id) {
-        throw new ValidationError(
-          "user_id is required for cross-scope search (D-09)",
-        );
-      }
-      conditions.push(
-        or(
+    if (options.scope.length === 0) {
+      throw new ValidationError("scope must contain at least one value");
+    }
+    // Build scope conditions from array
+    const scopeConditions: SQL[] = [];
+    for (const s of options.scope) {
+      if (s === "workspace") {
+        scopeConditions.push(
           and(
             eq(memories.workspace_id, options.workspace_id),
             eq(memories.scope, "workspace"),
-          ),
-          and(eq(memories.author, options.user_id), eq(memories.scope, "user")),
-          eq(memories.scope, "project"),
-        )!,
-      );
+          )!,
+        );
+      } else if (s === "user") {
+        if (!options.user_id) {
+          throw new ValidationError(
+            "user_id is required for user-scoped search",
+          );
+        }
+        scopeConditions.push(
+          and(
+            eq(memories.author, options.user_id),
+            eq(memories.scope, "user"),
+          )!,
+        );
+      } else {
+        scopeConditions.push(eq(memories.scope, "project"));
+      }
+    }
+    // Always include project-scoped if any non-project scope requested
+    const hasNonProjectScope = options.scope.some((s) => s !== "project");
+    if (hasNonProjectScope && !options.scope.includes("project")) {
+      scopeConditions.push(eq(memories.scope, "project"));
+    }
+    if (scopeConditions.length === 1) {
+      conditions.push(scopeConditions[0]);
+    } else {
+      conditions.push(or(...scopeConditions)!);
     }
 
     const result = await this.db

--- a/src/repositories/memory-repository.ts
+++ b/src/repositories/memory-repository.ts
@@ -16,7 +16,11 @@ import {
 import type { SQL } from "drizzle-orm";
 import type { Database } from "../db/index.js";
 import { memories, comments } from "../db/schema.js";
-import type { Memory, MemoryWithRelevance } from "../types/memory.js";
+import type {
+  Memory,
+  MemoryWithRelevance,
+  MemoryScope,
+} from "../types/memory.js";
 import { ConflictError, ValidationError } from "../utils/errors.js";
 import type {
   MemoryRepository,
@@ -584,7 +588,12 @@ export class DrizzleMemoryRepository implements MemoryRepository {
     userId: string;
     threshold: number;
   }): Promise<
-    Array<{ id: string; title: string; relevance: number; scope: string }>
+    Array<{
+      id: string;
+      title: string;
+      relevance: number;
+      scope: MemoryScope;
+    }>
   > {
     const distance = cosineDistance(memories.embedding, options.embedding);
     const similarity = sql<number>`(1 - (${distance}))`;

--- a/src/repositories/memory-repository.ts
+++ b/src/repositories/memory-repository.ts
@@ -319,22 +319,45 @@ export class DrizzleMemoryRepository implements MemoryRepository {
     conditions.push(eq(memories.project_id, options.project_id));
 
     // SCOP-01, SCOP-04: Scope-based filtering
-    if (options.scope === "workspace") {
-      if (!options.workspace_id) {
-        throw new ValidationError(
-          "workspace_id is required for workspace-scoped list",
+    // Scope-based filtering: build OR conditions for each requested scope
+    const scopeConditions: SQL[] = [];
+    for (const s of options.scope) {
+      if (s === "workspace") {
+        if (!options.workspace_id) {
+          throw new ValidationError(
+            "workspace_id is required for workspace-scoped list",
+          );
+        }
+        scopeConditions.push(
+          and(
+            eq(memories.workspace_id, options.workspace_id),
+            eq(memories.scope, "workspace"),
+          )!,
+        );
+      } else if (s === "project") {
+        scopeConditions.push(eq(memories.scope, "project"));
+      } else {
+        // user scope
+        if (!options.user_id) {
+          throw new ValidationError("user_id is required for user-scoped list");
+        }
+        scopeConditions.push(
+          and(
+            eq(memories.author, options.user_id),
+            eq(memories.scope, "user"),
+          )!,
         );
       }
-      conditions.push(eq(memories.workspace_id, options.workspace_id));
-    } else if (options.scope === "project") {
-      // Cross-workspace project scope -- no workspace_id filter
-      conditions.push(eq(memories.scope, "project"));
+    }
+    // Always include project-scoped memories if any non-project scope requested
+    const hasNonProjectScope = options.scope.some((s) => s !== "project");
+    if (hasNonProjectScope && !options.scope.includes("project")) {
+      scopeConditions.push(eq(memories.scope, "project"));
+    }
+    if (scopeConditions.length === 1) {
+      conditions.push(scopeConditions[0]);
     } else {
-      if (!options.user_id) {
-        throw new ValidationError("user_id is required for user-scoped list");
-      }
-      conditions.push(eq(memories.author, options.user_id));
-      conditions.push(eq(memories.scope, "user"));
+      conditions.push(or(...scopeConditions)!);
     }
 
     // D-48: Optional type filter

--- a/src/repositories/memory-repository.ts
+++ b/src/repositories/memory-repository.ts
@@ -199,7 +199,7 @@ export class DrizzleMemoryRepository implements MemoryRepository {
       );
     }
 
-    // Re-fetch to get comment_count via correlated subquery
+    // Re-fetch to get correlated subquery counts (comment_count, flag_count, relationship_count)
     const updated = await this.findById(id);
     if (!updated) {
       throw new ConflictError(`Memory ${id} not found after update`);
@@ -503,7 +503,7 @@ export class DrizzleMemoryRepository implements MemoryRepository {
       .returning({ id: memories.id });
 
     if (result.length === 0) return null;
-    // Re-fetch to get comment_count via correlated subquery
+    // Re-fetch to get correlated subquery counts (comment_count, flag_count, relationship_count)
     return this.findById(id);
   }
 

--- a/src/repositories/memory-repository.ts
+++ b/src/repositories/memory-repository.ts
@@ -57,9 +57,19 @@ const baseMemoryColumns = {
 function rowToMemory(row: Record<string, unknown>): Memory {
   const result = { ...row } as unknown as Memory;
   // Ensure comment_count is a number (PostgreSQL COUNT can return string via bigint)
-  const rawCount = (row as Record<string, unknown>).comment_count;
+  const rawCommentCount = (row as Record<string, unknown>).comment_count;
   result.comment_count =
-    rawCount !== undefined && rawCount !== null ? Number(rawCount) : 0;
+    rawCommentCount !== undefined && rawCommentCount !== null
+      ? Number(rawCommentCount)
+      : 0;
+  const rawFlagCount = (row as Record<string, unknown>).flag_count;
+  result.flag_count =
+    rawFlagCount !== undefined && rawFlagCount !== null
+      ? Number(rawFlagCount)
+      : 0;
+  const rawRelCount = (row as Record<string, unknown>).relationship_count;
+  result.relationship_count =
+    rawRelCount !== undefined && rawRelCount !== null ? Number(rawRelCount) : 0;
   return result;
 }
 
@@ -74,6 +84,14 @@ export class DrizzleMemoryRepository implements MemoryRepository {
       comment_count:
         sql<number>`(SELECT COUNT(*)::int FROM comments WHERE comments.memory_id = memories.id)`.as(
           "comment_count",
+        ),
+      flag_count:
+        sql<number>`(SELECT COUNT(*)::int FROM flags WHERE flags.memory_id = memories.id AND flags.resolved_at IS NULL)`.as(
+          "flag_count",
+        ),
+      relationship_count:
+        sql<number>`(SELECT COUNT(*)::int FROM relationships WHERE (relationships.source_id = memories.id OR relationships.target_id = memories.id) AND relationships.archived_at IS NULL)`.as(
+          "relationship_count",
         ),
     };
   }
@@ -101,8 +119,13 @@ export class DrizzleMemoryRepository implements MemoryRepository {
       })
       .returning(baseMemoryColumns);
 
-    // New memories have no comments yet -- set comment_count to 0 explicitly
-    return rowToMemory({ ...result[0], comment_count: 0 });
+    // New memories have no comments, flags, or relationships yet -- set counts to 0 explicitly
+    return rowToMemory({
+      ...result[0],
+      comment_count: 0,
+      flag_count: 0,
+      relationship_count: 0,
+    });
   }
 
   async findByIds(ids: string[]): Promise<Memory[]> {

--- a/src/repositories/memory-repository.ts
+++ b/src/repositories/memory-repository.ts
@@ -318,8 +318,10 @@ export class DrizzleMemoryRepository implements MemoryRepository {
     // Deployment isolation: always filter by project_id
     conditions.push(eq(memories.project_id, options.project_id));
 
-    // SCOP-01, SCOP-04: Scope-based filtering
     // Scope-based filtering: build OR conditions for each requested scope
+    if (options.scope.length === 0) {
+      throw new ValidationError("scope must contain at least one value");
+    }
     const scopeConditions: SQL[] = [];
     for (const s of options.scope) {
       if (s === "workspace") {

--- a/src/repositories/relationship-repository.ts
+++ b/src/repositories/relationship-repository.ts
@@ -72,6 +72,44 @@ export class DrizzleRelationshipRepository implements RelationshipRepository {
     return rows as Relationship[];
   }
 
+  async findByMemoryIds(
+    projectId: string,
+    memoryIds: string[],
+    direction: "outgoing" | "incoming" | "both",
+    type?: string,
+  ): Promise<Relationship[]> {
+    if (memoryIds.length === 0) return [];
+    const conditions = [
+      eq(relationships.project_id, projectId),
+      isNull(relationships.archived_at),
+    ];
+
+    if (direction === "outgoing") {
+      conditions.push(inArray(relationships.source_id, memoryIds));
+    } else if (direction === "incoming") {
+      conditions.push(inArray(relationships.target_id, memoryIds));
+    } else {
+      conditions.push(
+        or(
+          inArray(relationships.source_id, memoryIds),
+          inArray(relationships.target_id, memoryIds),
+        )!,
+      );
+    }
+
+    if (type) {
+      conditions.push(eq(relationships.type, type));
+    }
+
+    const rows = await this.db
+      .select()
+      .from(relationships)
+      .where(and(...conditions))
+      .orderBy(relationships.created_at);
+
+    return rows as Relationship[];
+  }
+
   async findExisting(
     projectId: string,
     sourceId: string,

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -8,7 +8,7 @@ import type { Relationship } from "../types/relationship.js";
 export interface ListOptions {
   project_id: string; // deployment project (from server config)
   workspace_id?: string; // optional for project-scope listing (cross-workspace)
-  scope: "workspace" | "user" | "project";
+  scope: Array<"workspace" | "user" | "project">;
   user_id?: string;
   type?: string;
   tags?: string[];

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -127,6 +127,7 @@ export interface CommentRepository {
     content: string;
   }): Promise<Comment>;
   findByMemoryId(memoryId: string): Promise<Comment[]>;
+  findByMemoryIds(memoryIds: string[]): Promise<Comment[]>;
   countByMemoryId(memoryId: string): Promise<number>;
 }
 
@@ -173,6 +174,7 @@ export interface FlagRepository {
     resolution: FlagResolution,
   ): Promise<Flag | null>;
   findByMemoryId(memoryId: string): Promise<Flag[]>;
+  findByMemoryIds(memoryIds: string[]): Promise<Flag[]>;
   autoResolveByMemoryId(memoryId: string): Promise<number>;
   hasOpenFlag(
     memoryId: string,

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -192,6 +192,12 @@ export interface RelationshipRepository {
     direction: "outgoing" | "incoming" | "both",
     type?: string,
   ): Promise<Relationship[]>;
+  findByMemoryIds(
+    projectId: string,
+    memoryIds: string[],
+    direction: "outgoing" | "incoming" | "both",
+    type?: string,
+  ): Promise<Relationship[]>;
   findExisting(
     projectId: string,
     sourceId: string,

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -8,7 +8,7 @@ import type { Relationship } from "../types/relationship.js";
 export interface ListOptions {
   project_id: string; // deployment project (from server config)
   workspace_id?: string; // optional for project-scope listing (cross-workspace)
-  scope: Array<"workspace" | "user" | "project">;
+  scope: Array<"workspace" | "user" | "project">; // project-scoped memories are auto-included when any non-project scope is requested
   user_id?: string;
   type?: string;
   tags?: string[];

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -22,7 +22,7 @@ export interface SearchOptions {
   embedding: number[];
   project_id: string; // deployment project
   workspace_id: string; // workspace to search within
-  scope: "workspace" | "user" | "both"; // D-08: 'both' for cross-scope search
+  scope: Array<"workspace" | "user" | "project">;
   user_id?: string;
   limit?: number;
   min_similarity?: number;

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -82,7 +82,12 @@ export interface MemoryRepository {
     userId: string;
     threshold: number;
   }): Promise<
-    Array<{ id: string; title: string; relevance: number; scope: string }>
+    Array<{
+      id: string;
+      title: string;
+      relevance: number;
+      scope: import("../types/memory.js").MemoryScope;
+    }>
   >;
 
   findPairwiseSimilar(options: {

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -8,7 +8,7 @@ import type { Relationship } from "../types/relationship.js";
 export interface ListOptions {
   project_id: string; // deployment project (from server config)
   workspace_id?: string; // optional for project-scope listing (cross-workspace)
-  scope: Array<"workspace" | "user" | "project">; // project-scoped memories are auto-included when any non-project scope is requested
+  scope: Array<"workspace" | "user" | "project">; // non-empty (enforced by Zod .min(1) + runtime guard); project-scoped memories are auto-included when any non-project scope is requested
   user_id?: string;
   type?: string;
   tags?: string[];
@@ -22,7 +22,7 @@ export interface SearchOptions {
   embedding: number[];
   project_id: string; // deployment project
   workspace_id: string; // workspace to search within
-  scope: Array<"workspace" | "user" | "project">;
+  scope: Array<"workspace" | "user" | "project">; // non-empty (enforced by Zod .min(1) + runtime guard); project-scoped memories are auto-included when any non-project scope is requested
   user_id?: string;
   limit?: number;
   min_similarity?: number;

--- a/src/routes/api-schemas.ts
+++ b/src/routes/api-schemas.ts
@@ -28,7 +28,7 @@ export const toolSchemas = {
   }),
 
   memory_get: z.object({
-    ids: z.array(z.string().min(1)).min(1),
+    ids: z.array(z.string().min(1)).min(1).max(100),
     user_id: slugSchema,
     include: z.array(z.enum(["comments", "flags", "relationships"])).optional(),
   }),

--- a/src/routes/api-schemas.ts
+++ b/src/routes/api-schemas.ts
@@ -52,7 +52,7 @@ export const toolSchemas = {
   memory_search: z.object({
     query: z.string().min(1),
     workspace_id: slugSchema,
-    scope: z.enum(["workspace", "user", "both"]).default("workspace"),
+    scope: z.array(memoryScopeEnum).min(1).default(["workspace"]),
     user_id: slugSchema,
     limit: z.number().int().min(1).max(100).default(10),
     min_similarity: z.number().min(0).max(1).default(0.3),

--- a/src/routes/api-schemas.ts
+++ b/src/routes/api-schemas.ts
@@ -59,7 +59,7 @@ export const toolSchemas = {
 
   memory_list: z.object({
     workspace_id: slugSchema.optional(),
-    scope: memoryScopeEnum.default("workspace"),
+    scope: z.array(memoryScopeEnum).min(1).default(["workspace"]),
     user_id: slugSchema,
     type: memoryTypeEnum.optional(),
     tags: z.array(z.string()).optional(),

--- a/src/routes/api-schemas.ts
+++ b/src/routes/api-schemas.ts
@@ -113,7 +113,7 @@ export const toolSchemas = {
   }),
 
   memory_relationships: z.object({
-    memory_ids: z.array(z.string().min(1)).min(1),
+    memory_ids: z.array(z.string().min(1)).min(1).max(100),
     direction: z.enum(["outgoing", "incoming", "both"]).default("both"),
     type: z.string().optional(),
     user_id: slugSchema,

--- a/src/routes/api-schemas.ts
+++ b/src/routes/api-schemas.ts
@@ -28,8 +28,9 @@ export const toolSchemas = {
   }),
 
   memory_get: z.object({
-    id: z.string().min(1),
+    ids: z.array(z.string().min(1)).min(1),
     user_id: slugSchema,
+    include: z.array(z.enum(["comments", "flags", "relationships"])).optional(),
   }),
 
   memory_update: z.object({

--- a/src/routes/api-schemas.ts
+++ b/src/routes/api-schemas.ts
@@ -113,7 +113,7 @@ export const toolSchemas = {
   }),
 
   memory_relationships: z.object({
-    memory_id: z.string().min(1),
+    memory_ids: z.array(z.string().min(1)).min(1),
     direction: z.enum(["outgoing", "incoming", "both"]).default("both"),
     type: z.string().optional(),
     user_id: slugSchema,

--- a/src/routes/api-tools.ts
+++ b/src/routes/api-tools.ts
@@ -67,7 +67,11 @@ export function createApiToolsRouter(
 
         case "memory_get": {
           const b = body as z.infer<typeof toolSchemas.memory_get>;
-          const result = await memoryService.getWithComments(b.id, b.user_id);
+          const result = await memoryService.getMany(
+            b.ids,
+            b.user_id,
+            b.include,
+          );
           res.json(result);
           break;
         }

--- a/src/routes/api-tools.ts
+++ b/src/routes/api-tools.ts
@@ -196,8 +196,8 @@ export function createApiToolsRouter(
 
         case "memory_relationships": {
           const b = body as z.infer<typeof toolSchemas.memory_relationships>;
-          const results = await relationshipService.listForMemory(
-            b.memory_id,
+          const results = await relationshipService.listForMemories(
+            b.memory_ids,
             b.direction,
             b.user_id,
             b.type,

--- a/src/routes/api-tools.ts
+++ b/src/routes/api-tools.ts
@@ -196,13 +196,25 @@ export function createApiToolsRouter(
 
         case "memory_relationships": {
           const b = body as z.infer<typeof toolSchemas.memory_relationships>;
-          const results = await relationshipService.listForMemories(
-            b.memory_ids,
-            b.direction,
-            b.user_id,
-            b.type,
+          const relStart = Date.now();
+          const { relationships, accessibleAnchorIds } =
+            await relationshipService.listForMemories(
+              b.memory_ids,
+              b.direction,
+              b.user_id,
+              b.type,
+            );
+          const omittedIds = b.memory_ids.filter(
+            (id) => !accessibleAnchorIds.has(id),
           );
-          res.json({ data: results, meta: { count: results.length } });
+          res.json({
+            data: relationships,
+            meta: {
+              count: relationships.length,
+              timing: Date.now() - relStart,
+              omitted: omittedIds.length > 0 ? omittedIds : undefined,
+            },
+          });
           break;
         }
       }

--- a/src/services/consolidation-service.ts
+++ b/src/services/consolidation-service.ts
@@ -201,7 +201,7 @@ export class ConsolidationService {
     const memoriesResult = await this.memoryRepo.list({
       project_id: this.projectId,
       workspace_id: workspaceId ?? undefined,
-      scope,
+      scope: [scope],
       limit: 1000,
     });
 

--- a/src/services/flag-service.ts
+++ b/src/services/flag-service.ts
@@ -78,6 +78,10 @@ export class FlagService {
     );
   }
 
+  async findByMemoryIds(memoryIds: string[]): Promise<Flag[]> {
+    return this.flagRepo.findByMemoryIds(memoryIds);
+  }
+
   async getFlagsByMemoryId(memoryId: string): Promise<Flag[]> {
     return this.flagRepo.findByMemoryId(memoryId);
   }

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -210,6 +210,8 @@ export class MemoryService {
       verified_at: null,
       archived_at: null,
       comment_count: 0,
+      flag_count: 0,
+      relationship_count: 0,
       last_comment_at: null,
       verified_by: null,
     };

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -743,7 +743,7 @@ export class MemoryService {
   async search(
     query: string,
     workspace_id: string,
-    scope: "workspace" | "user" | "both",
+    scope: Array<"workspace" | "user" | "project">,
     user_id: string,
     limit?: number,
     min_similarity?: number,
@@ -849,7 +849,7 @@ export class MemoryService {
       result = await this.search(
         context,
         workspaceId,
-        "both",
+        ["workspace", "user"],
         userId,
         limit,
         -1,

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -489,8 +489,8 @@ export class MemoryService {
           if (rels.length > 0) {
             map.set(id, rels);
           }
-        } catch {
-          // Memory may have been archived between fetch and relationship lookup
+        } catch (error) {
+          logger.warn(`Failed to load relationships for memory ${id}:`, error);
         }
       }),
     );

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -509,11 +509,8 @@ export class MemoryService {
   ): Promise<Map<string, RelationshipWithMemory[]>> {
     if (!this.relationshipService) return new Map();
 
-    const rels = await this.relationshipService.listForMemories(
-      memoryIds,
-      "both",
-      userId,
-    );
+    const { relationships: rels } =
+      await this.relationshipService.listForMemories(memoryIds, "both", userId);
     const map = new Map<string, RelationshipWithMemory[]>();
     for (const rel of rels) {
       const anchorId =

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -6,6 +6,7 @@ import type {
   Comment,
   MemoryGetResponse,
   MemoryGetManyItem,
+  FlagSummary,
   CreateSkipResult,
   MemorySummary,
   MemorySummaryWithRelevance,
@@ -300,7 +301,7 @@ export class MemoryService {
       : [];
 
     // Open flags for this memory
-    const flagsList: MemoryGetResponse["flags"] = [];
+    const flagsList: FlagSummary[] = [];
     if (this.flagService) {
       const allFlags = await this.flagService.getFlagsByMemoryId(id);
       for (const f of allFlags) {
@@ -378,12 +379,28 @@ export class MemoryService {
       (m) => m.project_id === this.projectId && canAccessMemory(m, userId),
     );
 
+    const returnedIds = new Set(accessible.map((m) => m.id));
+    const omitted = ids.filter((id) => !returnedIds.has(id));
+
+    // Early return if no accessible memories
+    if (accessible.length === 0) {
+      const timing = Date.now() - start;
+      return {
+        data: [],
+        meta: {
+          count: 0,
+          timing,
+          omitted: omitted.length > 0 ? omitted : undefined,
+        },
+      };
+    }
+
     const accessibleIds = accessible.map((m) => m.id);
     const includeSet = new Set(include ?? []);
 
     // Batch-fetch optional joins
     let commentsByMemory = new Map<string, Comment[]>();
-    let flagsByMemory = new Map<string, MemoryGetResponse["flags"]>();
+    let flagsByMemory = new Map<string, FlagSummary[]>();
     let relsByMemory = new Map<string, RelationshipWithMemory[]>();
 
     if (includeSet.has("comments") && this.commentRepo) {
@@ -428,12 +445,19 @@ export class MemoryService {
     });
 
     const timing = Date.now() - start;
-    return { data: items, meta: { count: items.length, timing } };
+    return {
+      data: items,
+      meta: {
+        count: items.length,
+        timing,
+        omitted: omitted.length > 0 ? omitted : undefined,
+      },
+    };
   }
 
   private async batchFetchFlags(
     memoryIds: string[],
-  ): Promise<Map<string, MemoryGetResponse["flags"]>> {
+  ): Promise<Map<string, FlagSummary[]>> {
     if (!this.flagService) return new Map();
 
     const allFlags = await this.flagService.findByMemoryIds(memoryIds);
@@ -448,7 +472,7 @@ export class MemoryService {
         : [];
     const relatedMap = new Map(relatedMemories.map((m) => [m.id, m]));
 
-    const map = new Map<string, MemoryGetResponse["flags"]>();
+    const map = new Map<string, FlagSummary[]>();
     for (const f of allFlags) {
       if (f.resolved_at) continue;
       let relatedMem = null;

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -5,6 +5,7 @@ import type {
   MemoryWithRelevance,
   Comment,
   MemoryGetResponse,
+  MemoryGetManyItem,
   CreateSkipResult,
   MemorySummary,
   MemorySummaryWithRelevance,
@@ -362,6 +363,138 @@ export class MemoryService {
       },
       meta: { timing },
     };
+  }
+
+  // Batch get: retrieve multiple memories by ID with optional include expansions
+  async getMany(
+    ids: string[],
+    userId: string,
+    include?: Array<"comments" | "flags" | "relationships">,
+  ): Promise<Envelope<MemoryGetManyItem[]>> {
+    const start = Date.now();
+
+    const allMemories = await this.memoryRepo.findByIds(ids);
+    const accessible = allMemories.filter(
+      (m) => m.project_id === this.projectId && canAccessMemory(m, userId),
+    );
+
+    const accessibleIds = accessible.map((m) => m.id);
+    const includeSet = new Set(include ?? []);
+
+    // Batch-fetch optional joins
+    let commentsByMemory = new Map<string, Comment[]>();
+    let flagsByMemory = new Map<string, MemoryGetResponse["flags"]>();
+    let relsByMemory = new Map<string, RelationshipWithMemory[]>();
+
+    if (includeSet.has("comments") && this.commentRepo) {
+      const allComments = await this.commentRepo.findByMemoryIds(accessibleIds);
+      commentsByMemory = groupBy(allComments, "memory_id");
+    }
+
+    if (includeSet.has("flags") && this.flagService) {
+      flagsByMemory = await this.batchFetchFlags(accessibleIds);
+    }
+
+    if (includeSet.has("relationships") && this.relationshipService) {
+      relsByMemory = await this.batchFetchRelationships(accessibleIds, userId);
+    }
+
+    const items: MemoryGetManyItem[] = accessible.map((memory) => {
+      const isOwner = memory.author === userId;
+      const isShared =
+        memory.scope === "workspace" || memory.scope === "project";
+
+      const item: MemoryGetManyItem = {
+        ...toDetail(memory),
+        flag_count: memory.flag_count,
+        relationship_count: memory.relationship_count,
+        can_edit: canAccessMemory(memory, userId),
+        can_archive: canAccessMemory(memory, userId),
+        can_verify: canAccessMemory(memory, userId),
+        can_comment: isShared && !isOwner,
+      };
+
+      if (includeSet.has("comments")) {
+        item.comments = commentsByMemory.get(memory.id) ?? [];
+      }
+      if (includeSet.has("flags")) {
+        item.flags = flagsByMemory.get(memory.id) ?? [];
+      }
+      if (includeSet.has("relationships")) {
+        item.relationships = relsByMemory.get(memory.id) ?? [];
+      }
+
+      return item;
+    });
+
+    const timing = Date.now() - start;
+    return { data: items, meta: { count: items.length, timing } };
+  }
+
+  private async batchFetchFlags(
+    memoryIds: string[],
+  ): Promise<Map<string, MemoryGetResponse["flags"]>> {
+    if (!this.flagService) return new Map();
+
+    const allFlags = await this.flagService.findByMemoryIds(memoryIds);
+    const map = new Map<string, MemoryGetResponse["flags"]>();
+
+    for (const f of allFlags) {
+      if (f.resolved_at) continue;
+      let relatedMem = null;
+      if (f.details.related_memory_id) {
+        const related = await this.memoryRepo.findById(
+          f.details.related_memory_id,
+        );
+        if (related) {
+          relatedMem = {
+            id: related.id,
+            title: related.title,
+            content: related.content,
+            scope: related.scope,
+          };
+        }
+      }
+      const entry = {
+        flag_id: f.id,
+        flag_type: f.flag_type,
+        related_memory: relatedMem,
+        reason: f.details.reason,
+      };
+      const arr = map.get(f.memory_id);
+      if (arr) {
+        arr.push(entry);
+      } else {
+        map.set(f.memory_id, [entry]);
+      }
+    }
+    return map;
+  }
+
+  private async batchFetchRelationships(
+    memoryIds: string[],
+    userId: string,
+  ): Promise<Map<string, RelationshipWithMemory[]>> {
+    if (!this.relationshipService) return new Map();
+
+    const map = new Map<string, RelationshipWithMemory[]>();
+    await Promise.all(
+      memoryIds.map(async (id) => {
+        try {
+          const rels = await this.relationshipService!.listForMemory(
+            id,
+            "both",
+            userId,
+          );
+          if (rels.length > 0) {
+            map.set(id, rels);
+          }
+        } catch {
+          // Memory may have been archived between fetch and relationship lookup
+        }
+      }),
+    );
+    return map;
   }
 
   // D-44 through D-50: Add comment to a project memory authored by another user
@@ -935,4 +1068,18 @@ export class MemoryService {
       },
     };
   }
+}
+
+function groupBy<T>(items: T[], key: keyof T & string): Map<string, T[]> {
+  const map = new Map<string, T[]>();
+  for (const item of items) {
+    const k = item[key] as string;
+    const arr = map.get(k);
+    if (arr) {
+      arr.push(item);
+    } else {
+      map.set(k, [item]);
+    }
+  }
+  return map;
 }

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -437,15 +437,23 @@ export class MemoryService {
     if (!this.flagService) return new Map();
 
     const allFlags = await this.flagService.findByMemoryIds(memoryIds);
-    const map = new Map<string, MemoryGetResponse["flags"]>();
 
+    // Batch-fetch all related memories in one query instead of N+1
+    const relatedMemoryIds = allFlags
+      .map((f) => f.details.related_memory_id)
+      .filter((id): id is string => !!id);
+    const relatedMemories =
+      relatedMemoryIds.length > 0
+        ? await this.memoryRepo.findByIds([...new Set(relatedMemoryIds)])
+        : [];
+    const relatedMap = new Map(relatedMemories.map((m) => [m.id, m]));
+
+    const map = new Map<string, MemoryGetResponse["flags"]>();
     for (const f of allFlags) {
       if (f.resolved_at) continue;
       let relatedMem = null;
       if (f.details.related_memory_id) {
-        const related = await this.memoryRepo.findById(
-          f.details.related_memory_id,
-        );
+        const related = relatedMap.get(f.details.related_memory_id);
         if (related) {
           relatedMem = {
             id: related.id,
@@ -477,23 +485,22 @@ export class MemoryService {
   ): Promise<Map<string, RelationshipWithMemory[]>> {
     if (!this.relationshipService) return new Map();
 
-    const map = new Map<string, RelationshipWithMemory[]>();
-    await Promise.all(
-      memoryIds.map(async (id) => {
-        try {
-          const rels = await this.relationshipService!.listForMemory(
-            id,
-            "both",
-            userId,
-          );
-          if (rels.length > 0) {
-            map.set(id, rels);
-          }
-        } catch (error) {
-          logger.warn(`Failed to load relationships for memory ${id}:`, error);
-        }
-      }),
+    const rels = await this.relationshipService.listForMemories(
+      memoryIds,
+      "both",
+      userId,
     );
+    const map = new Map<string, RelationshipWithMemory[]>();
+    for (const rel of rels) {
+      const anchorId =
+        rel.direction === "outgoing" ? rel.source_id : rel.target_id;
+      const arr = map.get(anchorId);
+      if (arr) {
+        arr.push(rel);
+      } else {
+        map.set(anchorId, [rel]);
+      }
+    }
     return map;
   }
 

--- a/src/services/relationship-service.ts
+++ b/src/services/relationship-service.ts
@@ -223,8 +223,13 @@ export class RelationshipService {
     direction: "outgoing" | "incoming" | "both",
     userId: string,
     type?: string,
-  ): Promise<RelationshipWithMemory[]> {
-    if (memoryIds.length === 0) return [];
+  ): Promise<{
+    relationships: RelationshipWithMemory[];
+    accessibleAnchorIds: Set<string>;
+  }> {
+    if (memoryIds.length === 0) {
+      return { relationships: [], accessibleAnchorIds: new Set() };
+    }
 
     // Verify access to all anchor memories
     const anchorMemories = await this.memoryRepo.findByIds(memoryIds);
@@ -232,7 +237,9 @@ export class RelationshipService {
       (m) => m.project_id === this.projectId && canAccessMemory(m, userId),
     );
     const anchorIds = new Set(accessibleAnchors.map((m) => m.id));
-    if (anchorIds.size === 0) return [];
+    if (anchorIds.size === 0) {
+      return { relationships: [], accessibleAnchorIds: new Set() };
+    }
 
     const relationships = await this.relationshipRepo.findByMemoryIds(
       this.projectId,
@@ -275,7 +282,7 @@ export class RelationshipService {
         result.push(this.toRelationshipWithMemory(rel, "incoming", related));
       }
     }
-    return result;
+    return { relationships: result, accessibleAnchorIds: anchorIds };
   }
 
   async listBetweenMemories(

--- a/src/services/relationship-service.ts
+++ b/src/services/relationship-service.ts
@@ -218,6 +218,66 @@ export class RelationshipService {
     return result;
   }
 
+  async listForMemories(
+    memoryIds: string[],
+    direction: "outgoing" | "incoming" | "both",
+    userId: string,
+    type?: string,
+  ): Promise<RelationshipWithMemory[]> {
+    if (memoryIds.length === 0) return [];
+
+    // Verify access to all anchor memories
+    const anchorMemories = await this.memoryRepo.findByIds(memoryIds);
+    const accessibleAnchors = anchorMemories.filter(
+      (m) => m.project_id === this.projectId && canAccessMemory(m, userId),
+    );
+    const anchorIds = new Set(accessibleAnchors.map((m) => m.id));
+    if (anchorIds.size === 0) return [];
+
+    const relationships = await this.relationshipRepo.findByMemoryIds(
+      this.projectId,
+      [...anchorIds],
+      direction,
+      type,
+    );
+
+    // Collect related memory IDs (the "other end" of each relationship)
+    const relatedIds = new Set<string>();
+    for (const rel of relationships) {
+      if (anchorIds.has(rel.source_id)) relatedIds.add(rel.target_id);
+      if (anchorIds.has(rel.target_id)) relatedIds.add(rel.source_id);
+    }
+    // Remove anchor IDs that are already fetched
+    for (const id of anchorIds) relatedIds.delete(id);
+
+    // Batch-fetch related memories
+    const relatedMemories =
+      relatedIds.size > 0
+        ? await this.memoryRepo.findByIds([...relatedIds])
+        : [];
+    const memoryMap = new Map(
+      [...accessibleAnchors, ...relatedMemories].map((m) => [m.id, m]),
+    );
+
+    const result: RelationshipWithMemory[] = [];
+    for (const rel of relationships) {
+      const isSourceAnchor = anchorIds.has(rel.source_id);
+      const isTargetAnchor = anchorIds.has(rel.target_id);
+
+      if (isSourceAnchor) {
+        const related = memoryMap.get(rel.target_id);
+        if (!related || !canAccessMemory(related, userId)) continue;
+        result.push(this.toRelationshipWithMemory(rel, "outgoing", related));
+      }
+      if (isTargetAnchor && !isSourceAnchor) {
+        const related = memoryMap.get(rel.source_id);
+        if (!related || !canAccessMemory(related, userId)) continue;
+        result.push(this.toRelationshipWithMemory(rel, "incoming", related));
+      }
+    }
+    return result;
+  }
+
   async listBetweenMemories(
     memoryIds: string[],
     userId: string,

--- a/src/tools/memory-get.ts
+++ b/src/tools/memory-get.ts
@@ -17,7 +17,8 @@ export function registerMemoryGet(
         ids: z
           .array(z.string().min(1))
           .min(1)
-          .describe("Memory IDs to retrieve"),
+          .max(100)
+          .describe("Memory IDs to retrieve (max 100)"),
         user_id: slugSchema.describe(
           "User identifier (e.g., 'alice'). Required for access control and capability computation.",
         ),

--- a/src/tools/memory-get.ts
+++ b/src/tools/memory-get.ts
@@ -12,7 +12,7 @@ export function registerMemoryGet(
     "memory_get",
     {
       description:
-        'Retrieve one or more memories by ID. Returns full details with comment_count, flag_count, and relationship_count. Use the include parameter to get full comments, flags, or relationships arrays instead of counts. With include: ["relationships"], there is no need to call memory_relationships separately. For the common "get all memories" flow: memory_list → memory_get. Example: memory_get({ ids: ["abc123"], user_id: "alice", include: ["comments", "relationships"] })',
+        'Retrieve one or more memories by ID. Returns full details with comment_count, flag_count, and relationship_count. Use the include parameter to get full comments, flags, or relationships arrays instead of counts. With include: ["relationships"], there is no need to call memory_relationships separately (relationships are always fetched in both directions). For the common "get all memories" flow: memory_list → memory_get. IDs that are inaccessible or not found are silently omitted (check meta.omitted). Example: memory_get({ ids: ["abc123"], user_id: "alice", include: ["comments", "relationships"] })',
       inputSchema: {
         ids: z
           .array(z.string().min(1))

--- a/src/tools/memory-get.ts
+++ b/src/tools/memory-get.ts
@@ -12,19 +12,29 @@ export function registerMemoryGet(
     "memory_get",
     {
       description:
-        'Retrieve a specific memory by ID. Returns full details including comments array, capability booleans (can_comment, can_edit, can_archive, can_verify), and open flags. user_id is required for access control and capability computation. Example: memory_get({ id: "abc123", user_id: "alice" })',
+        'Retrieve one or more memories by ID. Returns full details with comment_count, flag_count, and relationship_count. Use the include parameter to get full comments, flags, or relationships arrays instead of counts. With include: ["relationships"], there is no need to call memory_relationships separately. For the common "get all memories" flow: memory_list → memory_get. Example: memory_get({ ids: ["abc123"], user_id: "alice", include: ["comments", "relationships"] })',
       inputSchema: {
-        id: z.string().describe("Memory ID to retrieve"),
+        ids: z
+          .array(z.string().min(1))
+          .min(1)
+          .describe("Memory IDs to retrieve"),
         user_id: slugSchema.describe(
           "User identifier (e.g., 'alice'). Required for access control and capability computation.",
         ),
+        include: z
+          .array(z.enum(["comments", "flags", "relationships"]))
+          .optional()
+          .describe(
+            'Optional: expand these fields to full arrays instead of counts. E.g. ["comments", "relationships"]',
+          ),
       },
     },
     async (params) => {
       return withErrorHandling(async () => {
-        const result = await memoryService.getWithComments(
-          params.id,
+        const result = await memoryService.getMany(
+          params.ids,
           params.user_id,
+          params.include,
         );
         return toolResponse(result);
       });

--- a/src/tools/memory-list.ts
+++ b/src/tools/memory-list.ts
@@ -18,17 +18,19 @@ export function registerMemoryList(
     "memory_list",
     {
       description:
-        'Browse memories with filtering, sorting, and pagination. user_id is required for access control. Use for browsing by type or tags. For semantic search, use memory_search instead. Example: memory_list({ workspace_id: "my-project", user_id: "alice", type: "decision" })',
+        'Browse memories with filtering, sorting, and pagination. Supports multiple scopes in one call, e.g. scope: ["workspace", "user"]. Project-scoped memories are always included. Example: memory_list({ workspace_id: "my-project", user_id: "alice", scope: ["workspace", "user"] })',
       inputSchema: {
         workspace_id: slugSchema
           .optional()
           .describe(
             "Workspace slug (e.g., 'my-project'). Required for workspace/user scope. Optional for project scope (cross-workspace).",
           ),
-        scope: memoryScopeEnum
-          .catch("workspace")
+        scope: z
+          .array(memoryScopeEnum)
+          .min(1)
+          .catch(["workspace"])
           .describe(
-            "List scope: 'workspace' (shared team memories), 'user' (your private memories), or 'project' (cross-workspace)",
+            'Scopes to include, e.g. ["workspace", "user"]. Defaults to ["workspace"]. Project-scoped memories are always included.',
           ),
         user_id: slugSchema.describe(
           "User identifier (e.g., 'alice'). Required for access control.",

--- a/src/tools/memory-relationships.ts
+++ b/src/tools/memory-relationships.ts
@@ -12,9 +12,12 @@ export function registerMemoryRelationships(
     "memory_relationships",
     {
       description:
-        'List relationships for a memory. Returns all relationships in the requested direction, optionally filtered by type. Example: memory_relationships({ memory_id: "abc123", user_id: "alice", direction: "both" })',
+        'List relationships for one or more memories. Returns all relationships in the requested direction, optionally filtered by type. Example: memory_relationships({ memory_ids: ["abc123", "def456"], user_id: "alice", direction: "both" })',
       inputSchema: {
-        memory_id: z.string().describe("Memory ID to list relationships for"),
+        memory_ids: z
+          .array(z.string().min(1))
+          .min(1)
+          .describe("Memory IDs to list relationships for"),
         direction: z
           .enum(["outgoing", "incoming", "both"])
           .default("both")
@@ -32,8 +35,8 @@ export function registerMemoryRelationships(
     },
     async (params) => {
       return withErrorHandling(async () => {
-        const results = await relationshipService.listForMemory(
-          params.memory_id,
+        const results = await relationshipService.listForMemories(
+          params.memory_ids,
           params.direction,
           params.user_id,
           params.type,

--- a/src/tools/memory-relationships.ts
+++ b/src/tools/memory-relationships.ts
@@ -17,7 +17,8 @@ export function registerMemoryRelationships(
         memory_ids: z
           .array(z.string().min(1))
           .min(1)
-          .describe("Memory IDs to list relationships for"),
+          .max(100)
+          .describe("Memory IDs to list relationships for (max 100)"),
         direction: z
           .enum(["outgoing", "incoming", "both"])
           .default("both")

--- a/src/tools/memory-relationships.ts
+++ b/src/tools/memory-relationships.ts
@@ -36,13 +36,25 @@ export function registerMemoryRelationships(
     },
     async (params) => {
       return withErrorHandling(async () => {
-        const results = await relationshipService.listForMemories(
-          params.memory_ids,
-          params.direction,
-          params.user_id,
-          params.type,
+        const start = Date.now();
+        const { relationships, accessibleAnchorIds } =
+          await relationshipService.listForMemories(
+            params.memory_ids,
+            params.direction,
+            params.user_id,
+            params.type,
+          );
+        const omitted = params.memory_ids.filter(
+          (id) => !accessibleAnchorIds.has(id),
         );
-        return toolResponse({ data: results, meta: { count: results.length } });
+        return toolResponse({
+          data: relationships,
+          meta: {
+            count: relationships.length,
+            timing: Date.now() - start,
+            omitted: omitted.length > 0 ? omitted : undefined,
+          },
+        });
       });
     },
   );

--- a/src/tools/memory-search.ts
+++ b/src/tools/memory-search.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { MemoryService } from "../services/memory-service.js";
-import { slugSchema } from "../utils/validation.js";
+import { slugSchema, memoryScopeEnum } from "../utils/validation.js";
 import { toolResponse, withErrorHandling } from "./tool-utils.js";
 
 export function registerMemorySearch(
@@ -12,17 +12,18 @@ export function registerMemorySearch(
     "memory_search",
     {
       description:
-        'Search memories by semantic similarity. Returns ranked results with relevance scores. user_id is required for all searches to enforce scope-based access control. Example: memory_search({ workspace_id: "my-project", query: "database migration patterns", user_id: "alice" })',
+        'Search memories by semantic similarity across one or more scopes. Returns ranked results with relevance scores. user_id is required for all searches to enforce scope-based access control. Example: memory_search({ workspace_id: "my-project", query: "database migration patterns", user_id: "alice", scope: ["workspace", "user"] })',
       inputSchema: {
         workspace_id: slugSchema.describe(
           "Workspace slug to search within (e.g., 'my-project')",
         ),
         query: z.string().describe("Natural language search query"),
         scope: z
-          .enum(["workspace", "user", "both"])
-          .catch("workspace")
+          .array(memoryScopeEnum)
+          .min(1)
+          .catch(["workspace"])
           .describe(
-            "Search scope: 'workspace' (default), 'user' (your memories), or 'both'. Project-scoped memories are always included.",
+            'Scopes to search, e.g. ["workspace", "user"]. Defaults to ["workspace"]. Project-scoped memories are always included.',
           ),
         user_id: slugSchema.describe(
           "User identifier (e.g., 'alice'). Required for access control and user-scope filtering.",

--- a/src/types/envelope.ts
+++ b/src/types/envelope.ts
@@ -36,5 +36,6 @@ export interface Envelope<T> {
       reason: string;
     }>;
     relationships?: RelationshipSummary[];
+    omitted?: string[]; // IDs requested but not returned (inaccessible/not found)
   };
 }

--- a/src/types/envelope.ts
+++ b/src/types/envelope.ts
@@ -1,4 +1,5 @@
 import type { RelationshipSummary } from "./relationship.js";
+import type { MemoryScope } from "./memory.js";
 
 // D-02: Envelope response structure
 export interface Envelope<T> {
@@ -26,12 +27,17 @@ export interface Envelope<T> {
     flags?: Array<{
       flag_id: string;
       flag_type: string;
-      memory: { id: string; title: string; content: string; scope: string };
+      memory: {
+        id: string;
+        title: string;
+        content: string;
+        scope: MemoryScope;
+      };
       related_memory?: {
         id: string;
         title: string;
         content: string;
-        scope: string;
+        scope: MemoryScope;
       } | null;
       reason: string;
     }>;

--- a/src/types/flag.ts
+++ b/src/types/flag.ts
@@ -31,13 +31,13 @@ export interface FlagWithMemory extends Flag {
     id: string;
     title: string;
     content: string;
-    scope: string;
+    scope: import("./memory.js").MemoryScope;
   };
   related_memory?: {
     id: string;
     title: string;
     content: string;
-    scope: string;
+    scope: import("./memory.js").MemoryScope;
   } | null;
 }
 
@@ -45,12 +45,17 @@ export interface FlagWithMemory extends Flag {
 export interface FlagResponse {
   flag_id: string;
   flag_type: FlagType;
-  memory: { id: string; title: string; content: string; scope: string };
+  memory: {
+    id: string;
+    title: string;
+    content: string;
+    scope: import("./memory.js").MemoryScope;
+  };
   related_memory?: {
     id: string;
     title: string;
     content: string;
-    scope: string;
+    scope: import("./memory.js").MemoryScope;
   } | null;
   reason: string;
 }

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -36,6 +36,8 @@ export interface Memory {
   verified_at: Date | null;
   archived_at: Date | null;
   comment_count: number; // D-61: computed via COUNT, present on all responses
+  flag_count: number; // computed via COUNT of open flags
+  relationship_count: number; // computed via COUNT of active relationships
   last_comment_at: Date | null; // D-62: for change_type detection
   verified_by: string | null; // D-19: who verified
 }
@@ -55,6 +57,8 @@ export interface MemorySummary {
   verified_at: Date | null;
   verified_by: string | null;
   comment_count: number;
+  flag_count: number;
+  relationship_count: number;
   last_comment_at: Date | null;
 }
 
@@ -84,6 +88,8 @@ export function toSummary(memory: Memory): MemorySummary {
     verified_at: memory.verified_at,
     verified_by: memory.verified_by,
     comment_count: memory.comment_count,
+    flag_count: memory.flag_count,
+    relationship_count: memory.relationship_count,
     last_comment_at: memory.last_comment_at,
   };
 }

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -150,8 +150,6 @@ export interface MemoryGetResponse extends MemoryDetail {
 
 // Response type for batch memory_get — detail with counts, optionally expanded joins
 export interface MemoryGetManyItem extends MemoryDetail {
-  flag_count: number;
-  relationship_count: number;
   can_comment: boolean;
   can_edit: boolean;
   can_archive: boolean;

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -148,6 +148,30 @@ export interface MemoryGetResponse extends MemoryDetail {
   can_verify: boolean;
 }
 
+// Response type for batch memory_get — detail with counts, optionally expanded joins
+export interface MemoryGetManyItem extends MemoryDetail {
+  flag_count: number;
+  relationship_count: number;
+  can_comment: boolean;
+  can_edit: boolean;
+  can_archive: boolean;
+  can_verify: boolean;
+  // Optional: populated when requested via include parameter
+  comments?: Comment[];
+  flags?: Array<{
+    flag_id: string;
+    flag_type: string;
+    related_memory?: {
+      id: string;
+      title: string;
+      content: string;
+      scope: string;
+    } | null;
+    reason: string;
+  }>;
+  relationships?: import("./relationship.js").RelationshipWithMemory[];
+}
+
 // Input type for creating a memory
 export interface MemoryCreate {
   workspace_id?: string; // optional for project-scoped memories (cross-workspace)

--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -1,3 +1,5 @@
+import type { RelationshipWithMemory } from "./relationship.js";
+
 // D-17: Predefined memory types
 export type MemoryType =
   | "fact"
@@ -127,21 +129,24 @@ export interface Comment {
   created_at: Date;
 }
 
+// Shared flag summary shape for memory_get responses
+export interface FlagSummary {
+  flag_id: string;
+  flag_type: string;
+  related_memory?: {
+    id: string;
+    title: string;
+    content: string;
+    scope: MemoryScope;
+  } | null;
+  reason: string;
+}
+
 // D-72, D-63: Enhanced response for memory_get with comments and capability flags
 export interface MemoryGetResponse extends MemoryDetail {
   comments: Comment[];
-  flags: Array<{
-    flag_id: string;
-    flag_type: string;
-    related_memory?: {
-      id: string;
-      title: string;
-      content: string;
-      scope: string;
-    } | null;
-    reason: string;
-  }>;
-  relationships: import("./relationship.js").RelationshipWithMemory[];
+  flags: FlagSummary[];
+  relationships: RelationshipWithMemory[];
   can_comment: boolean;
   can_edit: boolean;
   can_archive: boolean;
@@ -156,18 +161,8 @@ export interface MemoryGetManyItem extends MemoryDetail {
   can_verify: boolean;
   // Optional: populated when requested via include parameter
   comments?: Comment[];
-  flags?: Array<{
-    flag_id: string;
-    flag_type: string;
-    related_memory?: {
-      id: string;
-      title: string;
-      content: string;
-      scope: string;
-    } | null;
-    reason: string;
-  }>;
-  relationships?: import("./relationship.js").RelationshipWithMemory[];
+  flags?: FlagSummary[];
+  relationships?: RelationshipWithMemory[];
 }
 
 // Input type for creating a memory

--- a/tests/integration/api-relationships.test.ts
+++ b/tests/integration/api-relationships.test.ts
@@ -93,23 +93,33 @@ describe("relationship API schemas", () => {
     const schema = toolSchemas.memory_relationships;
 
     it("defaults direction to both", () => {
-      const result = schema.parse({ memory_id: "mem_abc", user_id: "alice" });
+      const result = schema.parse({
+        memory_ids: ["mem_abc"],
+        user_id: "alice",
+      });
       expect(result.direction).toBe("both");
     });
 
-    it("accepts explicit direction", () => {
+    it("accepts multiple memory_ids", () => {
       const result = schema.parse({
-        memory_id: "mem_abc",
+        memory_ids: ["mem_abc", "mem_def"],
         user_id: "alice",
         direction: "outgoing",
       });
+      expect(result.memory_ids).toEqual(["mem_abc", "mem_def"]);
       expect(result.direction).toBe("outgoing");
+    });
+
+    it("rejects empty memory_ids array", () => {
+      expect(() => schema.parse({ memory_ids: [], user_id: "alice" })).toThrow(
+        z.ZodError,
+      );
     });
 
     it("rejects invalid direction", () => {
       expect(() =>
         schema.parse({
-          memory_id: "mem_abc",
+          memory_ids: ["mem_abc"],
           user_id: "alice",
           direction: "sideways",
         }),

--- a/tests/integration/audit.test.ts
+++ b/tests/integration/audit.test.ts
@@ -52,6 +52,8 @@ describe("audit repository", () => {
       archived_at: null,
       verified_by: null,
       comment_count: 0,
+      flag_count: 0,
+      relationship_count: 0,
       last_comment_at: null,
       embedding,
     });
@@ -151,6 +153,8 @@ describe("audit service", () => {
       archived_at: null,
       verified_by: null,
       comment_count: 0,
+      flag_count: 0,
+      relationship_count: 0,
       last_comment_at: null,
       embedding,
     });

--- a/tests/integration/flags.test.ts
+++ b/tests/integration/flags.test.ts
@@ -46,6 +46,8 @@ async function seedMemory(workspaceId: string): Promise<string> {
     archived_at: null,
     verified_by: null,
     comment_count: 0,
+    flag_count: 0,
+    relationship_count: 0,
     last_comment_at: null,
     embedding,
   });

--- a/tests/integration/memory-crud.test.ts
+++ b/tests/integration/memory-crud.test.ts
@@ -527,6 +527,48 @@ describe("Memory CRUD integration tests", () => {
 
     expect(result.data).toHaveLength(1);
     expect(result.data[0].id).toBe(m1.data.id);
+    // meta.omitted should list the inaccessible ID
+    expect(result.meta.omitted).toEqual([m2.data.id]);
+  });
+
+  it("batch get returns empty with omitted when all IDs are nonexistent", async () => {
+    const { memoryService } = createTestServiceWithRelationships();
+
+    const result = await memoryService.getMany(
+      ["nonexistent-1", "nonexistent-2"],
+      "alice",
+    );
+
+    expect(result.data).toHaveLength(0);
+    expect(result.meta.omitted).toEqual(["nonexistent-1", "nonexistent-2"]);
+  });
+
+  it("batch get does not set omitted when all IDs are accessible", async () => {
+    const { memoryService } = createTestServiceWithRelationships();
+
+    const m1 = await memoryService.create({
+      workspace_id: "test-project",
+      content: "All accessible one",
+      type: "fact",
+      author: "alice",
+    });
+    assertMemory(m1.data);
+
+    const m2 = await memoryService.create({
+      workspace_id: "test-project",
+      content: "All accessible two",
+      type: "fact",
+      author: "alice",
+    });
+    assertMemory(m2.data);
+
+    const result = await memoryService.getMany(
+      [m1.data.id, m2.data.id],
+      "alice",
+    );
+
+    expect(result.data).toHaveLength(2);
+    expect(result.meta.omitted).toBeUndefined();
   });
 
   it("supports the 2-call list→get pattern", async () => {

--- a/tests/integration/memory-crud.test.ts
+++ b/tests/integration/memory-crud.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterAll } from "vitest";
 import {
   createTestService,
+  createTestServiceWithRelationships,
   truncateAll,
   closeDb,
   assertMemory,
@@ -335,6 +336,39 @@ describe("Memory CRUD integration tests", () => {
 
     expect(result.data.length).toBe(1);
     expect(result.data[0].content).toBe("Deploy note");
+  });
+
+  it("returns flag_count and relationship_count on get", async () => {
+    const { memoryService, relationshipService } =
+      createTestServiceWithRelationships();
+
+    const m1 = await memoryService.create({
+      workspace_id: "test-project",
+      content: "Memory with counts",
+      type: "fact",
+      author: "alice",
+    });
+    assertMemory(m1.data);
+
+    const m2 = await memoryService.create({
+      workspace_id: "test-project",
+      content: "Related memory for counting",
+      type: "fact",
+      author: "alice",
+    });
+    assertMemory(m2.data);
+
+    await relationshipService.create({
+      sourceId: m1.data.id,
+      targetId: m2.data.id,
+      type: "refines",
+      userId: "alice",
+    });
+
+    const fetched = await memoryService.get(m1.data.id, "alice");
+    expect(fetched.data.flag_count).toBe(0);
+    expect(fetched.data.relationship_count).toBe(1);
+    expect(fetched.data.comment_count).toBe(0);
   });
 
   it("paginates with cursor", async () => {

--- a/tests/integration/memory-crud.test.ts
+++ b/tests/integration/memory-crud.test.ts
@@ -271,7 +271,7 @@ describe("Memory CRUD integration tests", () => {
     const result = await service.list({
       project_id: "test-project",
       workspace_id: "test-project",
-      scope: "workspace",
+      scope: ["workspace"],
     });
 
     expect(result.data.length).toBe(3);
@@ -303,7 +303,7 @@ describe("Memory CRUD integration tests", () => {
     const result = await service.list({
       project_id: "test-project",
       workspace_id: "test-project",
-      scope: "workspace",
+      scope: ["workspace"],
       type: "decision",
     });
 
@@ -330,7 +330,7 @@ describe("Memory CRUD integration tests", () => {
     const result = await service.list({
       project_id: "test-project",
       workspace_id: "test-project",
-      scope: "workspace",
+      scope: ["workspace"],
       tags: ["deploy"],
     });
 
@@ -386,7 +386,7 @@ describe("Memory CRUD integration tests", () => {
     const page1 = await service.list({
       project_id: "test-project",
       workspace_id: "test-project",
-      scope: "workspace",
+      scope: ["workspace"],
       limit: 2,
     });
     expect(page1.data.length).toBe(2);
@@ -398,7 +398,7 @@ describe("Memory CRUD integration tests", () => {
     const page2 = await service.list({
       project_id: "test-project",
       workspace_id: "test-project",
-      scope: "workspace",
+      scope: ["workspace"],
       limit: 2,
       cursor: { created_at: cursorParts[0], id: cursorParts[1] },
     });
@@ -410,7 +410,7 @@ describe("Memory CRUD integration tests", () => {
     const page3 = await service.list({
       project_id: "test-project",
       workspace_id: "test-project",
-      scope: "workspace",
+      scope: ["workspace"],
       limit: 2,
       cursor: { created_at: cursor2Parts[0], id: cursor2Parts[1] },
     });

--- a/tests/integration/memory-crud.test.ts
+++ b/tests/integration/memory-crud.test.ts
@@ -528,4 +528,45 @@ describe("Memory CRUD integration tests", () => {
     expect(result.data).toHaveLength(1);
     expect(result.data[0].id).toBe(m1.data.id);
   });
+
+  it("supports the 2-call list→get pattern", async () => {
+    const { memoryService } = createTestServiceWithRelationships();
+
+    // Create memories across scopes
+    const m1 = await memoryService.create({
+      workspace_id: "test-project",
+      content: "E2E test workspace memory",
+      type: "fact",
+      author: "alice",
+    });
+    assertMemory(m1.data);
+
+    const m2 = await memoryService.create({
+      workspace_id: "test-project",
+      content: "E2E test user memory",
+      type: "decision",
+      author: "alice",
+      scope: "user",
+    });
+    assertMemory(m2.data);
+
+    // Step 1: List across scopes
+    const listResult = await memoryService.list({
+      project_id: "test-project",
+      workspace_id: "test-project",
+      scope: ["workspace", "user"],
+      user_id: "alice",
+    });
+    expect(listResult.data.length).toBe(2);
+
+    // Step 2: Get full details for all listed IDs
+    const ids = listResult.data.map((m) => m.id);
+    const getResult = await memoryService.getMany(ids, "alice", [
+      "relationships",
+    ]);
+    expect(getResult.data.length).toBe(2);
+    expect(getResult.data[0]).toHaveProperty("can_edit");
+    expect(getResult.data[0]).toHaveProperty("relationships");
+    expect(getResult.data[0]).toHaveProperty("flag_count");
+  });
 });

--- a/tests/integration/memory-crud.test.ts
+++ b/tests/integration/memory-crud.test.ts
@@ -425,4 +425,107 @@ describe("Memory CRUD integration tests", () => {
     ];
     expect(new Set(allIds).size).toBe(5);
   });
+
+  it("batch gets multiple memories with counts", async () => {
+    const { memoryService } = createTestServiceWithRelationships();
+
+    const m1 = await memoryService.create({
+      workspace_id: "test-project",
+      content: "Batch get memory one",
+      type: "fact",
+      author: "alice",
+    });
+    assertMemory(m1.data);
+
+    const m2 = await memoryService.create({
+      workspace_id: "test-project",
+      content: "Batch get memory two",
+      type: "decision",
+      author: "alice",
+    });
+    assertMemory(m2.data);
+
+    const result = await memoryService.getMany(
+      [m1.data.id, m2.data.id],
+      "alice",
+    );
+
+    expect(result.data).toHaveLength(2);
+    expect(result.data[0].comment_count).toBe(0);
+    expect(result.data[0].flag_count).toBe(0);
+    expect(result.data[0].relationship_count).toBe(0);
+    expect(result.data[0]).not.toHaveProperty("comments");
+    expect(result.data[0]).not.toHaveProperty("flags");
+    expect(result.data[0]).not.toHaveProperty("relationships");
+  });
+
+  it("batch gets with include returns full data for specified joins", async () => {
+    const { memoryService, relationshipService } =
+      createTestServiceWithRelationships();
+
+    const m1 = await memoryService.create({
+      workspace_id: "test-project",
+      content: "Memory with relationship for include test",
+      type: "fact",
+      author: "alice",
+    });
+    assertMemory(m1.data);
+
+    const m2 = await memoryService.create({
+      workspace_id: "test-project",
+      content: "Related memory for include test",
+      type: "fact",
+      author: "alice",
+    });
+    assertMemory(m2.data);
+
+    await relationshipService.create({
+      sourceId: m1.data.id,
+      targetId: m2.data.id,
+      type: "refines",
+      userId: "alice",
+    });
+
+    const result = await memoryService.getMany([m1.data.id], "alice", [
+      "relationships",
+    ]);
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].relationships).toHaveLength(1);
+    expect(result.data[0].relationships![0].type).toBe("refines");
+    expect(result.data[0].comment_count).toBe(0);
+    expect(result.data[0].flag_count).toBe(0);
+    expect(result.data[0]).not.toHaveProperty("comments");
+    expect(result.data[0]).not.toHaveProperty("flags");
+  });
+
+  it("batch get silently omits inaccessible memories", async () => {
+    const { memoryService } = createTestServiceWithRelationships();
+
+    const m1 = await memoryService.create({
+      workspace_id: "test-project",
+      content: "Accessible workspace memory",
+      type: "fact",
+      author: "alice",
+    });
+    assertMemory(m1.data);
+
+    const m2 = await memoryService.create({
+      workspace_id: "test-project",
+      content: "Private user memory",
+      type: "fact",
+      author: "bob",
+      scope: "user",
+    });
+    assertMemory(m2.data);
+
+    // Alice should only see her own memory, not bob's user-scoped one
+    const result = await memoryService.getMany(
+      [m1.data.id, m2.data.id],
+      "alice",
+    );
+
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].id).toBe(m1.data.id);
+  });
 });

--- a/tests/integration/memory-scoping.test.ts
+++ b/tests/integration/memory-scoping.test.ts
@@ -37,7 +37,7 @@ describe("Memory scoping integration tests", () => {
     const result = await service.search(
       "deployment pipelines",
       "project-b",
-      "workspace",
+      ["workspace"],
       "alice",
     );
 
@@ -63,7 +63,7 @@ describe("Memory scoping integration tests", () => {
     const result = await service.search(
       "vim keybindings",
       "project-b",
-      "user",
+      ["user"],
       "alice",
       undefined,
       -1, // negative threshold ensures mock embeddings with any cosine similarity pass through
@@ -131,7 +131,7 @@ describe("Memory scoping integration tests", () => {
     const searchResult = await service.search(
       "ESM imports",
       "workspace-b",
-      "workspace",
+      ["workspace"],
       "bob",
       undefined,
       -1,
@@ -181,7 +181,7 @@ describe("Memory scoping integration tests", () => {
     expect(result.data.scope).toBe("project");
   });
 
-  it("search scope=both includes project-scoped memories", async () => {
+  it("search scope array includes project-scoped memories", async () => {
     // Create workspace-scoped memory
     await service.create({
       workspace_id: "test-project",
@@ -211,7 +211,7 @@ describe("Memory scoping integration tests", () => {
     const result = await service.search(
       "configuration patterns",
       "test-project",
-      "both",
+      ["workspace", "user"],
       "alice",
       undefined,
       -1,

--- a/tests/integration/memory-scoping.test.ts
+++ b/tests/integration/memory-scoping.test.ts
@@ -234,6 +234,37 @@ describe("Memory scoping integration tests", () => {
     expect(result.data.scope).toBe("workspace");
   });
 
+  it("lists memories across multiple scopes", async () => {
+    const ws = await service.create({
+      workspace_id: "test-project",
+      content: "Workspace memory for multi-scope test",
+      type: "fact",
+      author: "alice",
+    });
+    assertMemory(ws.data);
+
+    const user = await service.create({
+      workspace_id: "test-project",
+      content: "User memory for multi-scope test",
+      type: "fact",
+      author: "alice",
+      scope: "user",
+    });
+    assertMemory(user.data);
+
+    const result = await service.list({
+      project_id: "test-project",
+      workspace_id: "test-project",
+      scope: ["workspace", "user"],
+      user_id: "alice",
+    });
+
+    expect(result.data.length).toBe(2);
+    const scopes = result.data.map((m) => m.scope);
+    expect(scopes).toContain("workspace");
+    expect(scopes).toContain("user");
+  });
+
   it("recently verified memories excluded from list_stale", async () => {
     const { data: createdData } = await service.create({
       workspace_id: "test-project",

--- a/tests/integration/memory-search.test.ts
+++ b/tests/integration/memory-search.test.ts
@@ -43,7 +43,7 @@ describe("Memory search integration tests", () => {
     const result = await service.search(
       "database",
       "test-project",
-      "workspace",
+      ["workspace"],
       "alice",
       undefined,
       -1, // negative threshold ensures mock embeddings with any cosine similarity pass through
@@ -72,7 +72,7 @@ describe("Memory search integration tests", () => {
     const result = await service.search(
       "search content",
       "test-project",
-      "workspace",
+      ["workspace"],
       "alice",
       2,
       -1, // negative threshold ensures mock embeddings with any cosine similarity pass through
@@ -95,7 +95,7 @@ describe("Memory search integration tests", () => {
     const result = await service.search(
       "archived memory search",
       "test-project",
-      "workspace",
+      ["workspace"],
       "alice",
     );
 
@@ -115,7 +115,7 @@ describe("Memory search integration tests", () => {
     const result = await service.search(
       "completely unrelated query xyz",
       "test-project",
-      "workspace",
+      ["workspace"],
       "alice",
       undefined,
       0.99,
@@ -146,7 +146,7 @@ describe("Memory search integration tests", () => {
     const result = await service.search(
       "deployment",
       "test-project",
-      "both",
+      ["workspace", "user"],
       "alice",
       undefined,
       -1, // negative threshold ensures mock embeddings with any cosine similarity pass through
@@ -166,17 +166,45 @@ describe("Memory search integration tests", () => {
   });
 
   it("cross-scope search with both scopes requires user_id (D-09)", async () => {
-    // user_id is now a required parameter -- repository enforces it for scope='both'
+    // user_id is now a required parameter -- repository enforces it for scope=['workspace','user']
     // Passing a valid user_id must work without error
     const result = await service.search(
       "test",
       "test-project",
-      "both",
+      ["workspace", "user"],
       "alice",
       undefined,
       -1,
     );
     expect(result.data).toBeInstanceOf(Array);
+  });
+
+  it("searches across multiple scopes with array", async () => {
+    await service.create({
+      workspace_id: "test-project",
+      content: "Workspace search target multi-scope",
+      type: "fact",
+      author: "alice",
+    });
+
+    await service.create({
+      workspace_id: "test-project",
+      content: "User search target multi-scope",
+      type: "fact",
+      author: "alice",
+      scope: "user",
+    });
+
+    const result = await service.search(
+      "search target multi-scope",
+      "test-project",
+      ["workspace", "user"],
+      "alice",
+      undefined,
+      -1, // negative threshold ensures mock embeddings with any cosine similarity pass through
+    );
+
+    expect(result.data.length).toBe(2);
   });
 
   it("search results include relevance score between 0 and 1", async () => {
@@ -190,7 +218,7 @@ describe("Memory search integration tests", () => {
     const result = await service.search(
       "relevance scores",
       "test-project",
-      "workspace",
+      ["workspace"],
       "alice",
       undefined,
       -1, // negative threshold ensures mock embeddings with any cosine similarity pass through

--- a/tests/integration/relationships.test.ts
+++ b/tests/integration/relationships.test.ts
@@ -555,11 +555,12 @@ describe("listForMemories — batch anchor query", () => {
     });
 
     // Query for both m1 and m3 as anchors
-    const results = await relationshipService.listForMemories(
-      [m1.id, m3.id],
-      "both",
-      "alice",
-    );
+    const { relationships: results } =
+      await relationshipService.listForMemories(
+        [m1.id, m3.id],
+        "both",
+        "alice",
+      );
 
     // m1 has 2 relationships (outgoing to m2, incoming from m3)
     // m3 has 1 relationship (outgoing to m1) — but m1 is also an anchor, so isSourceAnchor wins
@@ -581,11 +582,8 @@ describe("listForMemories — batch anchor query", () => {
   });
 
   it("returns empty array for empty input", async () => {
-    const results = await relationshipService.listForMemories(
-      [],
-      "both",
-      "alice",
-    );
+    const { relationships: results } =
+      await relationshipService.listForMemories([], "both", "alice");
     expect(results).toHaveLength(0);
   });
 
@@ -616,19 +614,13 @@ describe("listForMemories — batch anchor query", () => {
       userId: "alice",
     });
 
-    const outgoing = await relationshipService.listForMemories(
-      [m1.id],
-      "outgoing",
-      "alice",
-    );
+    const { relationships: outgoing } =
+      await relationshipService.listForMemories([m1.id], "outgoing", "alice");
     expect(outgoing).toHaveLength(1);
     expect(outgoing[0].direction).toBe("outgoing");
 
-    const incoming = await relationshipService.listForMemories(
-      [m1.id],
-      "incoming",
-      "alice",
-    );
+    const { relationships: incoming } =
+      await relationshipService.listForMemories([m1.id], "incoming", "alice");
     expect(incoming).toHaveLength(0);
   });
 });

--- a/tests/integration/relationships.test.ts
+++ b/tests/integration/relationships.test.ts
@@ -487,6 +487,152 @@ describe("memory_get includes relationships", () => {
   });
 });
 
+describe("listForMemories — batch anchor query", () => {
+  let memoryService: ReturnType<
+    typeof createTestServiceWithRelationships
+  >["memoryService"];
+  let relationshipService: ReturnType<
+    typeof createTestServiceWithRelationships
+  >["relationshipService"];
+
+  beforeEach(async () => {
+    await truncateAll();
+    const services = createTestServiceWithRelationships();
+    memoryService = services.memoryService;
+    relationshipService = services.relationshipService;
+
+    const workspaceRepo = new DrizzleWorkspaceRepository(getTestDb());
+    await workspaceRepo.findOrCreate("test-ws");
+  });
+
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("returns relationships for multiple anchor memories in a single call", async () => {
+    // Create 3 memories
+    const r1 = await memoryService.create({
+      workspace_id: "test-ws",
+      content: "memory one",
+      type: "fact",
+      author: "alice",
+    });
+    assertMemory(r1.data);
+    const m1 = r1.data;
+
+    const r2 = await memoryService.create({
+      workspace_id: "test-ws",
+      content: "memory two",
+      type: "fact",
+      author: "alice",
+    });
+    assertMemory(r2.data);
+    const m2 = r2.data;
+
+    const r3 = await memoryService.create({
+      workspace_id: "test-ws",
+      content: "memory three",
+      type: "fact",
+      author: "alice",
+    });
+    assertMemory(r3.data);
+    const m3 = r3.data;
+
+    // m1 → m2 (outgoing from m1)
+    await relationshipService.create({
+      sourceId: m1.id,
+      targetId: m2.id,
+      type: "overrides",
+      userId: "alice",
+    });
+
+    // m3 → m1 (incoming to m1, outgoing from m3)
+    await relationshipService.create({
+      sourceId: m3.id,
+      targetId: m1.id,
+      type: "refines",
+      userId: "alice",
+    });
+
+    // Query for both m1 and m3 as anchors
+    const results = await relationshipService.listForMemories(
+      [m1.id, m3.id],
+      "both",
+      "alice",
+    );
+
+    // m1 has 2 relationships (outgoing to m2, incoming from m3)
+    // m3 has 1 relationship (outgoing to m1) — but m1 is also an anchor, so isSourceAnchor wins
+    // Total unique: m1→m2 (outgoing), m3→m1 (outgoing from m3 anchor perspective is covered
+    // by isSourceAnchor=true for m3; and incoming to m1 anchor but isTargetAnchor&&!isSourceAnchor skips it)
+    expect(results.length).toBeGreaterThanOrEqual(2);
+
+    const outgoingFromM1 = results.find(
+      (r) => r.source_id === m1.id && r.target_id === m2.id,
+    );
+    expect(outgoingFromM1).toBeDefined();
+    expect(outgoingFromM1!.direction).toBe("outgoing");
+
+    const outgoingFromM3 = results.find(
+      (r) => r.source_id === m3.id && r.target_id === m1.id,
+    );
+    expect(outgoingFromM3).toBeDefined();
+    expect(outgoingFromM3!.direction).toBe("outgoing");
+  });
+
+  it("returns empty array for empty input", async () => {
+    const results = await relationshipService.listForMemories(
+      [],
+      "both",
+      "alice",
+    );
+    expect(results).toHaveLength(0);
+  });
+
+  it("filters by direction across all anchors", async () => {
+    const r1 = await memoryService.create({
+      workspace_id: "test-ws",
+      content: "memory one",
+      type: "fact",
+      author: "alice",
+    });
+    assertMemory(r1.data);
+    const m1 = r1.data;
+
+    const r2 = await memoryService.create({
+      workspace_id: "test-ws",
+      content: "memory two",
+      type: "fact",
+      author: "alice",
+    });
+    assertMemory(r2.data);
+    const m2 = r2.data;
+
+    // m1 → m2
+    await relationshipService.create({
+      sourceId: m1.id,
+      targetId: m2.id,
+      type: "overrides",
+      userId: "alice",
+    });
+
+    const outgoing = await relationshipService.listForMemories(
+      [m1.id],
+      "outgoing",
+      "alice",
+    );
+    expect(outgoing).toHaveLength(1);
+    expect(outgoing[0].direction).toBe("outgoing");
+
+    const incoming = await relationshipService.listForMemories(
+      [m1.id],
+      "incoming",
+      "alice",
+    );
+    expect(incoming).toHaveLength(0);
+  });
+});
+
 describe("end-to-end: create relationship → get → archive → verify cleanup", () => {
   let memoryService: ReturnType<
     typeof createTestServiceWithRelationships

--- a/tests/integration/relationships.test.ts
+++ b/tests/integration/relationships.test.ts
@@ -565,7 +565,7 @@ describe("listForMemories — batch anchor query", () => {
     // m3 has 1 relationship (outgoing to m1) — but m1 is also an anchor, so isSourceAnchor wins
     // Total unique: m1→m2 (outgoing), m3→m1 (outgoing from m3 anchor perspective is covered
     // by isSourceAnchor=true for m3; and incoming to m1 anchor but isTargetAnchor&&!isSourceAnchor skips it)
-    expect(results.length).toBeGreaterThanOrEqual(2);
+    expect(results).toHaveLength(2);
 
     const outgoingFromM1 = results.find(
       (r) => r.source_id === m1.id && r.target_id === m2.id,

--- a/tests/unit/budget.test.ts
+++ b/tests/unit/budget.test.ts
@@ -34,6 +34,8 @@ function makeMemory(overrides: Partial<Memory> = {}): Memory {
     verified_at: null,
     archived_at: null,
     comment_count: 0,
+    flag_count: 0,
+    relationship_count: 0,
     last_comment_at: null,
     verified_by: null,
     ...overrides,

--- a/tests/unit/dedup.test.ts
+++ b/tests/unit/dedup.test.ts
@@ -32,6 +32,8 @@ function makeMemory(overrides: Partial<Memory> = {}): Memory {
     verified_at: null,
     archived_at: null,
     comment_count: 0,
+    flag_count: 0,
+    relationship_count: 0,
     last_comment_at: null,
     verified_by: null,
     ...overrides,


### PR DESCRIPTION
## Summary

- **`memory_list` and `memory_search`**: `scope` parameter changed from single string to `string[]`, enabling multi-scope queries in one call (e.g. `["workspace", "user"]`). The `"both"` option on search is removed.
- **`memory_get`**: `id` changed to `ids: string[]` (max 100) with optional `include` parameter (`["comments", "flags", "relationships"]`) to expand counts to full arrays. New `getMany()` service method.
- **`memory_relationships`**: `memory_id` changed to `memory_ids: string[]` for batch relationship queries.
- **New computed fields**: `flag_count` and `relationship_count` added as correlated subqueries alongside existing `comment_count` on all memory responses.

Enables the optimal 2-call agent pattern: `memory_list` → `memory_get` instead of N+1 individual calls.

## Test plan
- [x] 260 integration + unit tests passing
- [x] End-to-end test validates the list→get 2-call pattern
- [x] Batch get with/without include parameter
- [x] Multi-scope list and search
- [x] Batch relationship queries with dedup logic
- [x] Access control: inaccessible memories silently omitted in batch responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)