### PR TITLE
feat(scheduler): catch-up run on startup when last tick missed

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,24 +439,26 @@ src/
 
 ## Configuration reference
 
-| Variable                               | Default                                                   | Description                                                              |
-| -------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `PROJECT_ID`                           | —                                                         | **Required.** Deployment-level project identifier (1 server = 1 project) |
-| `DATABASE_URL`                         | `postgresql://agentic:agentic@localhost:5432/agent_brain` | Postgres connection string                                               |
-| `EMBEDDING_PROVIDER`                   | `mock`                                                    | `mock`, `ollama`, or `titan`                                             |
-| `AWS_REGION`                           | `us-east-1`                                               | AWS region for Bedrock                                                   |
-| `WRITE_BUDGET_PER_SESSION`             | `10`                                                      | Max memories an agent can create per session                             |
-| `DUPLICATE_THRESHOLD`                  | `0.90`                                                    | Cosine similarity above which a new memory is rejected as duplicate      |
-| `RECENCY_HALF_LIFE_DAYS`               | `14`                                                      | Half-life for recency score decay in search ranking                      |
-| `EMBEDDING_DIMENSIONS`                 | `768`                                                     | Vector dimensions (512 for Titan, 768 for nomic-embed-text)              |
-| `OLLAMA_BASE_URL`                      | `http://localhost:11434`                                  | Ollama API endpoint                                                      |
-| `OLLAMA_MODEL`                         | `nomic-embed-text`                                        | Ollama model for embeddings                                              |
-| `HOST`                                 | `127.0.0.1`                                               | Server bind address                                                      |
-| `PORT`                                 | `19898`                                                   | Server port                                                              |
-| `EMBEDDING_TIMEOUT_MS`                 | `10000`                                                   | Timeout for embedding API calls                                          |
-| `CONSOLIDATION_ENABLED`                | `false`                                                   | Enable the scheduled consolidation job                                   |
-| `CONSOLIDATION_CRON`                   | `0 3 * * *`                                               | Cron schedule for consolidation (default: 3 AM daily)                    |
-| `CONSOLIDATION_AUTO_ARCHIVE_THRESHOLD` | `0.95`                                                    | Similarity above which duplicates are auto-archived                      |
-| `CONSOLIDATION_FLAG_THRESHOLD`         | `0.90`                                                    | Similarity above which pairs are flagged as probable duplicates          |
-| `CONSOLIDATION_VERIFY_AFTER_DAYS`      | `30`                                                      | Days without verification before a memory is flagged for review          |
-| `CONSOLIDATION_MAX_FLAGS_PER_SESSION`  | `5`                                                       | Max flags surfaced to agents per session start                           |
+| Variable                               | Default                                                   | Description                                                                   |
+| -------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| `PROJECT_ID`                           | —                                                         | **Required.** Deployment-level project identifier (1 server = 1 project)      |
+| `DATABASE_URL`                         | `postgresql://agentic:agentic@localhost:5432/agent_brain` | Postgres connection string                                                    |
+| `EMBEDDING_PROVIDER`                   | `mock`                                                    | `mock`, `ollama`, or `titan`                                                  |
+| `AWS_REGION`                           | `us-east-1`                                               | AWS region for Bedrock                                                        |
+| `WRITE_BUDGET_PER_SESSION`             | `10`                                                      | Max memories an agent can create per session                                  |
+| `DUPLICATE_THRESHOLD`                  | `0.90`                                                    | Cosine similarity above which a new memory is rejected as duplicate           |
+| `RECENCY_HALF_LIFE_DAYS`               | `14`                                                      | Half-life for recency score decay in search ranking                           |
+| `EMBEDDING_DIMENSIONS`                 | `768`                                                     | Vector dimensions (512 for Titan, 768 for nomic-embed-text)                   |
+| `OLLAMA_BASE_URL`                      | `http://localhost:11434`                                  | Ollama API endpoint                                                           |
+| `OLLAMA_MODEL`                         | `nomic-embed-text`                                        | Ollama model for embeddings                                                   |
+| `HOST`                                 | `127.0.0.1`                                               | Server bind address                                                           |
+| `PORT`                                 | `19898`                                                   | Server port                                                                   |
+| `EMBEDDING_TIMEOUT_MS`                 | `10000`                                                   | Timeout for embedding API calls                                               |
+| `CONSOLIDATION_ENABLED`                | `false`                                                   | Enable the scheduled consolidation job                                        |
+| `CONSOLIDATION_CRON`                   | `0 3 * * *`                                               | Cron schedule for consolidation (default: 3 AM daily)                         |
+| `CONSOLIDATION_AUTO_ARCHIVE_THRESHOLD` | `0.95`                                                    | Similarity above which duplicates are auto-archived                           |
+| `CONSOLIDATION_FLAG_THRESHOLD`         | `0.90`                                                    | Similarity above which pairs are flagged as probable duplicates               |
+| `CONSOLIDATION_VERIFY_AFTER_DAYS`      | `30`                                                      | Days without verification before a memory is flagged for review               |
+| `CONSOLIDATION_MAX_FLAGS_PER_SESSION`  | `5`                                                       | Max flags surfaced to agents per session start                                |
+| `CONSOLIDATION_CATCHUP_ENABLED`        | `true`                                                    | Run a catch-up consolidation at startup if the last scheduled tick was missed |
+| `CONSOLIDATION_CATCHUP_GRACE_SECONDS`  | `60`                                                      | Grace window (seconds) applied to `last_run` when deciding on catch-up        |

--- a/docs/superpowers/plans/2026-04-20-scheduler-startup-catchup.md
+++ b/docs/superpowers/plans/2026-04-20-scheduler-startup-catchup.md
@@ -1,0 +1,753 @@
+# Scheduler Startup Catch-Up Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When the MCP server starts, run the consolidation job immediately if the last scheduled tick was missed (e.g. server was down during the cron time).
+
+**Architecture:** Persist `last_run` per scheduler job in a new small `scheduler_state` DB table. On `ConsolidationScheduler.start()`, compute the most recent cron tick using `cron-parser`, compare with the stored `last_run`, and fire a catch-up execution if the stored value is older than that tick. Update `last_run` inside `ConsolidationJob.execute()` after a successful run (under the same advisory lock that already guards concurrency). Add a configurable grace threshold so a restart just after a successful run does not re-trigger, and so a very long outage does not spam: at most **one** catch-up per startup.
+
+**Tech Stack:** TypeScript, Drizzle ORM, PostgreSQL, node-cron v4, `cron-parser` (new dep), Vitest.
+
+---
+
+## File Structure
+
+- **Create**
+  - `drizzle/0011_scheduler_state.sql` — migration adding `scheduler_state` table.
+  - `src/repositories/scheduler-state-repository.ts` — Drizzle implementation of the repo interface.
+  - `tests/unit/scheduler/catchup.test.ts` — unit tests for catch-up decision logic.
+  - `tests/integration/scheduler-catchup.test.ts` — integration test against real Postgres + real job.
+
+- **Modify**
+  - `src/db/schema.ts` — add `schedulerState` table definition.
+  - `src/repositories/types.ts` — add `SchedulerStateRepository` interface.
+  - `src/scheduler/consolidation-job.ts` — accept repo, update `last_run` after successful run, expose `jobName` constant.
+  - `src/scheduler/consolidation-scheduler.ts` — run catch-up check in `start()`.
+  - `src/server.ts` — wire new repo into `ConsolidationJob`.
+  - `src/config.ts` — add `CONSOLIDATION_CATCHUP_ENABLED` (default true) and `CONSOLIDATION_CATCHUP_GRACE_SECONDS` (default 60).
+  - `package.json` — add `cron-parser` dep.
+
+---
+
+## Task 1: Add `cron-parser` dependency
+
+**Files:**
+
+- Modify: `package.json`
+
+- [ ] **Step 1: Install**
+
+```bash
+npm install cron-parser@^4.9.0
+```
+
+- [ ] **Step 2: Verify typecheck still clean**
+
+Run: `npm run typecheck`
+Expected: exit 0, no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore: add cron-parser for prev-tick calculation"
+```
+
+---
+
+## Task 2: Add `scheduler_state` table — schema + migration
+
+**Files:**
+
+- Modify: `src/db/schema.ts`
+- Create: `drizzle/0011_scheduler_state.sql`
+
+- [ ] **Step 1: Add table to schema**
+
+Append to `src/db/schema.ts` (after the `workspaces` table block, before `memories`):
+
+```ts
+export const schedulerState = pgTable("scheduler_state", {
+  job_name: text("job_name").primaryKey(),
+  last_run_at: timestamp("last_run_at", { withTimezone: true }).notNull(),
+  updated_at: timestamp("updated_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+```
+
+- [ ] **Step 2: Generate migration**
+
+Run: `npm run db:generate`
+Expected: a new file `drizzle/0011_*.sql` is created.
+
+- [ ] **Step 3: Rename generated migration to stable name**
+
+```bash
+mv drizzle/0011_*.sql drizzle/0011_scheduler_state.sql
+```
+
+Update `drizzle/meta/_journal.json` tag field of the new entry to `"0011_scheduler_state"` if the generator set something else.
+
+- [ ] **Step 4: Verify migration content**
+
+Read `drizzle/0011_scheduler_state.sql`. Expected content (approximate):
+
+```sql
+CREATE TABLE "scheduler_state" (
+	"job_name" text PRIMARY KEY NOT NULL,
+	"last_run_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+```
+
+- [ ] **Step 5: Apply migration locally**
+
+Run: `docker compose up -d --wait && npm run db:migrate`
+Expected: migration applied, no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/db/schema.ts drizzle/0011_scheduler_state.sql drizzle/meta/_journal.json drizzle/meta/0011_snapshot.json
+git commit -m "feat(db): add scheduler_state table for per-job last_run tracking"
+```
+
+---
+
+## Task 3: Add `SchedulerStateRepository` interface
+
+**Files:**
+
+- Modify: `src/repositories/types.ts`
+
+- [ ] **Step 1: Append interface**
+
+Add at the bottom of `src/repositories/types.ts`:
+
+```ts
+export interface SchedulerStateRepository {
+  getLastRun(jobName: string): Promise<Date | null>;
+  recordRun(jobName: string, runAt: Date): Promise<void>;
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/repositories/types.ts
+git commit -m "feat(repo): add SchedulerStateRepository interface"
+```
+
+---
+
+## Task 4: Implement `DrizzleSchedulerStateRepository`
+
+**Files:**
+
+- Create: `src/repositories/scheduler-state-repository.ts`
+- Test: `tests/integration/scheduler-catchup.test.ts` (partial — add repo-level coverage here)
+
+- [ ] **Step 1: Write failing integration test for repo**
+
+Create `tests/integration/scheduler-catchup.test.ts`:
+
+```ts
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { setupTestDb, teardownTestDb, resetDb } from "../helpers.js";
+import type { Database } from "../../src/db/index.js";
+import { DrizzleSchedulerStateRepository } from "../../src/repositories/scheduler-state-repository.js";
+
+describe("DrizzleSchedulerStateRepository", () => {
+  let db: Database;
+  let repo: DrizzleSchedulerStateRepository;
+
+  beforeAll(async () => {
+    db = await setupTestDb();
+  });
+
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+
+  beforeEach(async () => {
+    await resetDb();
+    repo = new DrizzleSchedulerStateRepository(db);
+  });
+
+  it("returns null for unknown job", async () => {
+    const result = await repo.getLastRun("nonexistent");
+    expect(result).toBeNull();
+  });
+
+  it("records run and reads it back", async () => {
+    const when = new Date("2026-04-20T10:00:00Z");
+    await repo.recordRun("consolidation", when);
+    const result = await repo.getLastRun("consolidation");
+    expect(result?.toISOString()).toBe(when.toISOString());
+  });
+
+  it("overwrites existing run on repeat call", async () => {
+    const t1 = new Date("2026-04-20T10:00:00Z");
+    const t2 = new Date("2026-04-21T10:00:00Z");
+    await repo.recordRun("consolidation", t1);
+    await repo.recordRun("consolidation", t2);
+    const result = await repo.getLastRun("consolidation");
+    expect(result?.toISOString()).toBe(t2.toISOString());
+  });
+});
+```
+
+Note: use whatever helpers `tests/helpers.ts` actually exports. If names differ (`setupTestDb`/`resetDb`/`teardownTestDb`), adapt to the real helper names found at the top of existing files in `tests/integration/`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/integration/scheduler-catchup.test.ts`
+Expected: FAIL — module `scheduler-state-repository` not found.
+
+- [ ] **Step 3: Implement repository**
+
+Create `src/repositories/scheduler-state-repository.ts`:
+
+```ts
+import { eq, sql } from "drizzle-orm";
+import type { Database } from "../db/index.js";
+import { schedulerState } from "../db/schema.js";
+import type { SchedulerStateRepository } from "./types.js";
+
+export class DrizzleSchedulerStateRepository implements SchedulerStateRepository {
+  constructor(private readonly db: Database) {}
+
+  async getLastRun(jobName: string): Promise<Date | null> {
+    const rows = await this.db
+      .select({ last_run_at: schedulerState.last_run_at })
+      .from(schedulerState)
+      .where(eq(schedulerState.job_name, jobName))
+      .limit(1);
+
+    return rows.length > 0 ? rows[0].last_run_at : null;
+  }
+
+  async recordRun(jobName: string, runAt: Date): Promise<void> {
+    await this.db
+      .insert(schedulerState)
+      .values({ job_name: jobName, last_run_at: runAt })
+      .onConflictDoUpdate({
+        target: schedulerState.job_name,
+        set: { last_run_at: runAt, updated_at: sql`now()` },
+      });
+  }
+}
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `npx vitest run tests/integration/scheduler-catchup.test.ts`
+Expected: 3 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/repositories/scheduler-state-repository.ts tests/integration/scheduler-catchup.test.ts
+git commit -m "feat(repo): implement DrizzleSchedulerStateRepository"
+```
+
+---
+
+## Task 5: Persist `last_run` inside `ConsolidationJob`
+
+**Files:**
+
+- Modify: `src/scheduler/consolidation-job.ts`
+
+- [ ] **Step 1: Add job-name constant and accept repo**
+
+Replace the top of `src/scheduler/consolidation-job.ts` (constructor + fields) with:
+
+```ts
+import { sql } from "drizzle-orm";
+import type { Database } from "../db/index.js";
+import type { ConsolidationService } from "../services/consolidation-service.js";
+import type { SchedulerStateRepository } from "../repositories/types.js";
+import { logger } from "../utils/logger.js";
+
+/** PostgreSQL advisory lock ID for consolidation job exclusivity across server instances */
+const CONSOLIDATION_LOCK_ID = 42001;
+
+export const CONSOLIDATION_JOB_NAME = "consolidation";
+
+export class ConsolidationJob {
+  private running = false;
+
+  constructor(
+    private readonly consolidationService: ConsolidationService,
+    private readonly db: Database,
+    private readonly schedulerStateRepo: SchedulerStateRepository,
+  ) {}
+
+  get isRunning(): boolean {
+    return this.running;
+  }
+```
+
+- [ ] **Step 2: Record run after success**
+
+In the `try` block of `execute()`, after the `logger.info(...)` that reports completion, append:
+
+```ts
+await this.schedulerStateRepo.recordRun(
+  CONSOLIDATION_JOB_NAME,
+  new Date(start),
+);
+```
+
+Record `start` (not `Date.now()`) so the timestamp corresponds to the scheduled tick, not to post-completion. This matters because a long-running job that completes well after the next scheduled tick should still register as having covered the earlier tick.
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck`
+Expected: fails at `src/server.ts` because wiring missing — that's expected and fixed in Task 7. Skip to next step.
+
+- [ ] **Step 4: Commit (deferred to Task 7 so build stays green per commit)**
+
+Do not commit yet. Move on to Task 6.
+
+---
+
+## Task 6: Add catch-up logic in `ConsolidationScheduler`
+
+**Files:**
+
+- Modify: `src/scheduler/consolidation-scheduler.ts`
+- Test: `tests/unit/scheduler/catchup.test.ts`
+
+- [ ] **Step 1: Create test dir**
+
+```bash
+mkdir -p tests/unit/scheduler
+```
+
+- [ ] **Step 2: Write failing unit test for catch-up decision**
+
+Extract the decision into a pure helper to keep it unit-testable. Create `tests/unit/scheduler/catchup.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { shouldCatchUp } from "../../../src/scheduler/consolidation-scheduler.js";
+
+describe("shouldCatchUp", () => {
+  const cronExpr = "0 3 * * *"; // 03:00 daily
+
+  it("returns true when last run is before previous tick", () => {
+    const now = new Date("2026-04-20T10:00:00Z");
+    const lastRun = new Date("2026-04-18T03:00:00Z");
+    expect(shouldCatchUp(cronExpr, lastRun, now, 60)).toBe(true);
+  });
+
+  it("returns false when last run is after previous tick", () => {
+    const now = new Date("2026-04-20T10:00:00Z");
+    const lastRun = new Date("2026-04-20T03:00:05Z");
+    expect(shouldCatchUp(cronExpr, lastRun, now, 60)).toBe(false);
+  });
+
+  it("returns true when last run is null (first-ever startup)", () => {
+    const now = new Date("2026-04-20T10:00:00Z");
+    expect(shouldCatchUp(cronExpr, null, now, 60)).toBe(true);
+  });
+
+  it("returns false when last run is within grace window before prev tick", () => {
+    // prev tick = 2026-04-20T03:00:00Z; grace 60s → skip if lastRun >= 02:59:00Z
+    const now = new Date("2026-04-20T10:00:00Z");
+    const lastRun = new Date("2026-04-20T02:59:30Z");
+    expect(shouldCatchUp(cronExpr, lastRun, now, 60)).toBe(false);
+  });
+
+  it("returns false for invalid cron expression", () => {
+    const now = new Date("2026-04-20T10:00:00Z");
+    expect(shouldCatchUp("not-a-cron", null, now, 60)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/scheduler/catchup.test.ts`
+Expected: FAIL — `shouldCatchUp` not exported.
+
+- [ ] **Step 4: Rewrite `consolidation-scheduler.ts`**
+
+Replace the full contents of `src/scheduler/consolidation-scheduler.ts` with:
+
+```ts
+import cron from "node-cron";
+import cronParser from "cron-parser";
+import type { ConsolidationJob } from "./consolidation-job.js";
+import { CONSOLIDATION_JOB_NAME } from "./consolidation-job.js";
+import type { SchedulerStateRepository } from "../repositories/types.js";
+import { logger } from "../utils/logger.js";
+
+export interface CatchUpOptions {
+  enabled: boolean;
+  graceSeconds: number;
+}
+
+/**
+ * Decide whether a catch-up run is needed.
+ *
+ * Why graceSeconds: protects against re-firing when the server restarts
+ * seconds after a successful run — clock skew / transactional commit ordering
+ * can make `lastRun` appear a hair before `prevTick`.
+ */
+export function shouldCatchUp(
+  cronExpression: string,
+  lastRun: Date | null,
+  now: Date,
+  graceSeconds: number,
+): boolean {
+  let prevTick: Date;
+  try {
+    const interval = cronParser.parseExpression(cronExpression, {
+      currentDate: now,
+    });
+    prevTick = interval.prev().toDate();
+  } catch {
+    return false;
+  }
+
+  if (lastRun === null) return true;
+
+  const graceMs = graceSeconds * 1000;
+  return lastRun.getTime() + graceMs < prevTick.getTime();
+}
+
+export class ConsolidationScheduler {
+  private task: cron.ScheduledTask | null = null;
+
+  constructor(
+    private readonly job: ConsolidationJob,
+    private readonly cronExpression: string,
+    private readonly schedulerStateRepo: SchedulerStateRepository,
+    private readonly catchUp: CatchUpOptions,
+  ) {}
+
+  async start(): Promise<void> {
+    if (!cron.validate(this.cronExpression)) {
+      logger.error(
+        `Invalid cron expression: ${this.cronExpression}, scheduler not started`,
+      );
+      return;
+    }
+
+    if (this.catchUp.enabled) {
+      await this.runCatchUpIfNeeded();
+    }
+
+    this.task = cron.schedule(this.cronExpression, () => {
+      this.job.execute().catch((error) => {
+        logger.error("Consolidation job invocation failed:", error);
+      });
+    });
+
+    logger.info(
+      `Consolidation scheduler started with cron: ${this.cronExpression}`,
+    );
+  }
+
+  private async runCatchUpIfNeeded(): Promise<void> {
+    try {
+      const lastRun = await this.schedulerStateRepo.getLastRun(
+        CONSOLIDATION_JOB_NAME,
+      );
+      const now = new Date();
+      if (
+        shouldCatchUp(
+          this.cronExpression,
+          lastRun,
+          now,
+          this.catchUp.graceSeconds,
+        )
+      ) {
+        logger.info(
+          `Consolidation catch-up triggered on startup (last_run=${
+            lastRun?.toISOString() ?? "never"
+          })`,
+        );
+        // Fire-and-forget: do not block server startup on job completion.
+        this.job.execute().catch((error) => {
+          logger.error("Consolidation catch-up failed:", error);
+        });
+      }
+    } catch (error) {
+      logger.error("Consolidation catch-up check failed:", error);
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.task) {
+      this.task.stop();
+      this.task = null;
+    }
+
+    if (this.job.isRunning) {
+      logger.info("Waiting for running consolidation job to finish...");
+      const maxWait = 60_000;
+      const start = Date.now();
+      while (this.job.isRunning && Date.now() - start < maxWait) {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+      if (this.job.isRunning) {
+        logger.warn("Consolidation job did not finish within timeout");
+      }
+    }
+
+    logger.info("Consolidation scheduler stopped");
+  }
+}
+```
+
+- [ ] **Step 5: Run unit test, verify pass**
+
+Run: `npx vitest run tests/unit/scheduler/catchup.test.ts`
+Expected: 5 tests pass.
+
+- [ ] **Step 6: Do not commit yet — wiring still missing**
+
+Proceed to Task 7.
+
+---
+
+## Task 7: Wire new repo and config, update `server.ts` + `config.ts`
+
+**Files:**
+
+- Modify: `src/config.ts`, `src/server.ts`
+
+- [ ] **Step 1: Extend config schema**
+
+In `src/config.ts`, in the zod schema object, after `consolidationMaxFlagsPerSession`, add:
+
+```ts
+  consolidationCatchupEnabled: z
+    .string()
+    .optional()
+    .transform((v) => v !== "false")
+    .default("true"),
+  consolidationCatchupGraceSeconds: z.coerce
+    .number()
+    .int()
+    .nonnegative()
+    .default(60),
+```
+
+And in the env-mapping object (the block under `process.env.CONSOLIDATION_MAX_FLAGS_PER_SESSION`), add:
+
+```ts
+  consolidationCatchupEnabled: process.env.CONSOLIDATION_CATCHUP_ENABLED,
+  consolidationCatchupGraceSeconds: process.env.CONSOLIDATION_CATCHUP_GRACE_SECONDS,
+```
+
+- [ ] **Step 2: Wire in `server.ts`**
+
+In `src/server.ts`, near where other repositories are instantiated (search for `DrizzleWorkspaceRepository` and follow the local pattern), add:
+
+```ts
+import { DrizzleSchedulerStateRepository } from "./repositories/scheduler-state-repository.js";
+```
+
+```ts
+const schedulerStateRepo = new DrizzleSchedulerStateRepository(db);
+```
+
+Then replace the existing block starting at line ~130:
+
+```ts
+if (config.consolidationEnabled) {
+  const consolidationJob = new ConsolidationJob(consolidationService, db);
+  consolidationScheduler = new ConsolidationScheduler(
+    consolidationJob,
+    config.consolidationCron,
+  );
+  consolidationScheduler.start();
+}
+```
+
+with:
+
+```ts
+if (config.consolidationEnabled) {
+  const consolidationJob = new ConsolidationJob(
+    consolidationService,
+    db,
+    schedulerStateRepo,
+  );
+  consolidationScheduler = new ConsolidationScheduler(
+    consolidationJob,
+    config.consolidationCron,
+    schedulerStateRepo,
+    {
+      enabled: config.consolidationCatchupEnabled,
+      graceSeconds: config.consolidationCatchupGraceSeconds,
+    },
+  );
+  await consolidationScheduler.start();
+}
+```
+
+Note the `await` — `start()` is now async because it awaits the catch-up decision (the catch-up job itself is fire-and-forget).
+
+- [ ] **Step 3: Typecheck**
+
+Run: `npm run typecheck`
+Expected: exit 0.
+
+- [ ] **Step 4: Run full unit suite**
+
+Run: `npm run test:unit`
+Expected: all pass.
+
+- [ ] **Step 5: Commit Tasks 5 + 6 + 7 together**
+
+```bash
+git add src/scheduler/consolidation-job.ts src/scheduler/consolidation-scheduler.ts src/config.ts src/server.ts tests/unit/scheduler/catchup.test.ts
+git commit -m "feat(scheduler): catch-up run on startup when last tick missed"
+```
+
+---
+
+## Task 8: Integration test — end-to-end catch-up fires on startup
+
+**Files:**
+
+- Modify: `tests/integration/scheduler-catchup.test.ts`
+
+- [ ] **Step 1: Append integration test for scheduler**
+
+Append to `tests/integration/scheduler-catchup.test.ts`:
+
+```ts
+import { ConsolidationScheduler } from "../../src/scheduler/consolidation-scheduler.js";
+import {
+  ConsolidationJob,
+  CONSOLIDATION_JOB_NAME,
+} from "../../src/scheduler/consolidation-job.js";
+
+describe("ConsolidationScheduler catch-up", () => {
+  let db: Database;
+  let repo: DrizzleSchedulerStateRepository;
+
+  beforeAll(async () => {
+    db = await setupTestDb();
+  });
+
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+
+  beforeEach(async () => {
+    await resetDb();
+    repo = new DrizzleSchedulerStateRepository(db);
+  });
+
+  it("invokes the job on start when last_run is stale", async () => {
+    // Seed a stale last_run far in the past.
+    await repo.recordRun(
+      CONSOLIDATION_JOB_NAME,
+      new Date("2020-01-01T00:00:00Z"),
+    );
+
+    let executed = 0;
+    const fakeJob = {
+      isRunning: false,
+      execute: async () => {
+        executed++;
+      },
+    } as unknown as ConsolidationJob;
+
+    const scheduler = new ConsolidationScheduler(fakeJob, "0 3 * * *", repo, {
+      enabled: true,
+      graceSeconds: 60,
+    });
+    await scheduler.start();
+    // Fire-and-forget — give the microtask queue a chance.
+    await new Promise((r) => setTimeout(r, 50));
+    await scheduler.stop();
+
+    expect(executed).toBe(1);
+  });
+
+  it("does NOT invoke the job when last_run is recent", async () => {
+    // Record a last_run after the most recent tick (03:00 today).
+    await repo.recordRun(CONSOLIDATION_JOB_NAME, new Date());
+
+    let executed = 0;
+    const fakeJob = {
+      isRunning: false,
+      execute: async () => {
+        executed++;
+      },
+    } as unknown as ConsolidationJob;
+
+    const scheduler = new ConsolidationScheduler(fakeJob, "0 3 * * *", repo, {
+      enabled: true,
+      graceSeconds: 60,
+    });
+    await scheduler.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await scheduler.stop();
+
+    expect(executed).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run integration tests**
+
+Run: `npx vitest run tests/integration/scheduler-catchup.test.ts`
+Expected: all tests pass (3 repo tests from Task 4 + 2 scheduler tests = 5 total).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/scheduler-catchup.test.ts
+git commit -m "test(scheduler): integration test for startup catch-up"
+```
+
+---
+
+## Task 9: Manual smoke + docs
+
+**Files:**
+
+- Modify: `README.md` (only if it documents consolidation env vars — otherwise skip)
+
+- [ ] **Step 1: Smoke test locally**
+
+1. Ensure consolidation enabled: `export CONSOLIDATION_ENABLED=true`.
+2. Start server: `npm run dev`.
+3. Observe log: either `Consolidation catch-up triggered on startup` (first boot, no last_run) or `Consolidation scheduler started with cron: ...` only (after a recent run).
+4. Stop server, wait past one scheduled tick (or temporarily set `CONSOLIDATION_CRON="* * * * *"`), restart. Expect catch-up log on the second boot.
+5. Restore default cron.
+
+- [ ] **Step 2: Update README if consolidation env vars are documented**
+
+Run: `grep -n CONSOLIDATION_ README.md` — if results exist, add `CONSOLIDATION_CATCHUP_ENABLED` and `CONSOLIDATION_CATCHUP_GRACE_SECONDS` next to the existing entries with one-line descriptions. If README doesn't document these env vars, skip.
+
+- [ ] **Step 3: Commit if README changed**
+
+```bash
+git add README.md
+git commit -m "docs: document consolidation catch-up env vars"
+```
+
+---
+
+## Self-Review Checklist
+
+- Spec coverage: catch-up fires on startup ✓ (Task 6), persists `last_run` ✓ (Task 5), grace window ✓ (Task 6), opt-out env flag ✓ (Task 7), tests unit + integration ✓ (Tasks 6 + 8).
+- No placeholders: all code blocks contain full code, no TODOs.
+- Type consistency: `CONSOLIDATION_JOB_NAME` exported from `consolidation-job.ts`, imported in both scheduler and integration test. `SchedulerStateRepository` interface methods (`getLastRun`, `recordRun`) match across definition, impl, and callers. `CatchUpOptions` shape (`enabled`, `graceSeconds`) consistent between interface, server.ts wiring, and test instantiation.

--- a/drizzle/0011_scheduler_state.sql
+++ b/drizzle/0011_scheduler_state.sql
@@ -1,0 +1,5 @@
+CREATE TABLE "scheduler_state" (
+	"job_name" text PRIMARY KEY NOT NULL,
+	"last_run_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,1047 @@
+{
+  "id": "a9c58633-8840-4e62-8169-020f78d11a1f",
+  "prevId": "61ddf31f-adbf-4b4a-b142-54280d8f0347",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "audit_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor": {
+          "name": "actor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diff": {
+          "name": "diff",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_memory_id_idx": {
+          "name": "audit_log_memory_id_idx",
+          "columns": [
+            {
+              "expression": "memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_project_id_idx": {
+          "name": "audit_log_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_memory_id_memories_id_fk": {
+          "name": "audit_log_memory_id_memories_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "memories",
+          "columnsFrom": [
+            "memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comments_memory_id_idx": {
+          "name": "comments_memory_id_idx",
+          "columns": [
+            {
+              "expression": "memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "comments_created_at_idx": {
+          "name": "comments_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comments_memory_id_memories_id_fk": {
+          "name": "comments_memory_id_memories_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "memories",
+          "columnsFrom": [
+            "memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flags": {
+      "name": "flags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_id": {
+          "name": "memory_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flag_type": {
+          "name": "flag_type",
+          "type": "flag_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "severity": {
+          "name": "severity",
+          "type": "flag_severity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by": {
+          "name": "resolved_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "flags_memory_id_idx": {
+          "name": "flags_memory_id_idx",
+          "columns": [
+            {
+              "expression": "memory_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flags_severity_resolved_idx": {
+          "name": "flags_severity_resolved_idx",
+          "columns": [
+            {
+              "expression": "severity",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flags_memory_id_memories_id_fk": {
+          "name": "flags_memory_id_memories_id_fk",
+          "tableFrom": "flags",
+          "tableTo": "memories",
+          "columnsFrom": [
+            "memory_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.memories": {
+      "name": "memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "memory_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "memory_scope",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'workspace'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::text[]"
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_model": {
+          "name": "embedding_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_dimensions": {
+          "name": "embedding_dimensions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_by": {
+          "name": "verified_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_comment_at": {
+          "name": "last_comment_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "memories_embedding_idx": {
+          "name": "memories_embedding_idx",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": 16,
+            "ef_construction": 64
+          }
+        },
+        "memories_project_id_idx": {
+          "name": "memories_project_id_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memories_workspace_id_idx": {
+          "name": "memories_workspace_id_idx",
+          "columns": [
+            {
+              "expression": "workspace_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memories_author_idx": {
+          "name": "memories_author_idx",
+          "columns": [
+            {
+              "expression": "author",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memories_type_idx": {
+          "name": "memories_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "memories_created_at_idx": {
+          "name": "memories_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "memories_workspace_id_workspaces_id_fk": {
+          "name": "memories_workspace_id_workspaces_id_fk",
+          "tableFrom": "memories",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "memories_project_scope_null_workspace": {
+          "name": "memories_project_scope_null_workspace",
+          "value": "scope != 'project' OR workspace_id IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.relationships": {
+      "name": "relationships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_via": {
+          "name": "created_via",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "relationships_unique_active_edge": {
+          "name": "relationships_unique_active_edge",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "archived_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relationships_source_idx": {
+          "name": "relationships_source_idx",
+          "columns": [
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relationships_target_idx": {
+          "name": "relationships_target_idx",
+          "columns": [
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "relationships_project_type_idx": {
+          "name": "relationships_project_type_idx",
+          "columns": [
+            {
+              "expression": "project_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "relationships_source_id_memories_id_fk": {
+          "name": "relationships_source_id_memories_id_fk",
+          "tableFrom": "relationships",
+          "tableTo": "memories",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "relationships_target_id_memories_id_fk": {
+          "name": "relationships_target_id_memories_id_fk",
+          "tableFrom": "relationships",
+          "tableTo": "memories",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "relationships_no_self_ref": {
+          "name": "relationships_no_self_ref",
+          "value": "source_id != target_id"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.scheduler_state": {
+      "name": "scheduler_state",
+      "schema": "",
+      "columns": {
+        "job_name": {
+          "name": "job_name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session_tracking": {
+      "name": "session_tracking",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_session_at": {
+          "name": "last_session_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_tracking_workspace_id_workspaces_id_fk": {
+          "name": "session_tracking_workspace_id_workspaces_id_fk",
+          "tableFrom": "session_tracking",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_tracking_user_workspace_project_idx": {
+          "name": "session_tracking_user_workspace_project_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "workspace_id",
+            "project_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "budget_used": {
+          "name": "budget_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_workspace_id_workspaces_id_fk": {
+          "name": "sessions_workspace_id_workspaces_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "workspaces",
+          "columnsFrom": [
+            "workspace_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.workspaces": {
+      "name": "workspaces",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.audit_action": {
+      "name": "audit_action",
+      "schema": "public",
+      "values": [
+        "created",
+        "updated",
+        "archived",
+        "merged",
+        "flagged",
+        "commented"
+      ]
+    },
+    "public.flag_severity": {
+      "name": "flag_severity",
+      "schema": "public",
+      "values": [
+        "auto_resolved",
+        "needs_review"
+      ]
+    },
+    "public.flag_type": {
+      "name": "flag_type",
+      "schema": "public",
+      "values": [
+        "duplicate",
+        "contradiction",
+        "override",
+        "superseded",
+        "verify"
+      ]
+    },
+    "public.memory_scope": {
+      "name": "memory_scope",
+      "schema": "public",
+      "values": [
+        "workspace",
+        "user",
+        "project"
+      ]
+    },
+    "public.memory_type": {
+      "name": "memory_type",
+      "schema": "public",
+      "values": [
+        "fact",
+        "decision",
+        "learning",
+        "pattern",
+        "preference",
+        "architecture"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1776466860746,
       "tag": "0010_stiff_wither",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1776690355754,
+      "tag": "0011_scheduler_state",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1014.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "cron-parser": "^4.9.0",
         "dotenv": "^16.0.0",
+        "drizzle-kit": "^0.31.10",
         "drizzle-orm": "^0.45.1",
         "express": "^5.2.1",
         "nanoid": "^5.1.7",
@@ -26,7 +28,6 @@
         "@types/express": "^5.0.6",
         "@types/node": "^22.0.0",
         "@types/node-cron": "^3.0.11",
-        "drizzle-kit": "^0.31.10",
         "eslint": "^10.1.0",
         "eslint-config-prettier": "^10.1.8",
         "husky": "^9.1.7",
@@ -766,7 +767,6 @@
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@drizzle-team/brocli/-/brocli-0.10.2.tgz",
       "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
@@ -811,7 +811,6 @@
       "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.3.2.tgz",
       "integrity": "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==",
       "deprecated": "Merged into tsx: https://tsx.is",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.18.20",
@@ -825,7 +824,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -842,7 +840,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -859,7 +856,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -876,7 +872,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -893,7 +888,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -910,7 +904,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -927,7 +920,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -944,7 +936,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -961,7 +952,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -978,7 +968,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -995,7 +984,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1012,7 +1000,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1029,7 +1016,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1046,7 +1032,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1063,7 +1048,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1080,7 +1064,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1097,7 +1080,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1114,7 +1096,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1131,7 +1112,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1148,7 +1128,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1165,7 +1144,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1182,7 +1160,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1196,7 +1173,6 @@
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
       "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -1235,7 +1211,6 @@
       "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.6.5.tgz",
       "integrity": "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==",
       "deprecated": "Merged into tsx: https://tsx.is",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@esbuild-kit/core-utils": "^3.3.2",
@@ -1249,7 +1224,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1266,7 +1240,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1283,7 +1256,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1300,7 +1272,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1317,7 +1288,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1334,7 +1304,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1351,7 +1320,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1368,7 +1336,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1385,7 +1352,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1402,7 +1368,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1419,7 +1384,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1436,7 +1400,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1453,7 +1416,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1470,7 +1432,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1487,7 +1448,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1504,7 +1464,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1521,7 +1480,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1538,7 +1496,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1555,7 +1512,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1572,7 +1528,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1589,7 +1544,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1606,7 +1560,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1623,7 +1576,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1640,7 +1592,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1657,7 +1608,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1674,7 +1624,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4879,7 +4828,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/bundle-name": {
@@ -5164,6 +5112,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cron-parser": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
+      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5307,7 +5267,6 @@
       "version": "0.31.10",
       "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.10.tgz",
       "integrity": "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@drizzle-team/brocli": "^0.10.2",
@@ -5521,7 +5480,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -6912,6 +6870,15 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -8086,7 +8053,6 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -8106,7 +8072,6 @@
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
       "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
   "dependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.1014.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
+    "cron-parser": "^4.9.0",
     "dotenv": "^16.0.0",
+    "drizzle-kit": "^0.31.10",
     "drizzle-orm": "^0.45.1",
     "express": "^5.2.1",
     "nanoid": "^5.1.7",
@@ -32,7 +34,6 @@
     "pgvector": "^0.2.1",
     "postgres": "^3.4.8",
     "tsx": "^4.21.0",
-    "drizzle-kit": "^0.31.10",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,15 @@ const configSchema = z.object({
     .int()
     .nonnegative()
     .default(5),
+  consolidationCatchupEnabled: z
+    .enum(["true", "false"])
+    .default("true")
+    .transform((v) => v === "true"),
+  consolidationCatchupGraceSeconds: z.coerce
+    .number()
+    .int()
+    .nonnegative()
+    .default(60),
 });
 
 export const config = configSchema.parse({
@@ -60,4 +69,7 @@ export const config = configSchema.parse({
   consolidationVerifyAfterDays: process.env.CONSOLIDATION_VERIFY_AFTER_DAYS,
   consolidationMaxFlagsPerSession:
     process.env.CONSOLIDATION_MAX_FLAGS_PER_SESSION,
+  consolidationCatchupEnabled: process.env.CONSOLIDATION_CATCHUP_ENABLED,
+  consolidationCatchupGraceSeconds:
+    process.env.CONSOLIDATION_CATCHUP_GRACE_SECONDS,
 });

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -44,6 +44,14 @@ export const workspaces = pgTable("workspaces", {
     .defaultNow(),
 });
 
+export const schedulerState = pgTable("scheduler_state", {
+  job_name: text("job_name").primaryKey(),
+  last_run_at: timestamp("last_run_at", { withTimezone: true }).notNull(),
+  updated_at: timestamp("updated_at", { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
 export const memories = pgTable(
   "memories",
   {

--- a/src/repositories/scheduler-state-repository.ts
+++ b/src/repositories/scheduler-state-repository.ts
@@ -1,0 +1,28 @@
+import { eq, sql } from "drizzle-orm";
+import type { Database } from "../db/index.js";
+import { schedulerState } from "../db/schema.js";
+import type { SchedulerStateRepository } from "./types.js";
+
+export class DrizzleSchedulerStateRepository implements SchedulerStateRepository {
+  constructor(private readonly db: Database) {}
+
+  async getLastRun(jobName: string): Promise<Date | null> {
+    const rows = await this.db
+      .select({ last_run_at: schedulerState.last_run_at })
+      .from(schedulerState)
+      .where(eq(schedulerState.job_name, jobName))
+      .limit(1);
+
+    return rows.length > 0 ? rows[0].last_run_at : null;
+  }
+
+  async recordRun(jobName: string, runAt: Date): Promise<void> {
+    await this.db
+      .insert(schedulerState)
+      .values({ job_name: jobName, last_run_at: runAt })
+      .onConflictDoUpdate({
+        target: schedulerState.job_name,
+        set: { last_run_at: runAt, updated_at: sql`now()` },
+      });
+  }
+}

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -244,3 +244,8 @@ export interface TeamActivityCounts {
   updated_memories: number;
   commented_memories: number;
 }
+
+export interface SchedulerStateRepository {
+  getLastRun(jobName: string): Promise<Date | null>;
+  recordRun(jobName: string, runAt: Date): Promise<void>;
+}

--- a/src/scheduler/consolidation-job.ts
+++ b/src/scheduler/consolidation-job.ts
@@ -1,10 +1,13 @@
 import { sql } from "drizzle-orm";
 import type { Database } from "../db/index.js";
 import type { ConsolidationService } from "../services/consolidation-service.js";
+import type { SchedulerStateRepository } from "../repositories/types.js";
 import { logger } from "../utils/logger.js";
 
 /** PostgreSQL advisory lock ID for consolidation job exclusivity across server instances */
 const CONSOLIDATION_LOCK_ID = 42001;
+
+export const CONSOLIDATION_JOB_NAME = "consolidation";
 
 export class ConsolidationJob {
   private running = false;
@@ -12,6 +15,7 @@ export class ConsolidationJob {
   constructor(
     private readonly consolidationService: ConsolidationService,
     private readonly db: Database,
+    private readonly schedulerStateRepo: SchedulerStateRepository,
   ) {}
 
   get isRunning(): boolean {
@@ -47,6 +51,10 @@ export class ConsolidationJob {
       logger.info(
         `Consolidation job completed in ${elapsed}ms: ` +
           `archived=${result.archived}, flagged=${result.flagged}, errors=${result.errors}`,
+      );
+      await this.schedulerStateRepo.recordRun(
+        CONSOLIDATION_JOB_NAME,
+        new Date(start),
       );
     } catch (error) {
       logger.error("Consolidation job failed:", error);

--- a/src/scheduler/consolidation-scheduler.ts
+++ b/src/scheduler/consolidation-scheduler.ts
@@ -1,5 +1,5 @@
 import cron from "node-cron";
-import { parseExpression } from "cron-parser";
+import cronParser from "cron-parser";
 import type { ConsolidationJob } from "./consolidation-job.js";
 import { CONSOLIDATION_JOB_NAME } from "./consolidation-job.js";
 import type { SchedulerStateRepository } from "../repositories/types.js";
@@ -25,7 +25,9 @@ export function shouldCatchUp(
 ): boolean {
   let prevTick: Date;
   try {
-    const interval = parseExpression(cronExpression, { currentDate: now });
+    const interval = cronParser.parseExpression(cronExpression, {
+      currentDate: now,
+    });
     prevTick = interval.prev().toDate();
   } catch {
     return false;

--- a/src/scheduler/consolidation-scheduler.ts
+++ b/src/scheduler/consolidation-scheduler.ts
@@ -1,6 +1,41 @@
 import cron from "node-cron";
+import { parseExpression } from "cron-parser";
 import type { ConsolidationJob } from "./consolidation-job.js";
+import { CONSOLIDATION_JOB_NAME } from "./consolidation-job.js";
+import type { SchedulerStateRepository } from "../repositories/types.js";
 import { logger } from "../utils/logger.js";
+
+export interface CatchUpOptions {
+  enabled: boolean;
+  graceSeconds: number;
+}
+
+/**
+ * Decide whether a catch-up run is needed.
+ *
+ * graceSeconds protects against re-firing when the server restarts seconds
+ * after a successful run — clock skew / commit ordering can make `lastRun`
+ * appear a hair before `prevTick`.
+ */
+export function shouldCatchUp(
+  cronExpression: string,
+  lastRun: Date | null,
+  now: Date,
+  graceSeconds: number,
+): boolean {
+  let prevTick: Date;
+  try {
+    const interval = parseExpression(cronExpression, { currentDate: now });
+    prevTick = interval.prev().toDate();
+  } catch {
+    return false;
+  }
+
+  if (lastRun === null) return true;
+
+  const graceMs = graceSeconds * 1000;
+  return lastRun.getTime() + graceMs < prevTick.getTime();
+}
 
 export class ConsolidationScheduler {
   private task: cron.ScheduledTask | null = null;
@@ -8,14 +43,20 @@ export class ConsolidationScheduler {
   constructor(
     private readonly job: ConsolidationJob,
     private readonly cronExpression: string,
+    private readonly schedulerStateRepo: SchedulerStateRepository,
+    private readonly catchUp: CatchUpOptions,
   ) {}
 
-  start(): void {
+  async start(): Promise<void> {
     if (!cron.validate(this.cronExpression)) {
       logger.error(
         `Invalid cron expression: ${this.cronExpression}, scheduler not started`,
       );
       return;
+    }
+
+    if (this.catchUp.enabled) {
+      await this.runCatchUpIfNeeded();
     }
 
     this.task = cron.schedule(this.cronExpression, () => {
@@ -29,13 +70,41 @@ export class ConsolidationScheduler {
     );
   }
 
+  private async runCatchUpIfNeeded(): Promise<void> {
+    try {
+      const lastRun = await this.schedulerStateRepo.getLastRun(
+        CONSOLIDATION_JOB_NAME,
+      );
+      const now = new Date();
+      if (
+        shouldCatchUp(
+          this.cronExpression,
+          lastRun,
+          now,
+          this.catchUp.graceSeconds,
+        )
+      ) {
+        logger.info(
+          `Consolidation catch-up triggered on startup (last_run=${
+            lastRun?.toISOString() ?? "never"
+          })`,
+        );
+        // Fire-and-forget: do not block server startup on job completion.
+        this.job.execute().catch((error) => {
+          logger.error("Consolidation catch-up failed:", error);
+        });
+      }
+    } catch (error) {
+      logger.error("Consolidation catch-up check failed:", error);
+    }
+  }
+
   async stop(): Promise<void> {
     if (this.task) {
       this.task.stop();
       this.task = null;
     }
 
-    // Wait for running job to finish
     if (this.job.isRunning) {
       logger.info("Waiting for running consolidation job to finish...");
       const maxWait = 60_000;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,5 @@
 import "dotenv/config";
+import { fileURLToPath } from "node:url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
@@ -231,7 +232,11 @@ async function main() {
   process.on("SIGINT", shutdown);
 }
 
-main().catch((err) => {
-  logger.error("Fatal error:", err);
-  process.exit(1);
-});
+// Only auto-run main() when this file is the process entrypoint.
+// Importing it (e.g. from a smoke test) just resolves the module graph.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((err) => {
+    logger.error("Fatal error:", err);
+    process.exit(1);
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,7 @@ import {
 import { DrizzleAuditRepository } from "./repositories/audit-repository.js";
 import { DrizzleFlagRepository } from "./repositories/flag-repository.js";
 import { DrizzleRelationshipRepository } from "./repositories/relationship-repository.js";
+import { DrizzleSchedulerStateRepository } from "./repositories/scheduler-state-repository.js";
 import { MemoryService } from "./services/memory-service.js";
 import { RelationshipService } from "./services/relationship-service.js";
 import { AuditService } from "./services/audit-service.js";
@@ -128,12 +129,22 @@ async function main() {
   let consolidationScheduler: ConsolidationScheduler | null = null;
 
   if (config.consolidationEnabled) {
-    const consolidationJob = new ConsolidationJob(consolidationService, db);
+    const schedulerStateRepo = new DrizzleSchedulerStateRepository(db);
+    const consolidationJob = new ConsolidationJob(
+      consolidationService,
+      db,
+      schedulerStateRepo,
+    );
     consolidationScheduler = new ConsolidationScheduler(
       consolidationJob,
       config.consolidationCron,
+      schedulerStateRepo,
+      {
+        enabled: config.consolidationCatchupEnabled,
+        graceSeconds: config.consolidationCatchupGraceSeconds,
+      },
     );
-    consolidationScheduler.start();
+    await consolidationScheduler.start();
   }
 
   // Factory: creates a fresh MCP server per session (tools + prompts registered)

--- a/tests/integration/scheduler-catchup.test.ts
+++ b/tests/integration/scheduler-catchup.test.ts
@@ -2,6 +2,11 @@ import { describe, it, expect, beforeEach, afterAll } from "vitest";
 import { getTestDb, truncateAll, closeDb } from "../helpers.js";
 import { schedulerState } from "../../src/db/schema.js";
 import { DrizzleSchedulerStateRepository } from "../../src/repositories/scheduler-state-repository.js";
+import { ConsolidationScheduler } from "../../src/scheduler/consolidation-scheduler.js";
+import {
+  ConsolidationJob,
+  CONSOLIDATION_JOB_NAME,
+} from "../../src/scheduler/consolidation-job.js";
 
 describe("DrizzleSchedulerStateRepository", () => {
   let repo: DrizzleSchedulerStateRepository;
@@ -36,5 +41,67 @@ describe("DrizzleSchedulerStateRepository", () => {
     await repo.recordRun("consolidation", t2);
     const result = await repo.getLastRun("consolidation");
     expect(result?.toISOString()).toBe(t2.toISOString());
+  });
+});
+
+describe("ConsolidationScheduler catch-up", () => {
+  let repo: DrizzleSchedulerStateRepository;
+
+  beforeEach(async () => {
+    await truncateAll();
+    const db = getTestDb();
+    await db.delete(schedulerState);
+    repo = new DrizzleSchedulerStateRepository(db);
+  });
+
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("invokes the job on start when last_run is stale", async () => {
+    await repo.recordRun(
+      CONSOLIDATION_JOB_NAME,
+      new Date("2020-01-01T00:00:00Z"),
+    );
+
+    let executed = 0;
+    const fakeJob = {
+      isRunning: false,
+      execute: async () => {
+        executed++;
+      },
+    } as unknown as ConsolidationJob;
+
+    const scheduler = new ConsolidationScheduler(fakeJob, "0 3 * * *", repo, {
+      enabled: true,
+      graceSeconds: 60,
+    });
+    await scheduler.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await scheduler.stop();
+
+    expect(executed).toBe(1);
+  });
+
+  it("does NOT invoke the job when last_run is recent", async () => {
+    await repo.recordRun(CONSOLIDATION_JOB_NAME, new Date());
+
+    let executed = 0;
+    const fakeJob = {
+      isRunning: false,
+      execute: async () => {
+        executed++;
+      },
+    } as unknown as ConsolidationJob;
+
+    const scheduler = new ConsolidationScheduler(fakeJob, "0 3 * * *", repo, {
+      enabled: true,
+      graceSeconds: 60,
+    });
+    await scheduler.start();
+    await new Promise((r) => setTimeout(r, 50));
+    await scheduler.stop();
+
+    expect(executed).toBe(0);
   });
 });

--- a/tests/integration/scheduler-catchup.test.ts
+++ b/tests/integration/scheduler-catchup.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { getTestDb, truncateAll, closeDb } from "../helpers.js";
+import { schedulerState } from "../../src/db/schema.js";
+import { DrizzleSchedulerStateRepository } from "../../src/repositories/scheduler-state-repository.js";
+
+describe("DrizzleSchedulerStateRepository", () => {
+  let repo: DrizzleSchedulerStateRepository;
+
+  beforeEach(async () => {
+    await truncateAll();
+    const db = getTestDb();
+    await db.delete(schedulerState);
+    repo = new DrizzleSchedulerStateRepository(db);
+  });
+
+  afterAll(async () => {
+    await closeDb();
+  });
+
+  it("returns null for unknown job", async () => {
+    const result = await repo.getLastRun("nonexistent");
+    expect(result).toBeNull();
+  });
+
+  it("records run and reads it back", async () => {
+    const when = new Date("2026-04-20T10:00:00Z");
+    await repo.recordRun("consolidation", when);
+    const result = await repo.getLastRun("consolidation");
+    expect(result?.toISOString()).toBe(when.toISOString());
+  });
+
+  it("overwrites existing run on repeat call", async () => {
+    const t1 = new Date("2026-04-20T10:00:00Z");
+    const t2 = new Date("2026-04-21T10:00:00Z");
+    await repo.recordRun("consolidation", t1);
+    await repo.recordRun("consolidation", t2);
+    const result = await repo.getLastRun("consolidation");
+    expect(result?.toISOString()).toBe(t2.toISOString());
+  });
+});

--- a/tests/unit/scheduler/catchup.test.ts
+++ b/tests/unit/scheduler/catchup.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { shouldCatchUp } from "../../../src/scheduler/consolidation-scheduler.js";
+
+describe("shouldCatchUp", () => {
+  const cronExpr = "0 3 * * *"; // 03:00 daily
+
+  it("returns true when last run is before previous tick", () => {
+    const now = new Date("2026-04-20T10:00:00Z");
+    const lastRun = new Date("2026-04-18T03:00:00Z");
+    expect(shouldCatchUp(cronExpr, lastRun, now, 60)).toBe(true);
+  });
+
+  it("returns false when last run is after previous tick", () => {
+    const now = new Date("2026-04-20T10:00:00Z");
+    const lastRun = new Date("2026-04-20T03:00:05Z");
+    expect(shouldCatchUp(cronExpr, lastRun, now, 60)).toBe(false);
+  });
+
+  it("returns true when last run is null (first-ever startup)", () => {
+    const now = new Date("2026-04-20T10:00:00Z");
+    expect(shouldCatchUp(cronExpr, null, now, 60)).toBe(true);
+  });
+
+  it("returns false when last run is within grace window before prev tick", () => {
+    // prev tick = 2026-04-20T03:00:00Z; grace 60s -> skip if lastRun >= 02:59:00Z
+    const now = new Date("2026-04-20T10:00:00Z");
+    const lastRun = new Date("2026-04-20T02:59:30Z");
+    expect(shouldCatchUp(cronExpr, lastRun, now, 60)).toBe(false);
+  });
+
+  it("returns false for invalid cron expression", () => {
+    const now = new Date("2026-04-20T10:00:00Z");
+    expect(shouldCatchUp("not-a-cron", null, now, 60)).toBe(false);
+  });
+});

--- a/tests/unit/server-boot.test.ts
+++ b/tests/unit/server-boot.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+/**
+ * Smoke test for the production module graph.
+ *
+ * Vitest transforms modules via esbuild, which papers over CJS/ESM named-import
+ * mismatches that the real Node ESM loader rejects (e.g. `import { x } from "cjs-only-pkg"`).
+ * Tests can therefore pass while `npm start` crashes on import.
+ *
+ * This spawns Node with the tsx loader and imports src/server.ts without starting
+ * the listener (src/server.ts gates main() behind an entrypoint check). A non-zero
+ * exit means a module in the graph failed to resolve under real Node ESM semantics.
+ */
+describe("server module graph loads under Node ESM", () => {
+  it("imports src/server.ts without module-resolution errors", () => {
+    const result = spawnSync(
+      "node",
+      ["--import", "tsx", "-e", "await import('./src/server.js');"],
+      { cwd: repoRoot, encoding: "utf8", timeout: 20_000 },
+    );
+
+    if (result.status !== 0) {
+      throw new Error(
+        `Server module graph failed to load (exit ${result.status}):\n` +
+          `stderr:\n${result.stderr}\nstdout:\n${result.stdout}`,
+      );
+    }
+    expect(result.status).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `scheduler_state` table + `SchedulerStateRepository` to persist per-job `last_run_at`.
- On `ConsolidationScheduler.start()`, computes the previous cron tick via `cron-parser`; if `last_run_at` is stale (older than `prev_tick - grace`), fires a fire-and-forget catch-up invocation. `ConsolidationJob` records `last_run_at = start` after a successful run, under the same advisory lock.
- Configurable via `CONSOLIDATION_CATCHUP_ENABLED` (default `true`) and `CONSOLIDATION_CATCHUP_GRACE_SECONDS` (default `60`).
- Adds a `tests/unit/server-boot.test.ts` smoke test that spawns `node --import tsx` to load `src/server.ts` under the real Node ESM loader — closes the gap between vitest's esbuild transform and production runtime (it catches CJS/ESM named-import mismatches that tsc + vitest miss). `src/server.ts` now gates `main()` behind an entrypoint check so the smoke test doesn't start the listener.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test:unit` — 66/66 pass (includes new unit test for `shouldCatchUp` decision logic and the server-boot smoke test)
- [x] `npx vitest run tests/integration/scheduler-catchup.test.ts` — 5/5 pass (3 repo + 2 scheduler integration)
- [x] Smoke test verified to catch the original `{ parseExpression }` named-import regression (reverted cron-parser fix → smoke failed; re-applied → passes)
- [ ] Manual: start with `CONSOLIDATION_ENABLED=true`, confirm "Consolidation catch-up triggered on startup" log on first boot (empty `scheduler_state`), confirm no catch-up on immediate restart
- [ ] Manual: stop, wait past a scheduled tick (or temporarily set `CONSOLIDATION_CRON="* * * * *"`), restart → expect catch-up log on second boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)