### PR TITLE
feat: always load project-scoped memories at session start

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,3 +3,5 @@ set -e
 npm run format
 npm run lint -- --fix
 git add -u
+npm run typecheck
+npm run test:unit

--- a/src/repositories/memory-repository.ts
+++ b/src/repositories/memory-repository.ts
@@ -28,6 +28,7 @@ import type {
   SearchOptions,
   StaleOptions,
   RecentBothScopesOptions,
+  ProjectScopedOptions,
   RecentActivityOptions,
   TeamActivityCounts,
 } from "./types.js";
@@ -245,7 +246,6 @@ export class DrizzleMemoryRepository implements MemoryRepository {
     // SCOP-01: workspace scope queries workspace_id
     // SCOP-02: user scope queries author + scope column
     // SCOP-03: array scope uses OR for each requested scope
-    // All search modes also include project-scoped memories (cross-workspace)
     if (options.scope.length === 0) {
       throw new ValidationError("scope must contain at least one value");
     }
@@ -274,11 +274,6 @@ export class DrizzleMemoryRepository implements MemoryRepository {
       } else {
         scopeConditions.push(eq(memories.scope, "project"));
       }
-    }
-    // Always include project-scoped if any non-project scope requested
-    const hasNonProjectScope = options.scope.some((s) => s !== "project");
-    if (hasNonProjectScope && !options.scope.includes("project")) {
-      scopeConditions.push(eq(memories.scope, "project"));
     }
     if (scopeConditions.length === 1) {
       conditions.push(scopeConditions[0]);
@@ -358,11 +353,6 @@ export class DrizzleMemoryRepository implements MemoryRepository {
           )!,
         );
       }
-    }
-    // Always include project-scoped memories if any non-project scope requested
-    const hasNonProjectScope = options.scope.some((s) => s !== "project");
-    if (hasNonProjectScope && !options.scope.includes("project")) {
-      scopeConditions.push(eq(memories.scope, "project"));
     }
     if (scopeConditions.length === 1) {
       conditions.push(scopeConditions[0]);
@@ -498,10 +488,7 @@ export class DrizzleMemoryRepository implements MemoryRepository {
     };
   }
 
-  async listProjectScoped(options: {
-    project_id: string;
-    limit: number;
-  }): Promise<Memory[]> {
+  async listProjectScoped(options: ProjectScopedOptions): Promise<Memory[]> {
     const result = await this.db
       .select(this.memoryColumns())
       .from(memories)

--- a/src/repositories/memory-repository.ts
+++ b/src/repositories/memory-repository.ts
@@ -529,12 +529,14 @@ export class DrizzleMemoryRepository implements MemoryRepository {
           eq(memories.project_id, options.project_id),
           isNull(memories.archived_at),
           or(
-            eq(memories.workspace_id, options.workspace_id),
+            and(
+              eq(memories.workspace_id, options.workspace_id),
+              eq(memories.scope, "workspace"),
+            ),
             and(
               eq(memories.author, options.user_id),
               eq(memories.scope, "user"),
             ),
-            eq(memories.scope, "project"),
           )!,
         ),
       )

--- a/src/repositories/memory-repository.ts
+++ b/src/repositories/memory-repository.ts
@@ -498,6 +498,26 @@ export class DrizzleMemoryRepository implements MemoryRepository {
     };
   }
 
+  async listProjectScoped(options: {
+    project_id: string;
+    limit: number;
+  }): Promise<Memory[]> {
+    const result = await this.db
+      .select(this.memoryColumns())
+      .from(memories)
+      .where(
+        and(
+          eq(memories.project_id, options.project_id),
+          isNull(memories.archived_at),
+          eq(memories.scope, "project"),
+        ),
+      )
+      .orderBy(desc(memories.created_at), desc(memories.id))
+      .limit(options.limit);
+
+    return result.map(rowToMemory);
+  }
+
   async listRecentBothScopes(
     options: RecentBothScopesOptions,
   ): Promise<Memory[]> {

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -71,6 +71,10 @@ export interface MemoryRepository {
     cursor?: { created_at: string; id: string };
   }>;
   listRecentBothScopes(options: RecentBothScopesOptions): Promise<Memory[]>;
+  listProjectScoped(options: {
+    project_id: string;
+    limit: number;
+  }): Promise<Memory[]>;
   verify(id: string, verifiedBy: string): Promise<Memory | null>;
   findRecentActivity(options: RecentActivityOptions): Promise<Memory[]>;
   countTeamActivity(

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -13,7 +13,7 @@ import type { Relationship } from "../types/relationship.js";
 export interface ListOptions {
   project_id: string; // deployment project (from server config)
   workspace_id?: string; // optional for project-scope listing (cross-workspace)
-  scope: MemoryScope[]; // non-empty; project-scoped memories are auto-included when any non-project scope is requested
+  scope: MemoryScope[]; // non-empty; scopes are honored literally (no implicit project-scope inclusion)
   user_id?: string;
   type?: string;
   tags?: string[];
@@ -27,7 +27,7 @@ export interface SearchOptions {
   embedding: number[];
   project_id: string; // deployment project
   workspace_id: string; // workspace to search within
-  scope: MemoryScope[]; // non-empty; project-scoped memories are auto-included when any non-project scope is requested
+  scope: MemoryScope[]; // non-empty; scopes are honored literally (no implicit project-scope inclusion)
   user_id?: string;
   limit?: number;
   min_similarity?: number;
@@ -38,6 +38,11 @@ export interface RecentBothScopesOptions {
   workspace_id: string;
   user_id: string;
   limit: number;
+}
+
+export interface ProjectScopedOptions {
+  project_id: string; // deployment project
+  limit: number; // bounds enforced by caller (see PROJECT_LIMIT_{MIN,MAX})
 }
 
 export interface StaleOptions {
@@ -71,10 +76,7 @@ export interface MemoryRepository {
     cursor?: { created_at: string; id: string };
   }>;
   listRecentBothScopes(options: RecentBothScopesOptions): Promise<Memory[]>;
-  listProjectScoped(options: {
-    project_id: string;
-    limit: number;
-  }): Promise<Memory[]>;
+  listProjectScoped(options: ProjectScopedOptions): Promise<Memory[]>;
   verify(id: string, verifiedBy: string): Promise<Memory | null>;
   findRecentActivity(options: RecentActivityOptions): Promise<Memory[]>;
   countTeamActivity(

--- a/src/routes/api-schemas.ts
+++ b/src/routes/api-schemas.ts
@@ -5,6 +5,11 @@ import {
   memoryTypeEnum,
   memoryScopeEnum,
 } from "../utils/validation.js";
+import {
+  PROJECT_LIMIT_MIN,
+  PROJECT_LIMIT_MAX,
+  PROJECT_LIMIT_DEFAULT,
+} from "../utils/session-limits.js";
 
 export const toolSchemas = {
   memory_session_start: z.object({
@@ -12,7 +17,12 @@ export const toolSchemas = {
     user_id: slugSchema,
     context: z.string().optional(),
     limit: z.number().int().min(1).max(50).default(10),
-    project_limit: z.number().int().min(1).max(200).default(50),
+    project_limit: z
+      .number()
+      .int()
+      .min(PROJECT_LIMIT_MIN)
+      .max(PROJECT_LIMIT_MAX)
+      .default(PROJECT_LIMIT_DEFAULT),
   }),
 
   memory_create: z.object({

--- a/src/routes/api-schemas.ts
+++ b/src/routes/api-schemas.ts
@@ -12,6 +12,7 @@ export const toolSchemas = {
     user_id: slugSchema,
     context: z.string().optional(),
     limit: z.number().int().min(1).max(50).default(10),
+    project_limit: z.number().int().min(1).max(200).default(50),
   }),
 
   memory_create: z.object({

--- a/src/routes/api-tools.ts
+++ b/src/routes/api-tools.ts
@@ -42,6 +42,7 @@ export function createApiToolsRouter(
             b.user_id,
             b.context,
             b.limit,
+            b.project_limit,
           );
           res.json(result);
           break;

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -40,6 +40,11 @@ import { canAccessMemory } from "../utils/access.js";
 import { generateId } from "../utils/id.js";
 import { logger } from "../utils/logger.js";
 import { computeRelevance, OVER_FETCH_FACTOR } from "../utils/scoring.js";
+import {
+  PROJECT_LIMIT_MIN,
+  PROJECT_LIMIT_MAX,
+  PROJECT_LIMIT_DEFAULT,
+} from "../utils/session-limits.js";
 import { config } from "../config.js";
 
 const MAX_CONTENT_WARNING = 4_000; // D-20: Warn but allow
@@ -809,9 +814,21 @@ export class MemoryService {
     userId: string,
     context?: string,
     limit: number = 10,
-    projectLimit: number = 50,
+    projectLimit: number = PROJECT_LIMIT_DEFAULT,
   ): Promise<Envelope<MemorySummaryWithRelevance[]>> {
     const start = Date.now();
+
+    // Guard non-MCP callers that bypass Zod validation: drizzle .limit(NaN)/
+    // negative behavior is driver-dependent and can silently return 0 or all rows.
+    if (
+      !Number.isInteger(projectLimit) ||
+      projectLimit < PROJECT_LIMIT_MIN ||
+      projectLimit > PROJECT_LIMIT_MAX
+    ) {
+      throw new ValidationError(
+        `project_limit must be an integer between ${PROJECT_LIMIT_MIN} and ${PROJECT_LIMIT_MAX}`,
+      );
+    }
 
     // D-34: Auto-create workspace
     await this.workspaceRepo.findOrCreate(workspaceId);
@@ -880,14 +897,23 @@ export class MemoryService {
       result = { data: scored, meta: { count: scored.length, timing } };
     }
 
-    // Project-scoped memories (global instructions) served exclusively by
-    // listProjectScoped. Discard any that leaked in via search auto-include.
-    const nonProject = result.data.filter((m) => m.scope !== "project");
-
-    const projectMemories = await this.memoryRepo.listProjectScoped({
-      project_id: this.projectId,
-      limit: projectLimit,
-    });
+    // Project-scoped memories (global instructions) always included at
+    // session start, independent of ranked workspace/user results.
+    // Degrade gracefully on DB failure: surfacing ranked results beats
+    // aborting the whole session_start response.
+    let projectMemories: Memory[] = [];
+    try {
+      projectMemories = await this.memoryRepo.listProjectScoped({
+        project_id: this.projectId,
+        limit: projectLimit,
+      });
+    } catch (err) {
+      logger.error(
+        `listProjectScoped failed in sessionStart: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
     const projectScored: MemorySummaryWithRelevance[] = projectMemories.map(
       (m) => ({
         ...toSummary(m),
@@ -900,9 +926,21 @@ export class MemoryService {
       }),
     );
 
-    result.data = [...nonProject, ...projectScored];
-    result.data.sort((a, b) => b.relevance - a.relevance);
+    // Dedup by id so the invariant holds regardless of what the ranked path
+    // returns. Ranked path is expected to exclude scope="project" (search is
+    // called with ["workspace","user"] and listRecentBothScopes is narrowed
+    // to non-project scopes), but relying on that is brittle across refactors.
+    const merged = new Map<string, MemorySummaryWithRelevance>();
+    for (const m of result.data) merged.set(m.id, m);
+    for (const m of projectScored) merged.set(m.id, m);
+
+    result.data = [...merged.values()].sort(
+      (a, b) => b.relevance - a.relevance,
+    );
     result.meta.count = result.data.length;
+    if (projectMemories.length >= projectLimit) {
+      result.meta.project_truncated = true;
+    }
 
     // D-29: Add team_activity counts to meta
     let teamActivity:

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -880,26 +880,16 @@ export class MemoryService {
       result = { data: scored, meta: { count: scored.length, timing } };
     }
 
-    // Always include project-scoped memories (global instructions) up to projectLimit.
-    // Ranked query above may already include some (via listRecentBothScopes / search
-    // auto-include); union, dedupe, and cap the project portion.
+    // Project-scoped memories (global instructions) served exclusively by
+    // listProjectScoped. Discard any that leaked in via search auto-include.
     const nonProject = result.data.filter((m) => m.scope !== "project");
-    const rankedProject = result.data.filter((m) => m.scope === "project");
-    const rankedProjectIds = new Set(rankedProject.map((m) => m.id));
 
-    const slotsLeft = Math.max(0, projectLimit - rankedProject.length);
-    const extraProjectMemories =
-      slotsLeft > 0
-        ? await this.memoryRepo.listProjectScoped({
-            project_id: this.projectId,
-            limit: projectLimit,
-          })
-        : [];
-
-    const extraScored: MemorySummaryWithRelevance[] = extraProjectMemories
-      .filter((m) => !rankedProjectIds.has(m.id))
-      .slice(0, slotsLeft)
-      .map((m) => ({
+    const projectMemories = await this.memoryRepo.listProjectScoped({
+      project_id: this.projectId,
+      limit: projectLimit,
+    });
+    const projectScored: MemorySummaryWithRelevance[] = projectMemories.map(
+      (m) => ({
         ...toSummary(m),
         relevance: computeRelevance(
           1.0,
@@ -907,10 +897,10 @@ export class MemoryService {
           m.verified_at,
           config.recencyHalfLifeDays,
         ),
-      }));
+      }),
+    );
 
-    const cappedRankedProject = rankedProject.slice(0, projectLimit);
-    result.data = [...nonProject, ...cappedRankedProject, ...extraScored];
+    result.data = [...nonProject, ...projectScored];
     result.data.sort((a, b) => b.relevance - a.relevance);
     result.meta.count = result.data.length;
 

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -809,6 +809,7 @@ export class MemoryService {
     userId: string,
     context?: string,
     limit: number = 10,
+    projectLimit: number = 50,
   ): Promise<Envelope<MemorySummaryWithRelevance[]>> {
     const start = Date.now();
 
@@ -878,6 +879,40 @@ export class MemoryService {
       const timing = Date.now() - start;
       result = { data: scored, meta: { count: scored.length, timing } };
     }
+
+    // Always include project-scoped memories (global instructions) up to projectLimit.
+    // Ranked query above may already include some (via listRecentBothScopes / search
+    // auto-include); union, dedupe, and cap the project portion.
+    const nonProject = result.data.filter((m) => m.scope !== "project");
+    const rankedProject = result.data.filter((m) => m.scope === "project");
+    const rankedProjectIds = new Set(rankedProject.map((m) => m.id));
+
+    const slotsLeft = Math.max(0, projectLimit - rankedProject.length);
+    const extraProjectMemories =
+      slotsLeft > 0
+        ? await this.memoryRepo.listProjectScoped({
+            project_id: this.projectId,
+            limit: projectLimit,
+          })
+        : [];
+
+    const extraScored: MemorySummaryWithRelevance[] = extraProjectMemories
+      .filter((m) => !rankedProjectIds.has(m.id))
+      .slice(0, slotsLeft)
+      .map((m) => ({
+        ...toSummary(m),
+        relevance: computeRelevance(
+          1.0,
+          m.created_at,
+          m.verified_at,
+          config.recencyHalfLifeDays,
+        ),
+      }));
+
+    const cappedRankedProject = rankedProject.slice(0, projectLimit);
+    result.data = [...nonProject, ...cappedRankedProject, ...extraScored];
+    result.data.sort((a, b) => b.relevance - a.relevance);
+    result.meta.count = result.data.length;
 
     // D-29: Add team_activity counts to meta
     let teamActivity:

--- a/src/tools/memory-session-start.ts
+++ b/src/tools/memory-session-start.ts
@@ -12,7 +12,7 @@ export function registerMemorySessionStart(
     "memory_session_start",
     {
       description:
-        "Load relevant memories at session start. Searches both project and user scopes. " +
+        "Load relevant memories at session start. Searches workspace + user scopes (ranked) and always includes all project-scoped (global) memories. " +
         "user_id is required -- use your OS username in lowercase (run 'whoami' and convert to lowercase if needed). " +
         "Provide context for relevance-ranked results, or omit for recent memories. " +
         'Example: memory_session_start({ workspace_id: "my-project", user_id: "alice" })',
@@ -33,7 +33,18 @@ export function registerMemorySessionStart(
           .min(1)
           .max(50)
           .default(10)
-          .describe("Max memories to return (default 10)"),
+          .describe(
+            "Max workspace/user memories to return (default 10). Project-scoped memories are always included in addition, bounded by project_limit.",
+          ),
+        project_limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(200)
+          .default(50)
+          .describe(
+            "Max project-scoped (global) memories to always include (default 50)",
+          ),
       },
     },
     async (params) => {
@@ -43,6 +54,7 @@ export function registerMemorySessionStart(
           params.user_id,
           params.context,
           params.limit,
+          params.project_limit,
         );
         return toolResponse(result);
       });

--- a/src/tools/memory-session-start.ts
+++ b/src/tools/memory-session-start.ts
@@ -2,6 +2,11 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { MemoryService } from "../services/memory-service.js";
 import { slugSchema, userIdSchema } from "../utils/validation.js";
+import {
+  PROJECT_LIMIT_MIN,
+  PROJECT_LIMIT_MAX,
+  PROJECT_LIMIT_DEFAULT,
+} from "../utils/session-limits.js";
 import { toolResponse, withErrorHandling } from "./tool-utils.js";
 
 export function registerMemorySessionStart(
@@ -39,11 +44,11 @@ export function registerMemorySessionStart(
         project_limit: z
           .number()
           .int()
-          .min(1)
-          .max(200)
-          .default(50)
+          .min(PROJECT_LIMIT_MIN)
+          .max(PROJECT_LIMIT_MAX)
+          .default(PROJECT_LIMIT_DEFAULT)
           .describe(
-            "Max project-scoped (global) memories to always include (default 50)",
+            `Max project-scoped (global) memories to always include (default ${PROJECT_LIMIT_DEFAULT})`,
           ),
       },
     },

--- a/src/tools/memory-session-start.ts
+++ b/src/tools/memory-session-start.ts
@@ -34,7 +34,7 @@ export function registerMemorySessionStart(
           .max(50)
           .default(10)
           .describe(
-            "Max workspace/user memories to return (default 10). Project-scoped memories are always included in addition, bounded by project_limit.",
+            "Max workspace/user-scoped memories to return (default 10). Project-scoped memories are returned separately, bounded by project_limit. Total response may contain up to limit + project_limit memories.",
           ),
         project_limit: z
           .number()

--- a/src/types/envelope.ts
+++ b/src/types/envelope.ts
@@ -27,5 +27,6 @@ export interface Envelope<T> {
     flags?: FlagResponse[];
     relationships?: RelationshipSummary[];
     omitted?: string[]; // IDs requested but not returned (inaccessible/not found)
+    project_truncated?: boolean; // session_start only: true when project-scoped memories hit project_limit
   };
 }

--- a/src/utils/session-limits.ts
+++ b/src/utils/session-limits.ts
@@ -1,0 +1,7 @@
+// Centralized bounds for memory_session_start limit parameters.
+// Referenced by Zod schemas (MCP tool + HTTP route) and the service default
+// so the three sites cannot drift.
+
+export const PROJECT_LIMIT_MIN = 1;
+export const PROJECT_LIMIT_MAX = 200;
+export const PROJECT_LIMIT_DEFAULT = 50;

--- a/tests/integration/consolidation.test.ts
+++ b/tests/integration/consolidation.test.ts
@@ -94,6 +94,7 @@ describe("consolidation repository support", () => {
       scope: "user",
     });
     assertMemory(userMem.data);
+    const mem = userMem.data;
 
     const dups = await memoryRepo.findDuplicates({
       embedding: new Array(768).fill(0),
@@ -104,7 +105,7 @@ describe("consolidation repository support", () => {
       threshold: 0,
     });
 
-    expect(dups.find((d) => d.id === userMem.data.id)).toBeUndefined();
+    expect(dups.find((d) => d.id === mem.id)).toBeUndefined();
   });
 
   it("lists memories with embeddings for a workspace", async () => {

--- a/tests/integration/memory-scoping.test.ts
+++ b/tests/integration/memory-scoping.test.ts
@@ -127,11 +127,12 @@ describe("Memory scoping integration tests", () => {
     });
     assertMemory(result.data);
 
-    // Search from a different workspace should find it
+    // Search from a different workspace with project scope requested
+    // returns the cross-workspace memory.
     const searchResult = await service.search(
       "ESM imports",
       "workspace-b",
-      ["workspace"],
+      ["workspace", "project"],
       "bob",
       undefined,
       -1,
@@ -140,6 +141,30 @@ describe("Memory scoping integration tests", () => {
     const found = searchResult.data.find((m) => m.scope === "project");
     expect(found).toBeDefined();
     expect(found!.content).toContain("ESM imports");
+  });
+
+  it("search without project scope excludes project-scoped memories", async () => {
+    await service.create({
+      workspace_id: "workspace-a",
+      content: "Project-scoped only memory that must stay out",
+      type: "decision",
+      scope: "project",
+      author: "alice",
+      source: "manual",
+    });
+
+    const searchResult = await service.search(
+      "project scoped only",
+      "workspace-b",
+      ["workspace"],
+      "bob",
+      undefined,
+      -1,
+    );
+
+    expect(
+      searchResult.data.find((m) => m.scope === "project"),
+    ).toBeUndefined();
   });
 
   it("project-scoped memory cannot be created by agent-auto", async () => {
@@ -181,7 +206,7 @@ describe("Memory scoping integration tests", () => {
     expect(result.data.scope).toBe("project");
   });
 
-  it("search scope array includes project-scoped memories", async () => {
+  it("search scope array returns only explicitly requested scopes", async () => {
     // Create workspace-scoped memory
     await service.create({
       workspace_id: "test-project",
@@ -208,6 +233,8 @@ describe("Memory scoping integration tests", () => {
       source: "manual",
     });
 
+    // Requesting only workspace + user scopes returns those scopes literally;
+    // project-scoped memories are excluded unless explicitly requested.
     const result = await service.search(
       "configuration patterns",
       "test-project",
@@ -220,7 +247,19 @@ describe("Memory scoping integration tests", () => {
     const scopes = result.data.map((m) => m.scope);
     expect(scopes).toContain("workspace");
     expect(scopes).toContain("user");
-    expect(scopes).toContain("project");
+    expect(scopes).not.toContain("project");
+
+    // With project scope explicitly requested, it is returned
+    const resultWithProject = await service.search(
+      "configuration patterns",
+      "test-project",
+      ["workspace", "user", "project"],
+      "alice",
+      undefined,
+      -1,
+    );
+    const scopesWithProject = resultWithProject.data.map((m) => m.scope);
+    expect(scopesWithProject).toContain("project");
   });
 
   it("default scope is workspace when not specified", async () => {

--- a/tests/integration/session-start.test.ts
+++ b/tests/integration/session-start.test.ts
@@ -163,6 +163,67 @@ describe("memory_session_start integration tests", () => {
     expect(found).toBeUndefined();
   });
 
+  it("always includes project-scoped memories beyond ranked limit", async () => {
+    // Two project-scoped "global instructions"
+    await service.create({
+      content: "Global instruction: never commit secrets",
+      type: "decision",
+      scope: "project",
+      author: "alice",
+    });
+    await service.create({
+      content: "Global instruction: always run migrations before deploy",
+      type: "decision",
+      scope: "project",
+      author: "alice",
+    });
+
+    // Fill workspace with more memories than the ranked limit
+    for (let i = 1; i <= 5; i++) {
+      await service.create({
+        workspace_id: "test-project",
+        content: `Workspace memory number ${i}`,
+        type: "fact",
+        author: "alice",
+      });
+    }
+
+    // limit=2 on ranked portion; project memories must still be present
+    const result = await service.sessionStart(
+      "test-project",
+      "alice",
+      undefined,
+      2,
+    );
+
+    const projectScoped = result.data.filter((m) => m.scope === "project");
+    expect(projectScoped.length).toBe(2);
+    // Total = 2 workspace (ranked) + 2 project (always included)
+    expect(result.data.length).toBe(4);
+  });
+
+  it("project_limit caps project-scoped memories", async () => {
+    for (let i = 1; i <= 5; i++) {
+      await service.create({
+        content: `Global instruction number ${i}`,
+        type: "decision",
+        scope: "project",
+        author: "alice",
+      });
+    }
+
+    const result = await service.sessionStart(
+      "test-project",
+      "alice",
+      undefined,
+      10,
+      3,
+    );
+
+    const projectScoped = result.data.filter((m) => m.scope === "project");
+    expect(projectScoped.length).toBe(3);
+  });
+
   it("response envelope has count and timing (D-18)", async () => {
     await service.create({
       workspace_id: "test-project",

--- a/tests/integration/session-start.test.ts
+++ b/tests/integration/session-start.test.ts
@@ -1,11 +1,15 @@
 import { describe, it, expect, beforeEach, afterAll } from "vitest";
 import {
   createTestService,
+  getTestDb,
   truncateAll,
   closeDb,
   assertMemory,
 } from "../helpers.js";
 import type { MemoryService } from "../../src/services/memory-service.js";
+import { ValidationError } from "../../src/utils/errors.js";
+import { memories } from "../../src/db/schema.js";
+import { config } from "../../src/config.js";
 
 describe("memory_session_start integration tests", () => {
   let service: MemoryService;
@@ -227,6 +231,46 @@ describe("memory_session_start integration tests", () => {
     expect(projectScoped.length).toBe(3);
   });
 
+  it("context search fills ranked limit with workspace/user only, project memories added on top", async () => {
+    // 5 workspace memories — ranked pool should not be displaced by project
+    for (let i = 1; i <= 5; i++) {
+      await service.create({
+        workspace_id: "test-project",
+        content: `Workspace memory about databases number ${i}`,
+        type: "fact",
+        author: "alice",
+      });
+    }
+    // 2 project-scoped memories
+    await service.create({
+      content: "Global instruction about databases one",
+      type: "decision",
+      scope: "project",
+      author: "alice",
+    });
+    await service.create({
+      content: "Global instruction about databases two",
+      type: "decision",
+      scope: "project",
+      author: "alice",
+    });
+
+    const result = await service.sessionStart(
+      "test-project",
+      "alice",
+      "databases",
+      3,
+    );
+
+    const workspaceScoped = result.data.filter((m) => m.scope === "workspace");
+    const projectScoped = result.data.filter((m) => m.scope === "project");
+    // Ranked limit=3 fully populated by workspace memories (not displaced)
+    expect(workspaceScoped.length).toBe(3);
+    // Both project memories added on top of ranked results
+    expect(projectScoped.length).toBe(2);
+    expect(result.data.length).toBe(5);
+  });
+
   it("includes project-scoped memories with context search", async () => {
     await service.create({
       content: "Global instruction: always use parameterized queries",
@@ -276,6 +320,158 @@ describe("memory_session_start integration tests", () => {
 
     const ids = result.data.map((m) => m.id);
     expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("excludes archived project-scoped memories", async () => {
+    const { data: created } = await service.create({
+      content: "Archived global instruction",
+      type: "decision",
+      scope: "project",
+      author: "alice",
+    });
+    assertMemory(created);
+    await service.archive(created.id, "alice");
+
+    const result = await service.sessionStart("test-project", "alice");
+
+    expect(result.data.find((m) => m.id === created.id)).toBeUndefined();
+  });
+
+  it("behaves identically when no project-scoped memories exist", async () => {
+    await service.create({
+      workspace_id: "test-project",
+      content: "Workspace-only memory",
+      type: "fact",
+      author: "alice",
+    });
+
+    const result = await service.sessionStart("test-project", "alice");
+
+    expect(result.data.length).toBe(1);
+    expect(result.data[0].scope).toBe("workspace");
+    expect(result.meta.project_truncated).toBeUndefined();
+  });
+
+  it("project memories ordered by recency when project_limit truncates", async () => {
+    const created: string[] = [];
+    for (let i = 1; i <= 5; i++) {
+      const { data } = await service.create({
+        content: `Project memory ${i}`,
+        type: "decision",
+        scope: "project",
+        author: "alice",
+      });
+      assertMemory(data);
+      created.push(data.id);
+      // Ensure deterministic creation order for the recency assertion
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    const result = await service.sessionStart(
+      "test-project",
+      "alice",
+      undefined,
+      10,
+      2,
+    );
+
+    const projectIds = result.data
+      .filter((m) => m.scope === "project")
+      .map((m) => m.id);
+    expect(projectIds).toHaveLength(2);
+    // Newest two (last two created) must be the ones returned
+    expect(new Set(projectIds)).toEqual(new Set(created.slice(-2)));
+  });
+
+  it("sets meta.project_truncated when project memory count hits project_limit", async () => {
+    for (let i = 1; i <= 3; i++) {
+      await service.create({
+        content: `Global instruction ${i}`,
+        type: "decision",
+        scope: "project",
+        author: "alice",
+      });
+    }
+
+    const result = await service.sessionStart(
+      "test-project",
+      "alice",
+      undefined,
+      10,
+      3,
+    );
+
+    expect(result.meta.project_truncated).toBe(true);
+  });
+
+  it("does not set project_truncated when under project_limit", async () => {
+    await service.create({
+      content: "Single project memory",
+      type: "decision",
+      scope: "project",
+      author: "alice",
+    });
+
+    const result = await service.sessionStart(
+      "test-project",
+      "alice",
+      undefined,
+      10,
+      5,
+    );
+
+    expect(result.meta.project_truncated).toBeUndefined();
+  });
+
+  it("rejects invalid project_limit at service entry", async () => {
+    await expect(
+      service.sessionStart("test-project", "alice", undefined, 10, 0),
+    ).rejects.toBeInstanceOf(ValidationError);
+    await expect(
+      service.sessionStart("test-project", "alice", undefined, 10, 201),
+    ).rejects.toBeInstanceOf(ValidationError);
+    await expect(
+      service.sessionStart("test-project", "alice", undefined, 10, 1.5),
+    ).rejects.toBeInstanceOf(ValidationError);
+    await expect(
+      service.sessionStart("test-project", "alice", undefined, 10, Number.NaN),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it("listProjectScoped isolates memories by project_id", async () => {
+    // Create one project memory under test-project via the standard service
+    // fixture (project_id="test-project").
+    await service.create({
+      content: "Test-project global instruction",
+      type: "decision",
+      scope: "project",
+      author: "alice",
+    });
+    // Direct-insert a project memory under a different project_id. This
+    // regression-guards that listProjectScoped filters on project_id.
+    await getTestDb()
+      .insert(memories)
+      .values({
+        id: "m-other-project-test",
+        project_id: "other-project",
+        workspace_id: null,
+        content: "Other-project global instruction",
+        title: "Other-project global instruction",
+        type: "decision",
+        scope: "project",
+        tags: [],
+        author: "alice",
+        source: "manual",
+        metadata: {},
+        embedding: new Array(config.embeddingDimensions).fill(0),
+        version: 1,
+      });
+
+    const result = await service.sessionStart("test-project", "alice");
+
+    const projectRows = result.data.filter((m) => m.scope === "project");
+    expect(projectRows).toHaveLength(1);
+    expect(projectRows[0].content).toContain("Test-project");
   });
 
   it("response envelope has count and timing (D-18)", async () => {

--- a/tests/integration/session-start.test.ts
+++ b/tests/integration/session-start.test.ts
@@ -224,6 +224,27 @@ describe("memory_session_start integration tests", () => {
     expect(projectScoped.length).toBe(3);
   });
 
+  it("no duplicate memories in response", async () => {
+    // Create project + workspace memories
+    await service.create({
+      content: "Global instruction for dedup test",
+      type: "decision",
+      scope: "project",
+      author: "alice",
+    });
+    await service.create({
+      workspace_id: "test-project",
+      content: "Workspace memory for dedup test",
+      type: "fact",
+      author: "alice",
+    });
+
+    const result = await service.sessionStart("test-project", "alice");
+
+    const ids = result.data.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
   it("response envelope has count and timing (D-18)", async () => {
     await service.create({
       workspace_id: "test-project",

--- a/tests/integration/session-start.test.ts
+++ b/tests/integration/session-start.test.ts
@@ -200,6 +200,9 @@ describe("memory_session_start integration tests", () => {
     expect(projectScoped.length).toBe(2);
     // Total = 2 workspace (ranked) + 2 project (always included)
     expect(result.data.length).toBe(4);
+    // No duplicate IDs
+    const ids = result.data.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
   });
 
   it("project_limit caps project-scoped memories", async () => {
@@ -222,6 +225,36 @@ describe("memory_session_start integration tests", () => {
 
     const projectScoped = result.data.filter((m) => m.scope === "project");
     expect(projectScoped.length).toBe(3);
+  });
+
+  it("includes project-scoped memories with context search", async () => {
+    await service.create({
+      content: "Global instruction: always use parameterized queries",
+      type: "decision",
+      scope: "project",
+      author: "alice",
+    });
+    await service.create({
+      workspace_id: "test-project",
+      content: "PostgreSQL parameterized query patterns for security",
+      type: "fact",
+      scope: "workspace",
+      author: "alice",
+    });
+
+    const result = await service.sessionStart(
+      "test-project",
+      "alice",
+      "database security",
+    );
+
+    const projectScoped = result.data.filter((m) => m.scope === "project");
+    expect(projectScoped.length).toBe(1);
+    // Workspace memory also present from semantic search
+    expect(result.data.length).toBeGreaterThanOrEqual(2);
+    // No duplicates
+    const ids = result.data.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
   });
 
   it("no duplicate memories in response", async () => {


### PR DESCRIPTION
## Summary

Always load project-scoped memories (global instructions) at session start, independent of the ranked workspace/user search.

## Design

- **`listProjectScoped` is the sole source of project-scoped memories** at session start. Repository `search` and `list` no longer auto-include project scope — callers must request it explicitly in the scope array. This removes the ranked-limit displacement that previously caused context searches to return fewer than `limit` workspace/user memories.
- **`sessionStart` merges via Map-by-id dedup** so the invariant holds regardless of what the ranked path returns. Defensive against future ranked-path changes.
- **`project_limit` param** (min 1, max 200, default 50) caps the project-scoped portion; validated at the service entry so non-MCP callers can't bypass.
- **`meta.project_truncated`** flags when the cap is hit, so agents know global instructions were dropped.
- **Graceful degrade**: `listProjectScoped` DB errors are logged and produce an empty project list instead of aborting the whole `session_start` response.
- **Centralized bounds** (`src/utils/session-limits.ts`) shared between MCP tool schema, HTTP schema, and service default.

## Test plan

- [x] `npm test` — 284/284 passing
- [x] `npm run typecheck` — clean
- [x] Project memories always present beyond ranked `limit`
- [x] `project_limit` caps project-scoped memories
- [x] Context search does not displace ranked `limit` slots
- [x] Dedup invariant (no duplicate IDs)
- [x] Cross-project isolation: `project_id` filter enforced
- [x] Archived project-scoped memories excluded
- [x] Zero-project-memories baseline unchanged
- [x] Project memories ordered by recency under truncation
- [x] `meta.project_truncated` set at limit, unset below
- [x] Invalid `projectLimit` rejected at service entry (ValidationError)

🤖 Generated with [Claude Code](https://claude.com/claude-code)