### PR TITLE
feat(installer): one-shot setup for Claude Code + Copilot CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,16 @@ Mock mode uses random vectors — search results won't be semantically meaningfu
 
 ### 4. Set up with Claude Code
 
+**Fast path:**
+
+```bash
+npm run install:agent -- --target=claude
+```
+
+This copies hook scripts to `~/.claude/hooks/`, merges the MCP server config into `~/.claude/settings.json` (with a `.bak` backup), and prepends the agent instructions to `~/.claude/CLAUDE.md` between `<!-- agent-brain:start -->` / `<!-- agent-brain:end -->` markers. Re-run is idempotent. Uninstall with `npm run uninstall:agent -- --target=claude`. The manual steps below remain available.
+
+---
+
 **Step 1: Add the MCP server**
 
 Make sure Agent Brain is running (see [Start](#3-start)), then add to `~/.claude/settings.json` (global) or project `.claude/settings.json`:
@@ -191,6 +201,16 @@ The hooks connect to Agent Brain at `http://localhost:19898` by default. Set the
 Create or edit `~/.claude/CLAUDE.md` (global) and paste the contents of [`hooks/claude/claude-md-snippet.md`](hooks/claude/claude-md-snippet.md). It tells Claude Code to use agent-brain instead of the built-in file-based memory.
 
 ### 5. Set up with GitHub Copilot CLI
+
+**Fast path:**
+
+```bash
+npm run install:agent -- --target=copilot
+```
+
+Copies hook scripts to `~/.copilot/hooks/`, merges MCP config into `~/.copilot/mcp-config.json` and hook config into `~/.copilot/hooks/hooks.json` (both with `.bak` backups), and prepends instructions to `~/.copilot/copilot-instructions.md` between `<!-- agent-brain:start -->` / `<!-- agent-brain:end -->` markers. Re-run is idempotent. Uninstall with `npm run uninstall:agent -- --target=copilot`.
+
+---
 
 **Step 1: Add the MCP server**
 

--- a/docs/superpowers/specs/2026-04-21-installer-design.md
+++ b/docs/superpowers/specs/2026-04-21-installer-design.md
@@ -32,9 +32,10 @@ Both resolve to `tsx scripts/installer/index.ts` (uninstall passes `--uninstall`
 | -------------------------------- | ------------------------------------ |
 | `--target=claude\|copilot\|both` | Skip interactive target prompt       |
 | `--dry-run`                      | Print planned actions; write nothing |
-| `--yes` / `-y`                   | Skip confirmation prompt (CI)        |
 | `--uninstall`                    | Teardown mode                        |
 | `--help`                         | Usage                                |
+
+No pre-apply confirmation prompt. The installer writes directly once the target is resolved; `.bak` files, the dry-run mode, and idempotent re-run cover the "undo" need.
 
 Interactive behavior: if `--target` is missing and stdin is a TTY, prompt for target. Otherwise fail with an actionable error.
 
@@ -194,7 +195,7 @@ Fail fast. No silent catches. No fallback paths.
 
 **Atomicity:** writes are per-file, not transactional across files. Acceptable because re-run is idempotent.
 
-**Exit codes:** 0 success · 1 preflight fail · 2 runtime fail · 3 user declined confirmation.
+**Exit codes:** 0 success · 2 any failure (preflight or runtime). Differentiated codes were considered but dropped — `.bak` + dry-run + idempotent re-run cover the recovery need without needing scripts to branch on cause.
 
 ## Testing
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,5 +1,7 @@
 # Agent Integration Hook Templates
 
+> **Fast path:** from a cloned checkout, run `npm run install:agent` to install hooks, MCP config, and instructions for Claude Code or Copilot CLI in one step. Uninstall with `npm run uninstall:agent`. The manual steps below remain for reference and for users who prefer fine-grained control.
+
 Hook and configuration templates for automating memory workflows with Claude Code and GitHub
 Copilot CLI.
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "inspect": "npx @modelcontextprotocol/inspector --cli --transport http --server-url http://localhost:19898/mcp",
     "seed": "tsx scripts/seed.ts",
     "migrate:flag-relationships": "tsx scripts/migrate-flag-relationships.ts",
+    "install:agent": "tsx scripts/installer/index.ts",
+    "uninstall:agent": "tsx scripts/installer/index.ts --uninstall",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/scripts/installer/apply.ts
+++ b/scripts/installer/apply.ts
@@ -1,6 +1,6 @@
 import { mkdir, copyFile, chmod, readFile } from "node:fs/promises";
 import { dirname } from "node:path";
-import type { InstallPlan } from "./types.js";
+import type { InstallPlan, Source } from "./types.js";
 import { mergeJson } from "./merge-json.js";
 import { prependWithMarkers } from "./merge-markdown.js";
 
@@ -8,61 +8,66 @@ export interface ApplyOptions {
   dryRun: boolean;
 }
 
-async function resolvePatch(patch: unknown): Promise<unknown> {
-  if (
-    typeof patch === "object" &&
-    patch !== null &&
-    !Array.isArray(patch) &&
-    "__fromFile" in patch &&
-    typeof (patch as { __fromFile: unknown }).__fromFile === "string"
-  ) {
-    const raw = await readFile(
-      (patch as { __fromFile: string }).__fromFile,
-      "utf8",
-    );
+// Source<T> defers file reads to apply-time so plan() stays pure and dry-run avoids I/O.
+async function resolvePatch(src: Source<unknown>): Promise<unknown> {
+  if (src.kind === "inline") return src.value;
+  const raw = await readFile(src.path, "utf8");
+  try {
     return JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`${src.path}: invalid JSON in snippet`, { cause: e });
   }
-  return patch;
 }
 
-async function resolveSnippet(snippet: string): Promise<string> {
-  if (snippet.startsWith("__fromFile:")) {
-    return readFile(snippet.slice("__fromFile:".length), "utf8");
-  }
-  return snippet;
+async function resolveSnippet(src: Source<string>): Promise<string> {
+  if (src.kind === "inline") return src.value;
+  return readFile(src.path, "utf8");
 }
 
 export async function applyPlan(
   plan: InstallPlan,
   opts: ApplyOptions,
 ): Promise<void> {
-  for (const c of plan.copies) {
-    if (opts.dryRun) {
-      console.log(`[dry-run] copy ${c.src} → ${c.dest}`);
-      continue;
+  const applied: string[] = [];
+  try {
+    for (const c of plan.copies) {
+      if (opts.dryRun) {
+        console.log(`[dry-run] copy ${c.src} → ${c.dest}`);
+        continue;
+      }
+      await mkdir(dirname(c.dest), { recursive: true });
+      await copyFile(c.src, c.dest);
+      if (c.mode !== undefined) await chmod(c.dest, c.mode);
+      applied.push(c.dest);
     }
-    await mkdir(dirname(c.dest), { recursive: true });
-    await copyFile(c.src, c.dest);
-    if (c.mode !== undefined) await chmod(c.dest, c.mode);
-  }
 
-  for (const m of plan.jsonMerges) {
-    const patch = await resolvePatch(m.patch);
-    if (opts.dryRun) {
-      console.log(`[dry-run] merge ${m.file}`);
-      continue;
+    for (const m of plan.jsonMerges) {
+      const patch = await resolvePatch(m.patch);
+      if (opts.dryRun) {
+        console.log(`[dry-run] merge ${m.file}`);
+        continue;
+      }
+      await mkdir(dirname(m.file), { recursive: true });
+      await mergeJson(m.file, patch, { dryRun: false });
+      applied.push(m.file);
     }
-    await mkdir(dirname(m.file), { recursive: true });
-    await mergeJson(m.file, patch, { dryRun: false });
-  }
 
-  for (const p of plan.markdownPrepends) {
-    const snippet = await resolveSnippet(p.snippet);
-    if (opts.dryRun) {
-      console.log(`[dry-run] prepend ${p.file} [${p.markerId}]`);
-      continue;
+    for (const p of plan.markdownPrepends) {
+      const snippet = await resolveSnippet(p.snippet);
+      if (opts.dryRun) {
+        console.log(`[dry-run] prepend ${p.file} [${p.markerId}]`);
+        continue;
+      }
+      await mkdir(dirname(p.file), { recursive: true });
+      await prependWithMarkers(p.file, snippet, p.markerId, { dryRun: false });
+      applied.push(p.file);
     }
-    await mkdir(dirname(p.file), { recursive: true });
-    await prependWithMarkers(p.file, snippet, p.markerId, { dryRun: false });
+  } catch (e) {
+    if (applied.length > 0) {
+      console.error("Partially applied. These files were modified:");
+      for (const f of applied) console.error(`  ${f}`);
+      console.error("Re-run to reconcile, or restore from .bak siblings.");
+    }
+    throw e;
   }
 }

--- a/scripts/installer/apply.ts
+++ b/scripts/installer/apply.ts
@@ -1,0 +1,68 @@
+import { mkdir, copyFile, chmod, readFile } from "node:fs/promises";
+import { dirname } from "node:path";
+import type { InstallPlan } from "./types.js";
+import { mergeJson } from "./merge-json.js";
+import { prependWithMarkers } from "./merge-markdown.js";
+
+export interface ApplyOptions {
+  dryRun: boolean;
+}
+
+async function resolvePatch(patch: unknown): Promise<unknown> {
+  if (
+    typeof patch === "object" &&
+    patch !== null &&
+    !Array.isArray(patch) &&
+    "__fromFile" in patch &&
+    typeof (patch as { __fromFile: unknown }).__fromFile === "string"
+  ) {
+    const raw = await readFile(
+      (patch as { __fromFile: string }).__fromFile,
+      "utf8",
+    );
+    return JSON.parse(raw);
+  }
+  return patch;
+}
+
+async function resolveSnippet(snippet: string): Promise<string> {
+  if (snippet.startsWith("__fromFile:")) {
+    return readFile(snippet.slice("__fromFile:".length), "utf8");
+  }
+  return snippet;
+}
+
+export async function applyPlan(
+  plan: InstallPlan,
+  opts: ApplyOptions,
+): Promise<void> {
+  for (const c of plan.copies) {
+    if (opts.dryRun) {
+      console.log(`[dry-run] copy ${c.src} → ${c.dest}`);
+      continue;
+    }
+    await mkdir(dirname(c.dest), { recursive: true });
+    await copyFile(c.src, c.dest);
+    if (c.mode !== undefined) await chmod(c.dest, c.mode);
+  }
+
+  for (const m of plan.jsonMerges) {
+    const patch = await resolvePatch(m.patch);
+    if (opts.dryRun) {
+      console.log(`[dry-run] merge ${m.file}`);
+      continue;
+    }
+    await mkdir(dirname(m.file), { recursive: true });
+    await mergeJson(m.file, patch, { dryRun: false });
+  }
+
+  for (const p of plan.markdownPrepends) {
+    const snippet = await resolveSnippet(p.snippet);
+    if (opts.dryRun) {
+      console.log(`[dry-run] prepend ${p.file} [${p.markerId}]`);
+      continue;
+    }
+    await mkdir(dirname(p.file), { recursive: true });
+    await prependWithMarkers(p.file, snippet, p.markerId, { dryRun: false });
+  }
+}

--- a/scripts/installer/fs-util.ts
+++ b/scripts/installer/fs-util.ts
@@ -1,0 +1,49 @@
+import { access, rename, stat, writeFile } from "node:fs/promises";
+import { constants } from "node:fs";
+
+export async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw e;
+  }
+}
+
+// Write via temp + rename so SIGKILL/power-loss can't leave a truncated target.
+export async function atomicWrite(
+  file: string,
+  content: string,
+): Promise<void> {
+  const tmp = `${file}.tmp.${process.pid}`;
+  await writeFile(tmp, content, "utf8");
+  await rename(tmp, file);
+}
+
+// Each call produces a fresh timestamped backup so subsequent installs don't
+// clobber the last-known-good. Caller decides whether the source existed.
+export async function writeBackup(file: string): Promise<string> {
+  const now = new Date();
+  const stamp =
+    now.getFullYear().toString() +
+    String(now.getMonth() + 1).padStart(2, "0") +
+    String(now.getDate()).padStart(2, "0") +
+    "-" +
+    String(now.getHours()).padStart(2, "0") +
+    String(now.getMinutes()).padStart(2, "0") +
+    String(now.getSeconds()).padStart(2, "0");
+  const bak = `${file}.bak.${stamp}`;
+  const { copyFile } = await import("node:fs/promises");
+  await copyFile(file, bak);
+  return bak;
+}
+
+export async function isDirectory(path: string): Promise<boolean> {
+  try {
+    const s = await stat(path);
+    return s.isDirectory();
+  } catch {
+    return false;
+  }
+}

--- a/scripts/installer/index.ts
+++ b/scripts/installer/index.ts
@@ -19,8 +19,8 @@ export interface Env {
 
 export async function runInstaller(opts: RunOptions, env: Env): Promise<void> {
   // Preflight all targets before any apply
+  process.env.HOME = env.home;
   for (const name of opts.targets) {
-    process.env.HOME = env.home; // preflight reads HOME
     await TARGETS[name].preflight();
   }
 
@@ -57,7 +57,6 @@ export async function main(argv: string[]): Promise<void> {
     options: {
       target: { type: "string" },
       "dry-run": { type: "boolean", default: false },
-      yes: { type: "boolean", short: "y", default: false },
       uninstall: { type: "boolean", default: false },
       help: { type: "boolean", default: false },
     },
@@ -65,7 +64,7 @@ export async function main(argv: string[]): Promise<void> {
 
   if (values.help) {
     console.log(
-      `Usage: npm run install:agent -- [--target=claude|copilot|both] [--dry-run] [--yes] [--uninstall]`,
+      `Usage: npm run install:agent -- [--target=claude|copilot|both] [--dry-run] [--uninstall]`,
     );
     return;
   }
@@ -82,16 +81,19 @@ export async function main(argv: string[]): Promise<void> {
     throw new Error("--target required when not running interactively");
   }
 
+  if (!process.env.HOME) {
+    throw new Error("HOME environment variable is not set");
+  }
+
   await runInstaller(
     {
       targets,
       dryRun: Boolean(values["dry-run"]),
-      yes: Boolean(values.yes),
       uninstall: Boolean(values.uninstall),
     },
     {
       repoRoot: process.cwd(),
-      home: process.env.HOME ?? "",
+      home: process.env.HOME,
     },
   );
 }

--- a/scripts/installer/index.ts
+++ b/scripts/installer/index.ts
@@ -1,11 +1,15 @@
 import { parseArgs } from "node:util";
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
+import { fileURLToPath } from "node:url";
+import { realpathSync } from "node:fs";
+import { isAbsolute } from "node:path";
 import type { RunOptions, TargetName, Target } from "./types.js";
 import { claudeTarget } from "./targets/claude.js";
 import { copilotTarget } from "./targets/copilot.js";
 import { applyPlan } from "./apply.js";
 import { uninstallTarget } from "./uninstall.js";
+import { isDirectory } from "./fs-util.js";
 
 const TARGETS: Record<TargetName, Target> = {
   claude: claudeTarget,
@@ -18,16 +22,20 @@ export interface Env {
 }
 
 export async function runInstaller(opts: RunOptions, env: Env): Promise<void> {
-  // Preflight all targets before any apply
+  // Sync env.home into process.env.HOME: preflight helpers and downstream
+  // tools (jq, docker) read it directly from the environment.
   process.env.HOME = env.home;
+
   for (const name of opts.targets) {
-    await TARGETS[name].preflight();
+    await TARGETS[name].preflight(env.home);
   }
 
   for (const name of opts.targets) {
     const target = TARGETS[name];
     if (opts.uninstall) {
-      await uninstallTarget(target, env.home, { dryRun: opts.dryRun });
+      await uninstallTarget(target, env.repoRoot, env.home, {
+        dryRun: opts.dryRun,
+      });
       continue;
     }
     const plan = target.plan(env.repoRoot, env.home);
@@ -48,7 +56,28 @@ async function promptTarget(): Promise<TargetName[]> {
   rl.close();
   if (answer === "claude" || answer === "copilot") return [answer];
   if (answer === "both") return ["claude", "copilot"];
-  throw new Error(`Invalid target: ${answer}`);
+  throw new Error(
+    `Invalid target '${answer}'. Expected: claude | copilot | both.`,
+  );
+}
+
+// HOME must be an absolute path to an existing directory and not filesystem
+// root — otherwise targets would silently write into '/' or fail with a
+// confusing EACCES after partial mkdir.
+async function validateHome(home: string | undefined): Promise<string> {
+  if (!home || home.trim() === "") {
+    throw new Error("HOME environment variable is not set");
+  }
+  if (!isAbsolute(home)) {
+    throw new Error(`HOME must be an absolute path, got '${home}'`);
+  }
+  if (home === "/") {
+    throw new Error("HOME must not be filesystem root '/'");
+  }
+  if (!(await isDirectory(home))) {
+    throw new Error(`HOME='${home}' is not an existing directory`);
+  }
+  return home;
 }
 
 export async function main(argv: string[]): Promise<void> {
@@ -81,9 +110,7 @@ export async function main(argv: string[]): Promise<void> {
     throw new Error("--target required when not running interactively");
   }
 
-  if (!process.env.HOME) {
-    throw new Error("HOME environment variable is not set");
-  }
+  const home = await validateHome(process.env.HOME);
 
   await runInstaller(
     {
@@ -93,18 +120,42 @@ export async function main(argv: string[]): Promise<void> {
     },
     {
       repoRoot: process.cwd(),
-      home: process.env.HOME,
+      home,
     },
   );
 }
 
-const isMain =
-  import.meta.url === `file://${process.argv[1]}` ||
-  import.meta.url.endsWith(process.argv[1] ?? "");
-if (isMain) {
+function formatError(err: unknown): string {
+  const lines: string[] = [];
+  let current: unknown = err;
+  while (current) {
+    const msg = current instanceof Error ? current.message : String(current);
+    lines.push(lines.length === 0 ? msg : `  caused by: ${msg}`);
+    current = current instanceof Error ? current.cause : undefined;
+  }
+  if (process.env.DEBUG && err instanceof Error && err.stack) {
+    lines.push(err.stack);
+  }
+  return lines.join("\n");
+}
+
+// Compare the real path of this module with the real path of the entry
+// script. `endsWith` could match any suffix (including empty), which would
+// fire main() on unrelated imports.
+function isMainModule(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    const here = fileURLToPath(import.meta.url);
+    return realpathSync(here) === realpathSync(entry);
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule()) {
   main(process.argv.slice(2)).catch((err: unknown) => {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.error(`ERR: ${msg}`);
+    console.error(`ERR: ${formatError(err)}`);
     process.exit(2);
   });
 }

--- a/scripts/installer/index.ts
+++ b/scripts/installer/index.ts
@@ -1,0 +1,108 @@
+import { parseArgs } from "node:util";
+import { createInterface } from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+import type { RunOptions, TargetName, Target } from "./types.js";
+import { claudeTarget } from "./targets/claude.js";
+import { copilotTarget } from "./targets/copilot.js";
+import { applyPlan } from "./apply.js";
+import { uninstallTarget } from "./uninstall.js";
+
+const TARGETS: Record<TargetName, Target> = {
+  claude: claudeTarget,
+  copilot: copilotTarget,
+};
+
+export interface Env {
+  repoRoot: string;
+  home: string;
+}
+
+export async function runInstaller(opts: RunOptions, env: Env): Promise<void> {
+  // Preflight all targets before any apply
+  for (const name of opts.targets) {
+    process.env.HOME = env.home; // preflight reads HOME
+    await TARGETS[name].preflight();
+  }
+
+  for (const name of opts.targets) {
+    const target = TARGETS[name];
+    if (opts.uninstall) {
+      await uninstallTarget(target, env.home, { dryRun: opts.dryRun });
+      continue;
+    }
+    const plan = target.plan(env.repoRoot, env.home);
+    if (opts.dryRun) {
+      console.log(target.describe(plan));
+      continue;
+    }
+    await applyPlan(plan, { dryRun: false });
+    for (const line of plan.postInstructions) console.log(line);
+  }
+}
+
+async function promptTarget(): Promise<TargetName[]> {
+  const rl = createInterface({ input: stdin, output: stdout });
+  const answer = (await rl.question("Target (claude/copilot/both)? "))
+    .trim()
+    .toLowerCase();
+  rl.close();
+  if (answer === "claude" || answer === "copilot") return [answer];
+  if (answer === "both") return ["claude", "copilot"];
+  throw new Error(`Invalid target: ${answer}`);
+}
+
+export async function main(argv: string[]): Promise<void> {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      target: { type: "string" },
+      "dry-run": { type: "boolean", default: false },
+      yes: { type: "boolean", short: "y", default: false },
+      uninstall: { type: "boolean", default: false },
+      help: { type: "boolean", default: false },
+    },
+  });
+
+  if (values.help) {
+    console.log(
+      `Usage: npm run install:agent -- [--target=claude|copilot|both] [--dry-run] [--yes] [--uninstall]`,
+    );
+    return;
+  }
+
+  let targets: TargetName[];
+  if (values.target) {
+    const t = String(values.target);
+    if (t === "claude" || t === "copilot") targets = [t];
+    else if (t === "both") targets = ["claude", "copilot"];
+    else throw new Error(`Invalid --target: ${t}`);
+  } else if (stdin.isTTY) {
+    targets = await promptTarget();
+  } else {
+    throw new Error("--target required when not running interactively");
+  }
+
+  await runInstaller(
+    {
+      targets,
+      dryRun: Boolean(values["dry-run"]),
+      yes: Boolean(values.yes),
+      uninstall: Boolean(values.uninstall),
+    },
+    {
+      repoRoot: process.cwd(),
+      home: process.env.HOME ?? "",
+    },
+  );
+}
+
+const isMain =
+  import.meta.url === `file://${process.argv[1]}` ||
+  import.meta.url.endsWith(process.argv[1] ?? "");
+if (isMain) {
+  main(process.argv.slice(2)).catch((err: unknown) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`ERR: ${msg}`);
+    process.exit(2);
+  });
+}

--- a/scripts/installer/merge-json.ts
+++ b/scripts/installer/merge-json.ts
@@ -1,0 +1,77 @@
+import { readFile, writeFile, access, copyFile } from "node:fs/promises";
+import { constants } from "node:fs";
+
+export interface MergeJsonOptions {
+  dryRun: boolean;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function dedupeArray(arr: unknown[]): unknown[] {
+  const seen = new Set<string>();
+  const out: unknown[] = [];
+  for (const item of arr) {
+    const key = JSON.stringify(item);
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push(item);
+    }
+  }
+  return out;
+}
+
+function deepMerge(base: unknown, patch: unknown): unknown {
+  if (Array.isArray(base) && Array.isArray(patch)) {
+    return dedupeArray([...base, ...patch]);
+  }
+  if (isPlainObject(base) && isPlainObject(patch)) {
+    const result: Record<string, unknown> = { ...base };
+    for (const [k, v] of Object.entries(patch)) {
+      result[k] = k in base ? deepMerge(base[k], v) : v;
+    }
+    return result;
+  }
+  return patch;
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function mergeJson(
+  file: string,
+  patch: unknown,
+  opts: MergeJsonOptions,
+): Promise<void> {
+  const existed = await fileExists(file);
+  let base: unknown = {};
+  if (existed) {
+    const raw = await readFile(file, "utf8");
+    try {
+      base = JSON.parse(raw);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new Error(
+        `${file}: invalid JSON (${msg}). Fix or delete before re-running.`,
+        { cause: e },
+      );
+    }
+  }
+
+  const merged = deepMerge(base, patch);
+
+  if (opts.dryRun) return;
+
+  if (existed && !(await fileExists(`${file}.bak`))) {
+    await copyFile(file, `${file}.bak`);
+  }
+
+  await writeFile(file, JSON.stringify(merged, null, 2) + "\n", "utf8");
+}

--- a/scripts/installer/merge-json.ts
+++ b/scripts/installer/merge-json.ts
@@ -1,5 +1,5 @@
-import { readFile, writeFile, access, copyFile } from "node:fs/promises";
-import { constants } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { atomicWrite, fileExists, writeBackup } from "./fs-util.js";
 
 export interface MergeJsonOptions {
   dryRun: boolean;
@@ -22,27 +22,28 @@ function dedupeArray(arr: unknown[]): unknown[] {
   return out;
 }
 
-function deepMerge(base: unknown, patch: unknown): unknown {
+function deepMerge(
+  base: unknown,
+  patch: unknown,
+  keyPath: string[] = [],
+): unknown {
   if (Array.isArray(base) && Array.isArray(patch)) {
     return dedupeArray([...base, ...patch]);
   }
   if (isPlainObject(base) && isPlainObject(patch)) {
     const result: Record<string, unknown> = { ...base };
     for (const [k, v] of Object.entries(patch)) {
-      result[k] = k in base ? deepMerge(base[k], v) : v;
+      result[k] = k in base ? deepMerge(base[k], v, [...keyPath, k]) : v;
     }
     return result;
   }
-  return patch;
-}
-
-async function fileExists(path: string): Promise<boolean> {
-  try {
-    await access(path, constants.F_OK);
-    return true;
-  } catch {
-    return false;
+  if (base !== undefined && typeof base !== typeof patch) {
+    const path = keyPath.join(".") || "(root)";
+    console.warn(
+      `WARN: type mismatch at ${path}: replacing ${Array.isArray(base) ? "array" : typeof base} with ${Array.isArray(patch) ? "array" : typeof patch}`,
+    );
   }
+  return patch;
 }
 
 export async function mergeJson(
@@ -69,9 +70,10 @@ export async function mergeJson(
 
   if (opts.dryRun) return;
 
-  if (existed && !(await fileExists(`${file}.bak`))) {
-    await copyFile(file, `${file}.bak`);
+  if (existed) {
+    const bak = await writeBackup(file);
+    console.log(`Backup: ${bak}`);
   }
 
-  await writeFile(file, JSON.stringify(merged, null, 2) + "\n", "utf8");
+  await atomicWrite(file, JSON.stringify(merged, null, 2) + "\n");
 }

--- a/scripts/installer/merge-markdown.ts
+++ b/scripts/installer/merge-markdown.ts
@@ -47,7 +47,7 @@ export async function prependWithMarkers(
     const after = afterRaw.startsWith("\n") ? afterRaw.slice(1) : afterRaw;
     next = before + block + after;
   } else if (existed) {
-    const sep = existing.startsWith("\n") || existing === "" ? "" : "\n";
+    const sep = existing.startsWith("\n") ? "" : "\n";
     next = block + sep + existing;
   } else {
     next = block;

--- a/scripts/installer/merge-markdown.ts
+++ b/scripts/installer/merge-markdown.ts
@@ -1,0 +1,63 @@
+import { readFile, writeFile, access, copyFile } from "node:fs/promises";
+import { constants } from "node:fs";
+
+export interface MergeMarkdownOptions {
+  dryRun: boolean;
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function startMarker(id: string): string {
+  return `<!-- ${id}:start -->`;
+}
+function endMarker(id: string): string {
+  return `<!-- ${id}:end -->`;
+}
+
+function buildBlock(snippet: string, id: string): string {
+  const body = snippet.endsWith("\n") ? snippet : snippet + "\n";
+  return `${startMarker(id)}\n${body}${endMarker(id)}\n`;
+}
+
+export async function prependWithMarkers(
+  file: string,
+  snippet: string,
+  markerId: string,
+  opts: MergeMarkdownOptions,
+): Promise<void> {
+  const existed = await fileExists(file);
+  const existing = existed ? await readFile(file, "utf8") : "";
+  const start = startMarker(markerId);
+  const end = endMarker(markerId);
+  const block = buildBlock(snippet, markerId);
+
+  let next: string;
+  const startIdx = existing.indexOf(start);
+  const endIdx = existing.indexOf(end);
+  if (existed && startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+    const before = existing.slice(0, startIdx);
+    const afterRaw = existing.slice(endIdx + end.length);
+    const after = afterRaw.startsWith("\n") ? afterRaw.slice(1) : afterRaw;
+    next = before + block + after;
+  } else if (existed) {
+    const sep = existing.startsWith("\n") || existing === "" ? "" : "\n";
+    next = block + sep + existing;
+  } else {
+    next = block;
+  }
+
+  if (opts.dryRun) return;
+
+  if (existed && !(await fileExists(`${file}.bak`))) {
+    await copyFile(file, `${file}.bak`);
+  }
+
+  await writeFile(file, next, "utf8");
+}

--- a/scripts/installer/merge-markdown.ts
+++ b/scripts/installer/merge-markdown.ts
@@ -1,27 +1,19 @@
-import { readFile, writeFile, access, copyFile } from "node:fs/promises";
-import { constants } from "node:fs";
+import { readFile } from "node:fs/promises";
+import type { MarkerId } from "./types.js";
+import { atomicWrite, fileExists, writeBackup } from "./fs-util.js";
 
 export interface MergeMarkdownOptions {
   dryRun: boolean;
 }
 
-async function fileExists(path: string): Promise<boolean> {
-  try {
-    await access(path, constants.F_OK);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-function startMarker(id: string): string {
+function startMarker(id: MarkerId): string {
   return `<!-- ${id}:start -->`;
 }
-function endMarker(id: string): string {
+function endMarker(id: MarkerId): string {
   return `<!-- ${id}:end -->`;
 }
 
-function buildBlock(snippet: string, id: string): string {
+function buildBlock(snippet: string, id: MarkerId): string {
   const body = snippet.endsWith("\n") ? snippet : snippet + "\n";
   return `${startMarker(id)}\n${body}${endMarker(id)}\n`;
 }
@@ -29,7 +21,7 @@ function buildBlock(snippet: string, id: string): string {
 export async function prependWithMarkers(
   file: string,
   snippet: string,
-  markerId: string,
+  markerId: MarkerId,
   opts: MergeMarkdownOptions,
 ): Promise<void> {
   const existed = await fileExists(file);
@@ -55,9 +47,10 @@ export async function prependWithMarkers(
 
   if (opts.dryRun) return;
 
-  if (existed && !(await fileExists(`${file}.bak`))) {
-    await copyFile(file, `${file}.bak`);
+  if (existed) {
+    const bak = await writeBackup(file);
+    console.log(`Backup: ${bak}`);
   }
 
-  await writeFile(file, next, "utf8");
+  await atomicWrite(file, next);
 }

--- a/scripts/installer/preflight.ts
+++ b/scripts/installer/preflight.ts
@@ -5,14 +5,22 @@ import { execFile as execFileCb } from "node:child_process";
 
 const execFile = promisify(execFileCb);
 
+// Do not call onPath() with user-controlled input. `binary` is passed as a
+// positional arg to /bin/sh -c, which is safe for literal callers (jq, docker)
+// but would enable injection if the caller is ever user-controlled.
 async function onPath(binary: string): Promise<boolean> {
   try {
     await execFile("/bin/sh", ["-c", 'command -v "$1"', "--", binary], {
       env: { ...process.env },
     });
     return true;
-  } catch {
-    return false;
+  } catch (e) {
+    const code = (e as { code?: number | string }).code;
+    if (code === 1) return false;
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`Failed to probe PATH for '${binary}': ${msg}`, {
+      cause: e,
+    });
   }
 }
 
@@ -41,6 +49,11 @@ export async function checkTargetDirWritable(dir: string): Promise<void> {
 }
 
 export async function checkDockerWarn(): Promise<string | null> {
-  if (await onPath("docker")) return null;
+  try {
+    if (await onPath("docker")) return null;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return `docker probe failed: ${msg}`;
+  }
   return "docker not found on PATH. You'll need it to run the server (see post-install instructions).";
 }

--- a/scripts/installer/preflight.ts
+++ b/scripts/installer/preflight.ts
@@ -15,8 +15,12 @@ async function onPath(binary: string): Promise<boolean> {
     });
     return true;
   } catch (e) {
+    // Any numeric exit code means the shell ran and `command -v` reported
+    // not-found. Shells differ on the exact code: bash returns 1, dash returns
+    // 127. Non-numeric `.code` (e.g. ENOENT when /bin/sh is missing) is a real
+    // probe failure and rethrows.
     const code = (e as { code?: number | string }).code;
-    if (code === 1) return false;
+    if (typeof code === "number") return false;
     const msg = e instanceof Error ? e.message : String(e);
     throw new Error(`Failed to probe PATH for '${binary}': ${msg}`, {
       cause: e,

--- a/scripts/installer/preflight.ts
+++ b/scripts/installer/preflight.ts
@@ -1,0 +1,46 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { execFile as execFileCb } from "node:child_process";
+
+const execFile = promisify(execFileCb);
+
+async function onPath(binary: string): Promise<boolean> {
+  try {
+    await execFile("/bin/sh", ["-c", `command -v ${binary}`], {
+      env: { ...process.env },
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function checkJq(): Promise<void> {
+  if (await onPath("jq")) return;
+  throw new Error(
+    "jq not found. Install: brew install jq (macOS) or apt install jq (Linux).",
+  );
+}
+
+export async function checkTargetDirWritable(dir: string): Promise<void> {
+  try {
+    await mkdir(dir, { recursive: true });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`${dir} not writable: ${msg}`, { cause: e });
+  }
+  const probe = join(dir, `.agent-brain-probe-${process.pid}`);
+  try {
+    await writeFile(probe, "", "utf8");
+    await rm(probe, { force: true });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`${dir} not writable: ${msg}`, { cause: e });
+  }
+}
+
+export async function checkDockerWarn(): Promise<string | null> {
+  if (await onPath("docker")) return null;
+  return "docker not found on PATH. You'll need it to run the server (see post-install instructions).";
+}

--- a/scripts/installer/preflight.ts
+++ b/scripts/installer/preflight.ts
@@ -7,7 +7,7 @@ const execFile = promisify(execFileCb);
 
 async function onPath(binary: string): Promise<boolean> {
   try {
-    await execFile("/bin/sh", ["-c", `command -v ${binary}`], {
+    await execFile("/bin/sh", ["-c", 'command -v "$1"', "--", binary], {
       env: { ...process.env },
     });
     return true;

--- a/scripts/installer/targets/claude.ts
+++ b/scripts/installer/targets/claude.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import type { Target, InstallPlan } from "../types.js";
+import { makeMarkerId } from "../types.js";
 import {
   checkJq,
   checkTargetDirWritable,
@@ -7,23 +8,23 @@ import {
 } from "../preflight.js";
 import { describePlan } from "./shared.js";
 
-const HOOK_SCRIPTS = [
+export const HOOK_SCRIPTS = [
   "memory-session-start.sh",
   "memory-guard.sh",
   "memory-autofill.sh",
   "memory-nudge.sh",
   "memory-session-review.sh",
-];
+] as const;
 
 export const claudeTarget: Target = {
   name: "claude",
 
-  async preflight() {
+  async preflight(home: string) {
     await checkJq();
     const warn = await checkDockerWarn();
     if (warn) console.warn(`WARN: ${warn}`);
-    await checkTargetDirWritable(`${process.env.HOME ?? ""}/.claude`);
-    await checkTargetDirWritable(`${process.env.HOME ?? ""}/.claude/hooks`);
+    await checkTargetDirWritable(join(home, ".claude"));
+    await checkTargetDirWritable(join(home, ".claude", "hooks"));
   },
 
   plan(repoRoot: string, home: string): InstallPlan {
@@ -53,14 +54,14 @@ export const claudeTarget: Target = {
       jsonMerges: [
         {
           file: join(home, ".claude", "settings.json"),
-          patch: { __fromFile: snippetPath },
+          patch: { kind: "file", path: snippetPath },
         },
       ],
       markdownPrepends: [
         {
           file: join(home, ".claude", "CLAUDE.md"),
-          snippet: `__fromFile:${mdSnippetPath}`,
-          markerId: "agent-brain",
+          snippet: { kind: "file", path: mdSnippetPath },
+          markerId: makeMarkerId("agent-brain"),
         },
       ],
       postInstructions: [

--- a/scripts/installer/targets/claude.ts
+++ b/scripts/installer/targets/claude.ts
@@ -5,6 +5,7 @@ import {
   checkTargetDirWritable,
   checkDockerWarn,
 } from "../preflight.js";
+import { describePlan } from "./shared.js";
 
 const HOOK_SCRIPTS = [
   "memory-session-start.sh",
@@ -70,12 +71,5 @@ export const claudeTarget: Target = {
     };
   },
 
-  describe(plan: InstallPlan): string {
-    const lines: string[] = [`Target: ${plan.target}`];
-    for (const c of plan.copies) lines.push(`  copy  ${c.src} → ${c.dest}`);
-    for (const m of plan.jsonMerges) lines.push(`  merge ${m.file}`);
-    for (const p of plan.markdownPrepends)
-      lines.push(`  prepend ${p.file} [${p.markerId}]`);
-    return lines.join("\n");
-  },
+  describe: describePlan,
 };

--- a/scripts/installer/targets/claude.ts
+++ b/scripts/installer/targets/claude.ts
@@ -1,5 +1,4 @@
 import { join } from "node:path";
-import { readFile } from "node:fs/promises";
 import type { Target, InstallPlan } from "../types.js";
 import {
   checkJq,
@@ -80,12 +79,3 @@ export const claudeTarget: Target = {
     return lines.join("\n");
   },
 };
-
-export async function loadSnippetJson(path: string): Promise<unknown> {
-  const raw = await readFile(path, "utf8");
-  return JSON.parse(raw);
-}
-
-export async function loadSnippetText(path: string): Promise<string> {
-  return readFile(path, "utf8");
-}

--- a/scripts/installer/targets/claude.ts
+++ b/scripts/installer/targets/claude.ts
@@ -1,0 +1,91 @@
+import { join } from "node:path";
+import { readFile } from "node:fs/promises";
+import type { Target, InstallPlan } from "../types.js";
+import {
+  checkJq,
+  checkTargetDirWritable,
+  checkDockerWarn,
+} from "../preflight.js";
+
+const HOOK_SCRIPTS = [
+  "memory-session-start.sh",
+  "memory-guard.sh",
+  "memory-autofill.sh",
+  "memory-nudge.sh",
+  "memory-session-review.sh",
+];
+
+export const claudeTarget: Target = {
+  name: "claude",
+
+  async preflight() {
+    await checkJq();
+    const warn = await checkDockerWarn();
+    if (warn) console.warn(`WARN: ${warn}`);
+    await checkTargetDirWritable(`${process.env.HOME ?? ""}/.claude`);
+    await checkTargetDirWritable(`${process.env.HOME ?? ""}/.claude/hooks`);
+  },
+
+  plan(repoRoot: string, home: string): InstallPlan {
+    const hooksDir = join(home, ".claude", "hooks");
+    const copies = HOOK_SCRIPTS.map((name) => ({
+      src: join(repoRoot, "hooks", "claude", name),
+      dest: join(hooksDir, name),
+      mode: 0o755,
+    }));
+
+    const snippetPath = join(
+      repoRoot,
+      "hooks",
+      "claude",
+      "settings-snippet.json",
+    );
+    const mdSnippetPath = join(
+      repoRoot,
+      "hooks",
+      "claude",
+      "claude-md-snippet.md",
+    );
+
+    return {
+      target: "claude",
+      copies,
+      jsonMerges: [
+        {
+          file: join(home, ".claude", "settings.json"),
+          patch: { __fromFile: snippetPath },
+        },
+      ],
+      markdownPrepends: [
+        {
+          file: join(home, ".claude", "CLAUDE.md"),
+          snippet: `__fromFile:${mdSnippetPath}`,
+          markerId: "agent-brain",
+        },
+      ],
+      postInstructions: [
+        "Start the Agent Brain server:",
+        "  docker compose -f docker-compose.prod.yml up -d --wait",
+        "Override the MCP URL if needed: export AGENT_BRAIN_URL=http://host:port",
+      ],
+    };
+  },
+
+  describe(plan: InstallPlan): string {
+    const lines: string[] = [`Target: ${plan.target}`];
+    for (const c of plan.copies) lines.push(`  copy  ${c.src} → ${c.dest}`);
+    for (const m of plan.jsonMerges) lines.push(`  merge ${m.file}`);
+    for (const p of plan.markdownPrepends)
+      lines.push(`  prepend ${p.file} [${p.markerId}]`);
+    return lines.join("\n");
+  },
+};
+
+export async function loadSnippetJson(path: string): Promise<unknown> {
+  const raw = await readFile(path, "utf8");
+  return JSON.parse(raw);
+}
+
+export async function loadSnippetText(path: string): Promise<string> {
+  return readFile(path, "utf8");
+}

--- a/scripts/installer/targets/copilot.ts
+++ b/scripts/installer/targets/copilot.ts
@@ -5,6 +5,7 @@ import {
   checkTargetDirWritable,
   checkDockerWarn,
 } from "../preflight.js";
+import { describePlan } from "./shared.js";
 
 const HOOK_SCRIPTS = [
   "memory-session-start.sh",
@@ -67,12 +68,5 @@ export const copilotTarget: Target = {
     };
   },
 
-  describe(plan: InstallPlan): string {
-    const lines: string[] = [`Target: ${plan.target}`];
-    for (const c of plan.copies) lines.push(`  copy  ${c.src} → ${c.dest}`);
-    for (const m of plan.jsonMerges) lines.push(`  merge ${m.file}`);
-    for (const p of plan.markdownPrepends)
-      lines.push(`  prepend ${p.file} [${p.markerId}]`);
-    return lines.join("\n");
-  },
+  describe: describePlan,
 };

--- a/scripts/installer/targets/copilot.ts
+++ b/scripts/installer/targets/copilot.ts
@@ -1,0 +1,78 @@
+import { join } from "node:path";
+import type { Target, InstallPlan } from "../types.js";
+import {
+  checkJq,
+  checkTargetDirWritable,
+  checkDockerWarn,
+} from "../preflight.js";
+
+const HOOK_SCRIPTS = [
+  "memory-session-start.sh",
+  "memory-pretool.sh",
+  "memory-session-end.sh",
+];
+
+export const copilotTarget: Target = {
+  name: "copilot",
+
+  async preflight() {
+    await checkJq();
+    const warn = await checkDockerWarn();
+    if (warn) console.warn(`WARN: ${warn}`);
+    await checkTargetDirWritable(`${process.env.HOME ?? ""}/.copilot`);
+    await checkTargetDirWritable(`${process.env.HOME ?? ""}/.copilot/hooks`);
+  },
+
+  plan(repoRoot: string, home: string): InstallPlan {
+    const hooksDir = join(home, ".copilot", "hooks");
+    const copies = HOOK_SCRIPTS.map((name) => ({
+      src: join(repoRoot, "hooks", "copilot", name),
+      dest: join(hooksDir, name),
+      mode: 0o755,
+    }));
+
+    const mcpSnippet = join(repoRoot, "hooks", "copilot", "mcp-snippet.json");
+    const hooksSnippet = join(repoRoot, "hooks", "copilot", "hooks.json");
+    const instructionsSnippet = join(
+      repoRoot,
+      "hooks",
+      "copilot",
+      "instructions-snippet.md",
+    );
+
+    return {
+      target: "copilot",
+      copies,
+      jsonMerges: [
+        {
+          file: join(home, ".copilot", "mcp-config.json"),
+          patch: { __fromFile: mcpSnippet },
+        },
+        {
+          file: join(home, ".copilot", "hooks", "hooks.json"),
+          patch: { __fromFile: hooksSnippet },
+        },
+      ],
+      markdownPrepends: [
+        {
+          file: join(home, ".copilot", "copilot-instructions.md"),
+          snippet: `__fromFile:${instructionsSnippet}`,
+          markerId: "agent-brain",
+        },
+      ],
+      postInstructions: [
+        "Start the Agent Brain server:",
+        "  docker compose -f docker-compose.prod.yml up -d --wait",
+      ],
+    };
+  },
+
+  describe(plan: InstallPlan): string {
+    const lines: string[] = [`Target: ${plan.target}`];
+    for (const c of plan.copies) lines.push(`  copy  ${c.src} → ${c.dest}`);
+    for (const m of plan.jsonMerges) lines.push(`  merge ${m.file}`);
+    for (const p of plan.markdownPrepends)
+      lines.push(`  prepend ${p.file} [${p.markerId}]`);
+    return lines.join("\n");
+  },
+};

--- a/scripts/installer/targets/copilot.ts
+++ b/scripts/installer/targets/copilot.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import type { Target, InstallPlan } from "../types.js";
+import { makeMarkerId } from "../types.js";
 import {
   checkJq,
   checkTargetDirWritable,
@@ -7,21 +8,21 @@ import {
 } from "../preflight.js";
 import { describePlan } from "./shared.js";
 
-const HOOK_SCRIPTS = [
+export const HOOK_SCRIPTS = [
   "memory-session-start.sh",
   "memory-pretool.sh",
   "memory-session-end.sh",
-];
+] as const;
 
 export const copilotTarget: Target = {
   name: "copilot",
 
-  async preflight() {
+  async preflight(home: string) {
     await checkJq();
     const warn = await checkDockerWarn();
     if (warn) console.warn(`WARN: ${warn}`);
-    await checkTargetDirWritable(`${process.env.HOME ?? ""}/.copilot`);
-    await checkTargetDirWritable(`${process.env.HOME ?? ""}/.copilot/hooks`);
+    await checkTargetDirWritable(join(home, ".copilot"));
+    await checkTargetDirWritable(join(home, ".copilot", "hooks"));
   },
 
   plan(repoRoot: string, home: string): InstallPlan {
@@ -47,18 +48,18 @@ export const copilotTarget: Target = {
       jsonMerges: [
         {
           file: join(home, ".copilot", "mcp-config.json"),
-          patch: { __fromFile: mcpSnippet },
+          patch: { kind: "file", path: mcpSnippet },
         },
         {
           file: join(home, ".copilot", "hooks", "hooks.json"),
-          patch: { __fromFile: hooksSnippet },
+          patch: { kind: "file", path: hooksSnippet },
         },
       ],
       markdownPrepends: [
         {
           file: join(home, ".copilot", "copilot-instructions.md"),
-          snippet: `__fromFile:${instructionsSnippet}`,
-          markerId: "agent-brain",
+          snippet: { kind: "file", path: instructionsSnippet },
+          markerId: makeMarkerId("agent-brain"),
         },
       ],
       postInstructions: [

--- a/scripts/installer/targets/shared.ts
+++ b/scripts/installer/targets/shared.ts
@@ -1,0 +1,10 @@
+import type { InstallPlan } from "../types.js";
+
+export function describePlan(plan: InstallPlan): string {
+  const lines: string[] = [`Target: ${plan.target}`];
+  for (const c of plan.copies) lines.push(`  copy  ${c.src} → ${c.dest}`);
+  for (const m of plan.jsonMerges) lines.push(`  merge ${m.file}`);
+  for (const p of plan.markdownPrepends)
+    lines.push(`  prepend ${p.file} [${p.markerId}]`);
+  return lines.join("\n");
+}

--- a/scripts/installer/targets/shared.ts
+++ b/scripts/installer/targets/shared.ts
@@ -3,8 +3,13 @@ import type { InstallPlan } from "../types.js";
 export function describePlan(plan: InstallPlan): string {
   const lines: string[] = [`Target: ${plan.target}`];
   for (const c of plan.copies) lines.push(`  copy  ${c.src} → ${c.dest}`);
-  for (const m of plan.jsonMerges) lines.push(`  merge ${m.file}`);
-  for (const p of plan.markdownPrepends)
-    lines.push(`  prepend ${p.file} [${p.markerId}]`);
+  for (const m of plan.jsonMerges) {
+    const src = m.patch.kind === "file" ? ` (from ${m.patch.path})` : "";
+    lines.push(`  merge ${m.file}${src}`);
+  }
+  for (const p of plan.markdownPrepends) {
+    const src = p.snippet.kind === "file" ? ` (from ${p.snippet.path})` : "";
+    lines.push(`  prepend ${p.file} [${p.markerId}]${src}`);
+  }
   return lines.join("\n");
 }

--- a/scripts/installer/types.ts
+++ b/scripts/installer/types.ts
@@ -34,7 +34,6 @@ export interface Target {
 
 export interface RunOptions {
   dryRun: boolean;
-  yes: boolean;
   uninstall: boolean;
   targets: TargetName[];
 }

--- a/scripts/installer/types.ts
+++ b/scripts/installer/types.ts
@@ -1,5 +1,22 @@
 export type TargetName = "claude" | "copilot";
 
+export type MarkerId = string & { readonly __brand: "MarkerId" };
+
+const MARKER_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
+
+export function makeMarkerId(id: string): MarkerId {
+  if (!MARKER_ID_RE.test(id)) {
+    throw new Error(
+      `Invalid markerId '${id}': must match ${MARKER_ID_RE.source}`,
+    );
+  }
+  return id as MarkerId;
+}
+
+export type Source<T> =
+  | { kind: "inline"; value: T }
+  | { kind: "file"; path: string };
+
 export interface CopyAction {
   src: string;
   dest: string;
@@ -8,13 +25,13 @@ export interface CopyAction {
 
 export interface JsonMergeAction {
   file: string;
-  patch: unknown;
+  patch: Source<unknown>;
 }
 
 export interface MarkdownPrependAction {
   file: string;
-  snippet: string;
-  markerId: string;
+  snippet: Source<string>;
+  markerId: MarkerId;
 }
 
 export interface InstallPlan {
@@ -27,7 +44,7 @@ export interface InstallPlan {
 
 export interface Target {
   name: TargetName;
-  preflight(): Promise<void>;
+  preflight(home: string): Promise<void>;
   plan(repoRoot: string, home: string): InstallPlan;
   describe(plan: InstallPlan): string;
 }

--- a/scripts/installer/types.ts
+++ b/scripts/installer/types.ts
@@ -1,0 +1,40 @@
+export type TargetName = "claude" | "copilot";
+
+export interface CopyAction {
+  src: string;
+  dest: string;
+  mode?: number;
+}
+
+export interface JsonMergeAction {
+  file: string;
+  patch: unknown;
+}
+
+export interface MarkdownPrependAction {
+  file: string;
+  snippet: string;
+  markerId: string;
+}
+
+export interface InstallPlan {
+  target: TargetName;
+  copies: CopyAction[];
+  jsonMerges: JsonMergeAction[];
+  markdownPrepends: MarkdownPrependAction[];
+  postInstructions: string[];
+}
+
+export interface Target {
+  name: TargetName;
+  preflight(): Promise<void>;
+  plan(repoRoot: string, home: string): InstallPlan;
+  describe(plan: InstallPlan): string;
+}
+
+export interface RunOptions {
+  dryRun: boolean;
+  yes: boolean;
+  uninstall: boolean;
+  targets: TargetName[];
+}

--- a/scripts/installer/uninstall.ts
+++ b/scripts/installer/uninstall.ts
@@ -1,10 +1,124 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import type { Target } from "./types.js";
+import { rm, readFile, writeFile, access } from "node:fs/promises";
+import { constants } from "node:fs";
+import type { Target, InstallPlan } from "./types.js";
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await access(p, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function stripAgentBrainFromJson(
+  value: unknown,
+  hookPathPattern: RegExp,
+): unknown {
+  if (Array.isArray(value)) {
+    const filtered: unknown[] = [];
+    for (const item of value) {
+      const cleaned = stripAgentBrainFromJson(item, hookPathPattern);
+      if (
+        cleaned !== null &&
+        typeof cleaned === "object" &&
+        !Array.isArray(cleaned) &&
+        "hooks" in (cleaned as Record<string, unknown>) &&
+        Array.isArray((cleaned as { hooks: unknown[] }).hooks) &&
+        (cleaned as { hooks: unknown[] }).hooks.length === 0
+      ) {
+        continue;
+      }
+      if (
+        cleaned !== null &&
+        typeof cleaned === "object" &&
+        !Array.isArray(cleaned) &&
+        typeof (cleaned as { command?: unknown }).command === "string" &&
+        hookPathPattern.test((cleaned as { command: string }).command)
+      ) {
+        continue;
+      }
+      if (
+        cleaned !== null &&
+        typeof cleaned === "object" &&
+        !Array.isArray(cleaned) &&
+        typeof (cleaned as { bash?: unknown }).bash === "string" &&
+        hookPathPattern.test((cleaned as { bash: string }).bash)
+      ) {
+        continue;
+      }
+      filtered.push(cleaned);
+    }
+    return filtered;
+  }
+  if (value !== null && typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(obj)) {
+      if (k === "agent-brain") continue;
+      out[k] = stripAgentBrainFromJson(v, hookPathPattern);
+    }
+    return out;
+  }
+  return value;
+}
+
+function stripMarkerBlock(content: string, id: string): string {
+  const start = `<!-- ${id}:start -->`;
+  const end = `<!-- ${id}:end -->`;
+  const s = content.indexOf(start);
+  const e = content.indexOf(end);
+  if (s === -1 || e === -1 || e < s) return content;
+  const afterRaw = content.slice(e + end.length);
+  const after = afterRaw.startsWith("\n") ? afterRaw.slice(1) : afterRaw;
+  return content.slice(0, s) + after;
+}
 
 export async function uninstallTarget(
-  _target: Target,
-  _home: string,
-  _opts: { dryRun: boolean },
+  target: Target,
+  home: string,
+  opts: { dryRun: boolean },
 ): Promise<void> {
-  throw new Error("uninstall not implemented yet");
+  const plan: InstallPlan = target.plan(process.cwd(), home);
+  const hookPathPattern = /memory-[a-z-]+\.sh/;
+
+  for (const c of plan.copies) {
+    if (opts.dryRun) {
+      console.log(`[dry-run] rm ${c.dest}`);
+      continue;
+    }
+    await rm(c.dest, { force: true });
+  }
+
+  for (const m of plan.jsonMerges) {
+    if (!(await fileExists(m.file))) continue;
+    if (opts.dryRun) {
+      console.log(`[dry-run] clean ${m.file}`);
+      continue;
+    }
+    const raw = await readFile(m.file, "utf8");
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+    const stripped = stripAgentBrainFromJson(parsed, hookPathPattern);
+    await writeFile(m.file, JSON.stringify(stripped, null, 2) + "\n", "utf8");
+  }
+
+  for (const p of plan.markdownPrepends) {
+    if (!(await fileExists(p.file))) continue;
+    if (opts.dryRun) {
+      console.log(`[dry-run] strip markers in ${p.file}`);
+      continue;
+    }
+    const content = await readFile(p.file, "utf8");
+    const stripped = stripMarkerBlock(content, p.markerId);
+    await writeFile(p.file, stripped, "utf8");
+  }
+
+  console.log(
+    `Uninstalled ${target.name}. If the server is running: docker compose down`,
+  );
 }

--- a/scripts/installer/uninstall.ts
+++ b/scripts/installer/uninstall.ts
@@ -1,62 +1,87 @@
-import { rm, readFile, writeFile, access } from "node:fs/promises";
-import { constants } from "node:fs";
+import { rm, readFile } from "node:fs/promises";
 import type { Target, InstallPlan } from "./types.js";
+import { HOOK_SCRIPTS as CLAUDE_HOOKS } from "./targets/claude.js";
+import { HOOK_SCRIPTS as COPILOT_HOOKS } from "./targets/copilot.js";
+import { atomicWrite, fileExists, writeBackup } from "./fs-util.js";
 
-async function fileExists(p: string): Promise<boolean> {
-  try {
-    await access(p, constants.F_OK);
-    return true;
-  } catch {
-    return false;
-  }
+function hookNamesFor(targetName: string): readonly string[] {
+  if (targetName === "claude") return CLAUDE_HOOKS;
+  if (targetName === "copilot") return COPILOT_HOOKS;
+  return [];
+}
+
+function hookPathMatches(
+  path: string,
+  targetName: string,
+  hookNames: readonly string[],
+): boolean {
+  const dirFragment =
+    targetName === "claude" ? "/.claude/hooks/" : "/.copilot/hooks/";
+  if (!path.includes(dirFragment)) return false;
+  return hookNames.some((name) => path.endsWith(`/${name}`));
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+// An array item should be dropped when:
+//  - its cleaned form is an agent-brain hook entry (command/bash points at one
+//    of our scripts), or
+//  - it was a non-empty object that stripping hollowed out to {} (e.g. a hook
+//    group whose only key was a hooks array that got pruned), or
+//  - it still carries an empty hooks: [] (group that started with empty hooks,
+//    or a group the object-branch didn't prune for some reason).
+function shouldDropArrayItem(
+  original: unknown,
+  cleaned: unknown,
+  matchesHookPath: (p: string) => boolean,
+): boolean {
+  if (!isPlainObject(cleaned)) return false;
+
+  const command = cleaned.command;
+  if (typeof command === "string" && matchesHookPath(command)) return true;
+
+  const bash = cleaned.bash;
+  if (typeof bash === "string" && matchesHookPath(bash)) return true;
+
+  const hooks = cleaned.hooks;
+  if (Array.isArray(hooks) && hooks.length === 0) return true;
+
+  const hollowed =
+    Object.keys(cleaned).length === 0 &&
+    isPlainObject(original) &&
+    Object.keys(original).length > 0;
+  return hollowed;
 }
 
 function stripAgentBrainFromJson(
   value: unknown,
-  hookPathPattern: RegExp,
+  matchesHookPath: (p: string) => boolean,
 ): unknown {
   if (Array.isArray(value)) {
     const filtered: unknown[] = [];
     for (const item of value) {
-      const cleaned = stripAgentBrainFromJson(item, hookPathPattern);
-      if (
-        cleaned !== null &&
-        typeof cleaned === "object" &&
-        !Array.isArray(cleaned) &&
-        "hooks" in (cleaned as Record<string, unknown>) &&
-        Array.isArray((cleaned as { hooks: unknown[] }).hooks) &&
-        (cleaned as { hooks: unknown[] }).hooks.length === 0
-      ) {
-        continue;
-      }
-      if (
-        cleaned !== null &&
-        typeof cleaned === "object" &&
-        !Array.isArray(cleaned) &&
-        typeof (cleaned as { command?: unknown }).command === "string" &&
-        hookPathPattern.test((cleaned as { command: string }).command)
-      ) {
-        continue;
-      }
-      if (
-        cleaned !== null &&
-        typeof cleaned === "object" &&
-        !Array.isArray(cleaned) &&
-        typeof (cleaned as { bash?: unknown }).bash === "string" &&
-        hookPathPattern.test((cleaned as { bash: string }).bash)
-      ) {
-        continue;
-      }
+      const cleaned = stripAgentBrainFromJson(item, matchesHookPath);
+      if (shouldDropArrayItem(item, cleaned, matchesHookPath)) continue;
       filtered.push(cleaned);
     }
     return filtered;
   }
-  if (value !== null && typeof value === "object") {
-    const obj = value as Record<string, unknown>;
+  if (isPlainObject(value)) {
     const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(obj)) {
+    for (const [k, v] of Object.entries(value)) {
       if (k === "agent-brain") continue;
-      out[k] = stripAgentBrainFromJson(v, hookPathPattern);
+      const cleaned = stripAgentBrainFromJson(v, matchesHookPath);
+      // Drop keys whose array value went empty as a result of stripping.
+      // Preserves foreign keys that were already [] on entry.
+      const arrayEmptied =
+        Array.isArray(v) &&
+        v.length > 0 &&
+        Array.isArray(cleaned) &&
+        cleaned.length === 0;
+      if (arrayEmptied) continue;
+      out[k] = cleaned;
     }
     return out;
   }
@@ -76,20 +101,20 @@ function stripMarkerBlock(content: string, id: string): string {
 
 export async function uninstallTarget(
   target: Target,
+  repoRoot: string,
   home: string,
   opts: { dryRun: boolean },
 ): Promise<void> {
-  const plan: InstallPlan = target.plan(process.cwd(), home);
-  const hookPathPattern = /memory-[a-z-]+\.sh/;
+  const plan: InstallPlan = target.plan(repoRoot, home);
+  const hookNames = hookNamesFor(target.name);
+  const matchesHookPath = (p: string): boolean =>
+    hookPathMatches(p, target.name, hookNames);
 
-  for (const c of plan.copies) {
-    if (opts.dryRun) {
-      console.log(`[dry-run] rm ${c.dest}`);
-      continue;
-    }
-    await rm(c.dest, { force: true });
-  }
+  let incomplete = false;
 
+  // Strip config references BEFORE removing the scripts. If config-strip fails,
+  // re-running uninstall can still clean up. If we did it the other way, a
+  // failure would leave dangling hook refs pointing at deleted files.
   for (const m of plan.jsonMerges) {
     if (!(await fileExists(m.file))) continue;
     if (opts.dryRun) {
@@ -100,12 +125,18 @@ export async function uninstallTarget(
     let parsed: unknown;
     try {
       parsed = JSON.parse(raw);
-    } catch {
-      console.warn(`WARN: skipping ${m.file} (invalid JSON)`);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn(
+        `WARN: ${m.file}: invalid JSON (${msg}) — skipping clean. Restore manually or inspect .bak siblings.`,
+      );
+      incomplete = true;
       continue;
     }
-    const stripped = stripAgentBrainFromJson(parsed, hookPathPattern);
-    await writeFile(m.file, JSON.stringify(stripped, null, 2) + "\n", "utf8");
+    const stripped = stripAgentBrainFromJson(parsed, matchesHookPath);
+    const bak = await writeBackup(m.file);
+    console.log(`Backup: ${bak}`);
+    await atomicWrite(m.file, JSON.stringify(stripped, null, 2) + "\n");
   }
 
   for (const p of plan.markdownPrepends) {
@@ -116,10 +147,32 @@ export async function uninstallTarget(
     }
     const content = await readFile(p.file, "utf8");
     const stripped = stripMarkerBlock(content, p.markerId);
-    await writeFile(p.file, stripped, "utf8");
+    const bak = await writeBackup(p.file);
+    console.log(`Backup: ${bak}`);
+    await atomicWrite(p.file, stripped);
+  }
+
+  for (const c of plan.copies) {
+    if (opts.dryRun) {
+      console.log(`[dry-run] rm ${c.dest}`);
+      continue;
+    }
+    try {
+      await rm(c.dest);
+    } catch (e) {
+      const code = (e as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") continue;
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn(`WARN: failed to remove ${c.dest}: ${msg}`);
+      incomplete = true;
+    }
   }
 
   console.log(
     `Uninstalled ${target.name}. If the server is running: docker compose down`,
   );
+
+  if (incomplete) {
+    process.exitCode = 3;
+  }
 }

--- a/scripts/installer/uninstall.ts
+++ b/scripts/installer/uninstall.ts
@@ -1,0 +1,10 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import type { Target } from "./types.js";
+
+export async function uninstallTarget(
+  _target: Target,
+  _home: string,
+  _opts: { dryRun: boolean },
+): Promise<void> {
+  throw new Error("uninstall not implemented yet");
+}

--- a/scripts/installer/uninstall.ts
+++ b/scripts/installer/uninstall.ts
@@ -101,6 +101,7 @@ export async function uninstallTarget(
     try {
       parsed = JSON.parse(raw);
     } catch {
+      console.warn(`WARN: skipping ${m.file} (invalid JSON)`);
       continue;
     }
     const stripped = stripAgentBrainFromJson(parsed, hookPathPattern);

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -2,7 +2,7 @@ import "dotenv/config";
 import { createDb } from "../src/db/index.js";
 import { runMigrations } from "../src/db/migrate.js";
 import { DrizzleMemoryRepository } from "../src/repositories/memory-repository.js";
-import { DrizzleProjectRepository } from "../src/repositories/project-repository.js";
+import { DrizzleWorkspaceRepository } from "../src/repositories/workspace-repository.js";
 import { MockEmbeddingProvider } from "../src/providers/embedding/mock.js";
 import { MemoryService } from "../src/services/memory-service.js";
 import type { MemoryCreate } from "../src/types/memory.js";
@@ -11,6 +11,8 @@ const DATABASE_URL =
   process.env.DATABASE_URL ??
   "postgresql://agentic:agentic@localhost:5432/agent_brain";
 
+const PROJECT_ID = "agent-brain";
+
 async function seed() {
   console.error("[seed] Connecting to database...");
 
@@ -18,27 +20,36 @@ async function seed() {
   await runMigrations(db);
 
   const memoryRepo = new DrizzleMemoryRepository(db);
-  const projectRepo = new DrizzleProjectRepository(db);
+  const workspaceRepo = new DrizzleWorkspaceRepository(db);
   const embedder = new MockEmbeddingProvider();
-  const service = new MemoryService(memoryRepo, projectRepo, embedder);
+  const service = new MemoryService(
+    memoryRepo,
+    workspaceRepo,
+    embedder,
+    PROJECT_ID,
+  );
 
   let totalCreated = 0;
-  const projectsCreated = new Set<string>();
+  const workspacesCreated = new Set<string>();
 
   async function createMemory(input: MemoryCreate): Promise<void> {
     const result = await service.create(input);
-    projectsCreated.add(input.project_id);
+    if (input.workspace_id) workspacesCreated.add(input.workspace_id);
     totalCreated++;
-    console.error(
-      `  [${totalCreated}] ${result.data.id} - "${result.data.title}"`,
-    );
+    if ("skipped" in result.data) {
+      console.error(`  [${totalCreated}] skipped: ${result.data.reason}`);
+    } else {
+      console.error(
+        `  [${totalCreated}] ${result.data.id} - "${result.data.title}"`,
+      );
+    }
   }
 
-  // --- Project 1: agent-brain (8 memories covering all types) ---
-  console.error("\n[seed] Creating memories for project: agent-brain");
+  // --- Workspace 1: agent-brain (8 memories covering all types) ---
+  console.error("\n[seed] Creating memories for workspace: agent-brain");
 
   await createMemory({
-    project_id: "agent-brain",
+    workspace_id: "agent-brain",
     content:
       "PostgreSQL 17 with pgvector 0.8.x supports HNSW indexes for fast similarity search. Iterative index scans in 0.8.0 fix filtered search accuracy issues and provide up to 5.7x query performance improvement.",
     type: "fact",
@@ -48,7 +59,7 @@ async function seed() {
   });
 
   await createMemory({
-    project_id: "agent-brain",
+    workspace_id: "agent-brain",
     content:
       "Using 512 dimensions for embeddings -- retains 99% accuracy of 1024 at half the storage cost. Each vector takes 2KB. This is the best balance of accuracy, storage, and HNSW index build performance.",
     type: "decision",
@@ -58,7 +69,7 @@ async function seed() {
   });
 
   await createMemory({
-    project_id: "agent-brain",
+    workspace_id: "agent-brain",
     content:
       "console.log in MCP stdio servers corrupts JSON-RPC framing because stdout is the transport channel. Always use console.error for debug output -- it writes to stderr and doesn't interfere with the protocol.",
     type: "learning",
@@ -69,7 +80,7 @@ async function seed() {
   });
 
   await createMemory({
-    project_id: "agent-brain",
+    workspace_id: "agent-brain",
     content:
       "All MCP tool responses use envelope format: { data, meta: { count, timing } }. The data field contains the actual response payload, meta.timing is milliseconds for the operation, and meta.count is present for list/search results.",
     type: "pattern",
@@ -79,7 +90,7 @@ async function seed() {
   });
 
   await createMemory({
-    project_id: "agent-brain",
+    workspace_id: "agent-brain",
     content:
       "Use nanoid for ID generation -- 21 chars, URL-safe, 148 bits of entropy. Faster and smaller than UUID. Import from nanoid package: import { nanoid } from 'nanoid'; const id = nanoid();",
     type: "preference",
@@ -89,7 +100,7 @@ async function seed() {
   });
 
   await createMemory({
-    project_id: "agent-brain",
+    workspace_id: "agent-brain",
     content:
       "Layered architecture: transport (MCP stdio) -> tools (Zod schemas) -> services (business logic) -> repositories (data access) -> database (Drizzle + Postgres). Each layer only depends on the one below it. Tools never touch the database directly.",
     type: "architecture",
@@ -99,7 +110,7 @@ async function seed() {
   });
 
   await createMemory({
-    project_id: "agent-brain",
+    workspace_id: "agent-brain",
     content:
       "Optimistic locking via version column prevents concurrent update conflicts. Every update must include the expected version number. If it doesn't match, the update fails with ConflictError (409). The client must re-read and retry.",
     type: "decision",
@@ -109,7 +120,7 @@ async function seed() {
   });
 
   await createMemory({
-    project_id: "agent-brain",
+    workspace_id: "agent-brain",
     content:
       "Amazon Titan Text Embeddings V2 costs $0.02 per million tokens. Model ID: amazon.titan-embed-text-v2:0. Supports 8192 token input and configurable output dimensions (256/512/1024). Outputs unit-normalized vectors optimized for cosine similarity.",
     type: "fact",
@@ -118,11 +129,11 @@ async function seed() {
     source: "manual",
   });
 
-  // --- Project 2: side-project (2 memories) ---
-  console.error("\n[seed] Creating memories for project: side-project");
+  // --- Workspace 2: side-project (2 memories) ---
+  console.error("\n[seed] Creating memories for workspace: side-project");
 
   await createMemory({
-    project_id: "side-project",
+    workspace_id: "side-project",
     content:
       "The side project uses React 19 with Server Components for the frontend. Data fetching happens server-side to reduce client bundle size and improve initial load performance.",
     type: "architecture",
@@ -132,7 +143,7 @@ async function seed() {
   });
 
   await createMemory({
-    project_id: "side-project",
+    workspace_id: "side-project",
     content:
       "Deploy the side project with Vercel -- automatic preview deployments on PRs, edge functions for API routes, and built-in analytics. The free tier covers our expected traffic.",
     type: "decision",
@@ -141,11 +152,11 @@ async function seed() {
     source: "manual",
   });
 
-  // --- User-scoped memory (visible across projects) ---
+  // --- User-scoped memory (visible across workspaces) ---
   console.error("\n[seed] Creating user-scoped memory for alice");
 
   await createMemory({
-    project_id: "agent-brain",
+    workspace_id: "agent-brain",
     content:
       "Alice prefers TypeScript strict mode with noUncheckedIndexedAccess enabled. Always use explicit return types on exported functions. Favor composition over inheritance.",
     type: "preference",
@@ -156,7 +167,7 @@ async function seed() {
   });
 
   console.error(
-    `\n[seed] Seeded ${totalCreated} memories across ${projectsCreated.size} projects`,
+    `\n[seed] Seeded ${totalCreated} memories across ${workspacesCreated.size} workspaces`,
   );
 
   await db.$client.end();

--- a/tests/unit/installer/home-validation.test.ts
+++ b/tests/unit/installer/home-validation.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { main } from "../../../scripts/installer/index.js";
+
+describe("HOME validation in main()", () => {
+  const originalHome = process.env.HOME;
+  let sandbox: string;
+
+  beforeEach(() => {
+    sandbox = mkdtempSync(join(tmpdir(), "abhv-"));
+  });
+  afterEach(() => {
+    process.env.HOME = originalHome;
+    rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  it("rejects unset HOME", async () => {
+    delete process.env.HOME;
+    await expect(main(["--target=claude", "--dry-run"])).rejects.toThrow(
+      /HOME environment variable is not set/,
+    );
+  });
+
+  it("rejects empty HOME", async () => {
+    process.env.HOME = "";
+    await expect(main(["--target=claude", "--dry-run"])).rejects.toThrow(
+      /HOME environment variable is not set/,
+    );
+  });
+
+  it("rejects filesystem root '/'", async () => {
+    process.env.HOME = "/";
+    await expect(main(["--target=claude", "--dry-run"])).rejects.toThrow(
+      /must not be filesystem root/,
+    );
+  });
+
+  it("rejects relative HOME", async () => {
+    process.env.HOME = "relative/path";
+    await expect(main(["--target=claude", "--dry-run"])).rejects.toThrow(
+      /must be an absolute path/,
+    );
+  });
+
+  it("rejects HOME that is not an existing directory", async () => {
+    process.env.HOME = join(sandbox, "does-not-exist");
+    await expect(main(["--target=claude", "--dry-run"])).rejects.toThrow(
+      /is not an existing directory/,
+    );
+  });
+
+  it("accepts a valid sandbox directory", async () => {
+    process.env.HOME = sandbox;
+    await expect(
+      main(["--target=claude", "--dry-run"]),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/installer/install.test.ts
+++ b/tests/unit/installer/install.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  statSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { runInstaller } from "../../../scripts/installer/index.js";
+
+const REPO_ROOT = process.cwd();
+
+describe("installer end-to-end", () => {
+  let home: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "abhome-"));
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("installs Claude target: copies hooks, merges settings, prepends CLAUDE.md", async () => {
+    await runInstaller(
+      { targets: ["claude"], dryRun: false, yes: true, uninstall: false },
+      { repoRoot: REPO_ROOT, home },
+    );
+
+    const hooksDir = join(home, ".claude", "hooks");
+    expect(existsSync(join(hooksDir, "memory-session-start.sh"))).toBe(true);
+    expect(
+      statSync(join(hooksDir, "memory-session-start.sh")).mode & 0o111,
+    ).not.toBe(0);
+
+    const settings = JSON.parse(
+      readFileSync(join(home, ".claude", "settings.json"), "utf8"),
+    );
+    expect(settings.mcpServers["agent-brain"]).toBeDefined();
+    expect(settings.hooks.SessionStart).toBeDefined();
+
+    const claudeMd = readFileSync(join(home, ".claude", "CLAUDE.md"), "utf8");
+    expect(claudeMd).toContain("<!-- agent-brain:start -->");
+    expect(claudeMd).toContain("agent-brain");
+  });
+
+  it("installs Copilot target: copies hooks, merges two JSON files, prepends instructions", async () => {
+    await runInstaller(
+      { targets: ["copilot"], dryRun: false, yes: true, uninstall: false },
+      { repoRoot: REPO_ROOT, home },
+    );
+
+    const hooksDir = join(home, ".copilot", "hooks");
+    expect(existsSync(join(hooksDir, "memory-pretool.sh"))).toBe(true);
+
+    const mcpCfg = JSON.parse(
+      readFileSync(join(home, ".copilot", "mcp-config.json"), "utf8"),
+    );
+    expect(mcpCfg.mcpServers["agent-brain"]).toBeDefined();
+
+    const hooksCfg = JSON.parse(
+      readFileSync(join(home, ".copilot", "hooks", "hooks.json"), "utf8"),
+    );
+    expect(hooksCfg.version).toBe(1);
+
+    const instr = readFileSync(
+      join(home, ".copilot", "copilot-instructions.md"),
+      "utf8",
+    );
+    expect(instr).toContain("<!-- agent-brain:start -->");
+  });
+
+  it("is idempotent: running install twice produces no duplicates", async () => {
+    const opts = {
+      targets: ["claude" as const],
+      dryRun: false,
+      yes: true,
+      uninstall: false,
+    };
+    await runInstaller(opts, { repoRoot: REPO_ROOT, home });
+    await runInstaller(opts, { repoRoot: REPO_ROOT, home });
+
+    const settings = JSON.parse(
+      readFileSync(join(home, ".claude", "settings.json"), "utf8"),
+    );
+    expect(settings.hooks.SessionStart).toHaveLength(1);
+
+    const claudeMd = readFileSync(join(home, ".claude", "CLAUDE.md"), "utf8");
+    const starts = claudeMd.match(/<!-- agent-brain:start -->/g) ?? [];
+    expect(starts).toHaveLength(1);
+  });
+
+  it("dryRun writes nothing", async () => {
+    await runInstaller(
+      { targets: ["claude"], dryRun: true, yes: true, uninstall: false },
+      { repoRoot: REPO_ROOT, home },
+    );
+
+    expect(existsSync(join(home, ".claude", "settings.json"))).toBe(false);
+    expect(existsSync(join(home, ".claude", "CLAUDE.md"))).toBe(false);
+  });
+});

--- a/tests/unit/installer/install.test.ts
+++ b/tests/unit/installer/install.test.ts
@@ -25,7 +25,7 @@ describe("installer end-to-end", () => {
 
   it("installs Claude target: copies hooks, merges settings, prepends CLAUDE.md", async () => {
     await runInstaller(
-      { targets: ["claude"], dryRun: false, yes: true, uninstall: false },
+      { targets: ["claude"], dryRun: false, uninstall: false },
       { repoRoot: REPO_ROOT, home },
     );
 
@@ -48,7 +48,7 @@ describe("installer end-to-end", () => {
 
   it("installs Copilot target: copies hooks, merges two JSON files, prepends instructions", async () => {
     await runInstaller(
-      { targets: ["copilot"], dryRun: false, yes: true, uninstall: false },
+      { targets: ["copilot"], dryRun: false, uninstall: false },
       { repoRoot: REPO_ROOT, home },
     );
 
@@ -76,7 +76,6 @@ describe("installer end-to-end", () => {
     const opts = {
       targets: ["claude" as const],
       dryRun: false,
-      yes: true,
       uninstall: false,
     };
     await runInstaller(opts, { repoRoot: REPO_ROOT, home });
@@ -94,7 +93,7 @@ describe("installer end-to-end", () => {
 
   it("dryRun writes nothing", async () => {
     await runInstaller(
-      { targets: ["claude"], dryRun: true, yes: true, uninstall: false },
+      { targets: ["claude"], dryRun: true, uninstall: false },
       { repoRoot: REPO_ROOT, home },
     );
 

--- a/tests/unit/installer/merge-json.test.ts
+++ b/tests/unit/installer/merge-json.test.ts
@@ -4,7 +4,7 @@ import {
   rmSync,
   writeFileSync,
   readFileSync,
-  existsSync,
+  readdirSync,
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -61,16 +61,27 @@ describe("mergeJson", () => {
     expect(result.hooks.SessionStart).toHaveLength(1);
   });
 
-  it("writes .bak on first run only, never overwrites existing .bak", async () => {
+  it("writes a timestamped .bak on every run; previous backups retained", async () => {
     writeFileSync(file, JSON.stringify({ original: true }));
     await mergeJson(file, { added: 1 }, { dryRun: false });
-    expect(existsSync(`${file}.bak`)).toBe(true);
-    expect(JSON.parse(readFileSync(`${file}.bak`, "utf8"))).toEqual({
+
+    const baksAfterFirst = readdirSync(dir).filter((n) =>
+      n.startsWith("settings.json.bak."),
+    );
+    expect(baksAfterFirst).toHaveLength(1);
+    const [firstBak] = baksAfterFirst;
+    expect(JSON.parse(readFileSync(join(dir, firstBak), "utf8"))).toEqual({
       original: true,
     });
 
+    await new Promise((r) => setTimeout(r, 1100));
     await mergeJson(file, { added: 2 }, { dryRun: false });
-    expect(JSON.parse(readFileSync(`${file}.bak`, "utf8"))).toEqual({
+
+    const baksAfterSecond = readdirSync(dir).filter((n) =>
+      n.startsWith("settings.json.bak."),
+    );
+    expect(baksAfterSecond.length).toBeGreaterThanOrEqual(2);
+    expect(JSON.parse(readFileSync(join(dir, firstBak), "utf8"))).toEqual({
       original: true,
     });
   });
@@ -86,6 +97,9 @@ describe("mergeJson", () => {
     writeFileSync(file, JSON.stringify({ a: 1 }));
     await mergeJson(file, { b: 2 }, { dryRun: true });
     expect(JSON.parse(readFileSync(file, "utf8"))).toEqual({ a: 1 });
-    expect(existsSync(`${file}.bak`)).toBe(false);
+    const baks = readdirSync(dir).filter((n) =>
+      n.startsWith("settings.json.bak."),
+    );
+    expect(baks).toHaveLength(0);
   });
 });

--- a/tests/unit/installer/merge-json.test.ts
+++ b/tests/unit/installer/merge-json.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mergeJson } from "../../../scripts/installer/merge-json.js";
+
+describe("mergeJson", () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mergejson-"));
+    file = join(dir, "settings.json");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("creates file from {} when missing", async () => {
+    await mergeJson(
+      file,
+      { mcpServers: { "agent-brain": { url: "u" } } },
+      { dryRun: false },
+    );
+    expect(JSON.parse(readFileSync(file, "utf8"))).toEqual({
+      mcpServers: { "agent-brain": { url: "u" } },
+    });
+  });
+
+  it("preserves foreign keys in existing file", async () => {
+    writeFileSync(
+      file,
+      JSON.stringify({ mcpServers: { other: { url: "x" } }, theme: "dark" }),
+    );
+    await mergeJson(
+      file,
+      { mcpServers: { "agent-brain": { url: "u" } } },
+      { dryRun: false },
+    );
+    const result = JSON.parse(readFileSync(file, "utf8"));
+    expect(result).toEqual({
+      mcpServers: { other: { url: "x" }, "agent-brain": { url: "u" } },
+      theme: "dark",
+    });
+  });
+
+  it("is idempotent on re-run (array dedupe by JSON.stringify)", async () => {
+    const patch = {
+      hooks: { SessionStart: [{ type: "command", command: "x" }] },
+    };
+    await mergeJson(file, patch, { dryRun: false });
+    await mergeJson(file, patch, { dryRun: false });
+    const result = JSON.parse(readFileSync(file, "utf8"));
+    expect(result.hooks.SessionStart).toHaveLength(1);
+  });
+
+  it("writes .bak on first run only, never overwrites existing .bak", async () => {
+    writeFileSync(file, JSON.stringify({ original: true }));
+    await mergeJson(file, { added: 1 }, { dryRun: false });
+    expect(existsSync(`${file}.bak`)).toBe(true);
+    expect(JSON.parse(readFileSync(`${file}.bak`, "utf8"))).toEqual({
+      original: true,
+    });
+
+    await mergeJson(file, { added: 2 }, { dryRun: false });
+    expect(JSON.parse(readFileSync(`${file}.bak`, "utf8"))).toEqual({
+      original: true,
+    });
+  });
+
+  it("throws on invalid JSON", async () => {
+    writeFileSync(file, "{ not valid json");
+    await expect(mergeJson(file, { x: 1 }, { dryRun: false })).rejects.toThrow(
+      /invalid JSON/,
+    );
+  });
+
+  it("dryRun does not write", async () => {
+    writeFileSync(file, JSON.stringify({ a: 1 }));
+    await mergeJson(file, { b: 2 }, { dryRun: true });
+    expect(JSON.parse(readFileSync(file, "utf8"))).toEqual({ a: 1 });
+    expect(existsSync(`${file}.bak`)).toBe(false);
+  });
+});

--- a/tests/unit/installer/merge-markdown.test.ts
+++ b/tests/unit/installer/merge-markdown.test.ts
@@ -4,11 +4,14 @@ import {
   rmSync,
   writeFileSync,
   readFileSync,
-  existsSync,
+  readdirSync,
 } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { prependWithMarkers } from "../../../scripts/installer/merge-markdown.js";
+import { makeMarkerId } from "../../../scripts/installer/types.js";
+
+const M = makeMarkerId("agent-brain");
 
 describe("prependWithMarkers", () => {
   let dir: string;
@@ -24,7 +27,7 @@ describe("prependWithMarkers", () => {
   });
 
   it("creates file with wrapped snippet when missing", async () => {
-    await prependWithMarkers(file, "hello\n", "agent-brain", { dryRun: false });
+    await prependWithMarkers(file, "hello\n", M, { dryRun: false });
     const content = readFileSync(file, "utf8");
     expect(content).toContain("<!-- agent-brain:start -->");
     expect(content).toContain("hello");
@@ -33,7 +36,7 @@ describe("prependWithMarkers", () => {
 
   it("prepends wrapped snippet when file exists without markers", async () => {
     writeFileSync(file, "# Existing\nuser content\n");
-    await prependWithMarkers(file, "snippet body\n", "agent-brain", {
+    await prependWithMarkers(file, "snippet body\n", M, {
       dryRun: false,
     });
     const content = readFileSync(file, "utf8");
@@ -46,8 +49,8 @@ describe("prependWithMarkers", () => {
   });
 
   it("replaces content between markers on re-run", async () => {
-    await prependWithMarkers(file, "v1\n", "agent-brain", { dryRun: false });
-    await prependWithMarkers(file, "v2 updated\n", "agent-brain", {
+    await prependWithMarkers(file, "v1\n", M, { dryRun: false });
+    await prependWithMarkers(file, "v2 updated\n", M, {
       dryRun: false,
     });
     const content = readFileSync(file, "utf8");
@@ -58,32 +61,44 @@ describe("prependWithMarkers", () => {
   });
 
   it("preserves content outside markers when replacing", async () => {
-    await prependWithMarkers(file, "v1\n", "agent-brain", { dryRun: false });
+    await prependWithMarkers(file, "v1\n", M, { dryRun: false });
     writeFileSync(
       file,
       readFileSync(file, "utf8") + "\n# User section\nuser body\n",
     );
-    await prependWithMarkers(file, "v2\n", "agent-brain", { dryRun: false });
+    await prependWithMarkers(file, "v2\n", M, { dryRun: false });
     const content = readFileSync(file, "utf8");
     expect(content).toContain("v2");
     expect(content).toContain("# User section");
     expect(content).toContain("user body");
   });
 
-  it("writes .bak on first run only", async () => {
+  it("writes a timestamped .bak on every run; previous backups retained", async () => {
     writeFileSync(file, "original\n");
-    await prependWithMarkers(file, "a\n", "agent-brain", { dryRun: false });
-    expect(existsSync(`${file}.bak`)).toBe(true);
-    expect(readFileSync(`${file}.bak`, "utf8")).toBe("original\n");
+    await prependWithMarkers(file, "a\n", M, { dryRun: false });
 
-    await prependWithMarkers(file, "b\n", "agent-brain", { dryRun: false });
-    expect(readFileSync(`${file}.bak`, "utf8")).toBe("original\n");
+    const first = readdirSync(dir).filter((n) =>
+      n.startsWith("CLAUDE.md.bak."),
+    );
+    expect(first).toHaveLength(1);
+    const [firstBak] = first;
+    expect(readFileSync(join(dir, firstBak), "utf8")).toBe("original\n");
+
+    await new Promise((r) => setTimeout(r, 1100));
+    await prependWithMarkers(file, "b\n", M, { dryRun: false });
+
+    const second = readdirSync(dir).filter((n) =>
+      n.startsWith("CLAUDE.md.bak."),
+    );
+    expect(second.length).toBeGreaterThanOrEqual(2);
+    expect(readFileSync(join(dir, firstBak), "utf8")).toBe("original\n");
   });
 
   it("dryRun does not write", async () => {
     writeFileSync(file, "orig\n");
-    await prependWithMarkers(file, "x\n", "agent-brain", { dryRun: true });
+    await prependWithMarkers(file, "x\n", M, { dryRun: true });
     expect(readFileSync(file, "utf8")).toBe("orig\n");
-    expect(existsSync(`${file}.bak`)).toBe(false);
+    const baks = readdirSync(dir).filter((n) => n.startsWith("CLAUDE.md.bak."));
+    expect(baks).toHaveLength(0);
   });
 });

--- a/tests/unit/installer/merge-markdown.test.ts
+++ b/tests/unit/installer/merge-markdown.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { prependWithMarkers } from "../../../scripts/installer/merge-markdown.js";
+
+describe("prependWithMarkers", () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mergemd-"));
+    file = join(dir, "CLAUDE.md");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("creates file with wrapped snippet when missing", async () => {
+    await prependWithMarkers(file, "hello\n", "agent-brain", { dryRun: false });
+    const content = readFileSync(file, "utf8");
+    expect(content).toContain("<!-- agent-brain:start -->");
+    expect(content).toContain("hello");
+    expect(content).toContain("<!-- agent-brain:end -->");
+  });
+
+  it("prepends wrapped snippet when file exists without markers", async () => {
+    writeFileSync(file, "# Existing\nuser content\n");
+    await prependWithMarkers(file, "snippet body\n", "agent-brain", {
+      dryRun: false,
+    });
+    const content = readFileSync(file, "utf8");
+    expect(content.indexOf("<!-- agent-brain:start -->")).toBe(0);
+    expect(content).toContain("snippet body");
+    expect(content).toContain("# Existing");
+    expect(content.indexOf("# Existing")).toBeGreaterThan(
+      content.indexOf("<!-- agent-brain:end -->"),
+    );
+  });
+
+  it("replaces content between markers on re-run", async () => {
+    await prependWithMarkers(file, "v1\n", "agent-brain", { dryRun: false });
+    await prependWithMarkers(file, "v2 updated\n", "agent-brain", {
+      dryRun: false,
+    });
+    const content = readFileSync(file, "utf8");
+    expect(content).toContain("v2 updated");
+    expect(content).not.toContain("v1\n");
+    const starts = content.match(/<!-- agent-brain:start -->/g) ?? [];
+    expect(starts).toHaveLength(1);
+  });
+
+  it("preserves content outside markers when replacing", async () => {
+    await prependWithMarkers(file, "v1\n", "agent-brain", { dryRun: false });
+    writeFileSync(
+      file,
+      readFileSync(file, "utf8") + "\n# User section\nuser body\n",
+    );
+    await prependWithMarkers(file, "v2\n", "agent-brain", { dryRun: false });
+    const content = readFileSync(file, "utf8");
+    expect(content).toContain("v2");
+    expect(content).toContain("# User section");
+    expect(content).toContain("user body");
+  });
+
+  it("writes .bak on first run only", async () => {
+    writeFileSync(file, "original\n");
+    await prependWithMarkers(file, "a\n", "agent-brain", { dryRun: false });
+    expect(existsSync(`${file}.bak`)).toBe(true);
+    expect(readFileSync(`${file}.bak`, "utf8")).toBe("original\n");
+
+    await prependWithMarkers(file, "b\n", "agent-brain", { dryRun: false });
+    expect(readFileSync(`${file}.bak`, "utf8")).toBe("original\n");
+  });
+
+  it("dryRun does not write", async () => {
+    writeFileSync(file, "orig\n");
+    await prependWithMarkers(file, "x\n", "agent-brain", { dryRun: true });
+    expect(readFileSync(file, "utf8")).toBe("orig\n");
+    expect(existsSync(`${file}.bak`)).toBe(false);
+  });
+});

--- a/tests/unit/installer/preflight.test.ts
+++ b/tests/unit/installer/preflight.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, chmodSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  checkJq,
+  checkTargetDirWritable,
+  checkDockerWarn,
+} from "../../../scripts/installer/preflight.js";
+
+describe("preflight", () => {
+  describe("checkJq", () => {
+    const originalPath = process.env.PATH;
+    afterEach(() => {
+      process.env.PATH = originalPath;
+    });
+
+    it("passes when jq on PATH", async () => {
+      const stubDir = mkdtempSync(join(tmpdir(), "pfjq-"));
+      const jqPath = join(stubDir, "jq");
+      writeFileSync(jqPath, "#!/bin/sh\necho stub\n");
+      chmodSync(jqPath, 0o755);
+      process.env.PATH = stubDir;
+      await expect(checkJq()).resolves.toBeUndefined();
+      rmSync(stubDir, { recursive: true, force: true });
+    });
+
+    it("throws when jq missing", async () => {
+      const emptyDir = mkdtempSync(join(tmpdir(), "pfnojq-"));
+      process.env.PATH = emptyDir;
+      await expect(checkJq()).rejects.toThrow(/jq not found/);
+      rmSync(emptyDir, { recursive: true, force: true });
+    });
+  });
+
+  describe("checkTargetDirWritable", () => {
+    let dir: string;
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), "pfdir-"));
+    });
+    afterEach(() => {
+      try {
+        chmodSync(dir, 0o755);
+      } catch {
+        /* ignore */
+      }
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("passes when dir exists and writable", async () => {
+      await expect(checkTargetDirWritable(dir)).resolves.toBeUndefined();
+    });
+
+    it("passes when dir missing but parent writable (creates it)", async () => {
+      const child = join(dir, "sub");
+      await expect(checkTargetDirWritable(child)).resolves.toBeUndefined();
+    });
+
+    it("throws when dir not writable", async () => {
+      chmodSync(dir, 0o500);
+      const child = join(dir, "blocked");
+      await expect(checkTargetDirWritable(child)).rejects.toThrow(
+        /not writable/,
+      );
+    });
+  });
+
+  describe("checkDockerWarn", () => {
+    const originalPath = process.env.PATH;
+    afterEach(() => {
+      process.env.PATH = originalPath;
+    });
+
+    it("returns null when docker present", async () => {
+      const stubDir = mkdtempSync(join(tmpdir(), "pfdocker-"));
+      const dockerPath = join(stubDir, "docker");
+      writeFileSync(dockerPath, "#!/bin/sh\n");
+      chmodSync(dockerPath, 0o755);
+      process.env.PATH = stubDir;
+      expect(await checkDockerWarn()).toBeNull();
+      rmSync(stubDir, { recursive: true, force: true });
+    });
+
+    it("returns warning string when docker missing", async () => {
+      const emptyDir = mkdtempSync(join(tmpdir(), "pfnodocker-"));
+      process.env.PATH = emptyDir;
+      const result = await checkDockerWarn();
+      expect(result).toMatch(/docker not found/);
+      rmSync(emptyDir, { recursive: true, force: true });
+    });
+  });
+});

--- a/tests/unit/installer/roundtrip.test.ts
+++ b/tests/unit/installer/roundtrip.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+  readdirSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { runInstaller } from "../../../scripts/installer/index.js";
+
+const REPO_ROOT = process.cwd();
+
+describe("installer round-trip", () => {
+  let home: string;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "abrt-"));
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("install then uninstall leaves pre-existing foreign keys intact", async () => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    const seed = {
+      theme: "dark",
+      mcpServers: { other: { url: "x" } },
+      hooks: { OtherEvent: [{ type: "command", command: "/usr/bin/foo" }] },
+    };
+    const seedJson = JSON.stringify(seed, null, 2) + "\n";
+    writeFileSync(join(home, ".claude", "settings.json"), seedJson);
+    writeFileSync(join(home, ".claude", "CLAUDE.md"), "# User\nbody\n");
+
+    await runInstaller(
+      { targets: ["claude"], dryRun: false, uninstall: false },
+      { repoRoot: REPO_ROOT, home },
+    );
+    await runInstaller(
+      { targets: ["claude"], dryRun: false, uninstall: true },
+      { repoRoot: REPO_ROOT, home },
+    );
+
+    const settingsAfter = JSON.parse(
+      readFileSync(join(home, ".claude", "settings.json"), "utf8"),
+    );
+    expect(settingsAfter.theme).toBe("dark");
+    expect(settingsAfter.mcpServers).toEqual({ other: { url: "x" } });
+    expect(settingsAfter.hooks?.OtherEvent).toEqual([
+      { type: "command", command: "/usr/bin/foo" },
+    ]);
+    expect(settingsAfter.hooks?.SessionStart).toBeUndefined();
+
+    const mdAfter = readFileSync(join(home, ".claude", "CLAUDE.md"), "utf8");
+    expect(mdAfter).toContain("# User");
+    expect(mdAfter).toContain("body");
+    expect(mdAfter).not.toContain("<!-- agent-brain:start -->");
+  });
+
+  it("uninstall with invalid JSON leaves the file byte-identical and sets exitCode=3", async () => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    const corrupt = "{ not valid json";
+    writeFileSync(join(home, ".claude", "settings.json"), corrupt);
+
+    // Hook script on disk so we can check ordering. Uninstall ordering
+    // strips config *before* removing the script; with invalid JSON, the
+    // script may be removed anyway but the settings file must survive.
+    mkdirSync(join(home, ".claude", "hooks"), { recursive: true });
+    writeFileSync(
+      join(home, ".claude", "hooks", "memory-session-start.sh"),
+      "#!/bin/sh\n",
+    );
+
+    const prevExit = process.exitCode;
+    process.exitCode = 0;
+    try {
+      await runInstaller(
+        { targets: ["claude"], dryRun: false, uninstall: true },
+        { repoRoot: REPO_ROOT, home },
+      );
+      expect(process.exitCode).toBe(3);
+      expect(readFileSync(join(home, ".claude", "settings.json"), "utf8")).toBe(
+        corrupt,
+      );
+    } finally {
+      process.exitCode = prevExit;
+    }
+  });
+
+  it("sandbox home never writes to real $HOME", async () => {
+    const realHome = process.env.HOME;
+    await runInstaller(
+      { targets: ["claude"], dryRun: false, uninstall: false },
+      { repoRoot: REPO_ROOT, home },
+    );
+    expect(existsSync(join(home, ".claude"))).toBe(true);
+    // After the installer returns, process.env.HOME is set to the sandbox —
+    // that's intentional for the duration of the run. The point of this
+    // test is that no stray .claude directory appears under the real HOME
+    // as a result of the install.
+    if (realHome && realHome !== home) {
+      const sandboxEntries = readdirSync(home);
+      expect(sandboxEntries).toContain(".claude");
+    }
+  });
+
+  it("failing preflight on target 2 prevents any writes on target 1", async () => {
+    const { chmodSync } = await import("node:fs");
+    mkdirSync(join(home, ".copilot"), { recursive: true });
+    chmodSync(join(home, ".copilot"), 0o500);
+
+    try {
+      await expect(
+        runInstaller(
+          { targets: ["claude", "copilot"], dryRun: false, uninstall: false },
+          { repoRoot: REPO_ROOT, home },
+        ),
+      ).rejects.toThrow();
+
+      expect(existsSync(join(home, ".claude", "settings.json"))).toBe(false);
+      expect(existsSync(join(home, ".claude", "CLAUDE.md"))).toBe(false);
+      expect(
+        existsSync(join(home, ".claude", "hooks", "memory-session-start.sh")),
+      ).toBe(false);
+    } finally {
+      chmodSync(join(home, ".copilot"), 0o700);
+    }
+  });
+
+  it("orphan start marker falls through to prepend (does not break file)", async () => {
+    const claudeMd = join(home, ".claude", "CLAUDE.md");
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(claudeMd, "<!-- agent-brain:start -->\nhalf written\n");
+    await runInstaller(
+      { targets: ["claude"], dryRun: false, uninstall: false },
+      { repoRoot: REPO_ROOT, home },
+    );
+    const after = readFileSync(claudeMd, "utf8");
+    expect(after.startsWith("<!-- agent-brain:start -->")).toBe(true);
+    expect(after).toContain("<!-- agent-brain:end -->");
+  });
+});

--- a/tests/unit/installer/source-resolver.test.ts
+++ b/tests/unit/installer/source-resolver.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { applyPlan } from "../../../scripts/installer/apply.js";
+import { makeMarkerId } from "../../../scripts/installer/types.js";
+
+describe("Source<T> resolution in applyPlan", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "absrc-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("resolves {kind:'file'} patch by reading and parsing JSON", async () => {
+    const snippet = join(dir, "snippet.json");
+    writeFileSync(snippet, JSON.stringify({ mcpServers: { a: { url: "u" } } }));
+    const target = join(dir, "settings.json");
+
+    await applyPlan(
+      {
+        target: "claude",
+        copies: [],
+        jsonMerges: [{ file: target, patch: { kind: "file", path: snippet } }],
+        markdownPrepends: [],
+        postInstructions: [],
+      },
+      { dryRun: false },
+    );
+
+    expect(JSON.parse(readFileSync(target, "utf8"))).toEqual({
+      mcpServers: { a: { url: "u" } },
+    });
+  });
+
+  it("resolves {kind:'inline'} patch without reading any file", async () => {
+    const target = join(dir, "settings.json");
+    await applyPlan(
+      {
+        target: "claude",
+        copies: [],
+        jsonMerges: [
+          { file: target, patch: { kind: "inline", value: { x: 1 } } },
+        ],
+        markdownPrepends: [],
+        postInstructions: [],
+      },
+      { dryRun: false },
+    );
+    expect(JSON.parse(readFileSync(target, "utf8"))).toEqual({ x: 1 });
+  });
+
+  it("resolves {kind:'file'} snippet for markdown and writes wrapped body", async () => {
+    const snippetPath = join(dir, "snippet.md");
+    writeFileSync(snippetPath, "loaded-from-file\n");
+    const target = join(dir, "CLAUDE.md");
+
+    await applyPlan(
+      {
+        target: "claude",
+        copies: [],
+        jsonMerges: [],
+        markdownPrepends: [
+          {
+            file: target,
+            snippet: { kind: "file", path: snippetPath },
+            markerId: makeMarkerId("test-marker"),
+          },
+        ],
+        postInstructions: [],
+      },
+      { dryRun: false },
+    );
+
+    const content = readFileSync(target, "utf8");
+    expect(content).toContain("<!-- test-marker:start -->");
+    expect(content).toContain("loaded-from-file");
+    expect(content).not.toContain("__fromFile");
+  });
+
+  it("throws with file path context when patch file contains invalid JSON", async () => {
+    const snippet = join(dir, "broken.json");
+    writeFileSync(snippet, "{ not valid");
+    const target = join(dir, "settings.json");
+
+    await expect(
+      applyPlan(
+        {
+          target: "claude",
+          copies: [],
+          jsonMerges: [
+            { file: target, patch: { kind: "file", path: snippet } },
+          ],
+          markdownPrepends: [],
+          postInstructions: [],
+        },
+        { dryRun: false },
+      ),
+    ).rejects.toThrow(/broken\.json: invalid JSON/);
+    expect(existsSync(target)).toBe(false);
+  });
+});

--- a/tests/unit/installer/targets.test.ts
+++ b/tests/unit/installer/targets.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { claudeTarget } from "../../../scripts/installer/targets/claude.js";
+import { copilotTarget } from "../../../scripts/installer/targets/copilot.js";
 
 describe("claudeTarget.plan", () => {
   const repoRoot = "/repo";
@@ -40,6 +41,50 @@ describe("claudeTarget.plan", () => {
 
   it("postInstructions include docker-compose command", () => {
     const plan = claudeTarget.plan(repoRoot, home);
+    expect(
+      plan.postInstructions.some((s) => s.includes("docker compose")),
+    ).toBe(true);
+  });
+});
+
+describe("copilotTarget.plan", () => {
+  const repoRoot = "/repo";
+  const home = "/home/u";
+
+  it("copies 3 hook scripts", () => {
+    const plan = copilotTarget.plan(repoRoot, home);
+    const filenames = plan.copies.map((c) => c.dest.split("/").pop()).sort();
+    expect(filenames).toEqual([
+      "memory-pretool.sh",
+      "memory-session-end.sh",
+      "memory-session-start.sh",
+    ]);
+    for (const c of plan.copies) {
+      expect(c.dest.startsWith("/home/u/.copilot/hooks/")).toBe(true);
+      expect(c.mode).toBe(0o755);
+    }
+  });
+
+  it("merges two JSON files: mcp-config.json and hooks/hooks.json", () => {
+    const plan = copilotTarget.plan(repoRoot, home);
+    const files = plan.jsonMerges.map((m) => m.file).sort();
+    expect(files).toEqual([
+      "/home/u/.copilot/hooks/hooks.json",
+      "/home/u/.copilot/mcp-config.json",
+    ]);
+  });
+
+  it("prepends copilot-instructions.md with agent-brain marker", () => {
+    const plan = copilotTarget.plan(repoRoot, home);
+    expect(plan.markdownPrepends).toHaveLength(1);
+    expect(plan.markdownPrepends[0].file).toBe(
+      "/home/u/.copilot/copilot-instructions.md",
+    );
+    expect(plan.markdownPrepends[0].markerId).toBe("agent-brain");
+  });
+
+  it("postInstructions include docker-compose command", () => {
+    const plan = copilotTarget.plan(repoRoot, home);
     expect(
       plan.postInstructions.some((s) => s.includes("docker compose")),
     ).toBe(true);

--- a/tests/unit/installer/targets.test.ts
+++ b/tests/unit/installer/targets.test.ts
@@ -81,6 +81,7 @@ describe("copilotTarget.plan", () => {
       "/home/u/.copilot/copilot-instructions.md",
     );
     expect(plan.markdownPrepends[0].markerId).toBe("agent-brain");
+    expect(plan.markdownPrepends[0].snippet).toMatch(/^__fromFile:/);
   });
 
   it("postInstructions include docker-compose command", () => {

--- a/tests/unit/installer/targets.test.ts
+++ b/tests/unit/installer/targets.test.ts
@@ -36,7 +36,11 @@ describe("claudeTarget.plan", () => {
     expect(plan.markdownPrepends).toHaveLength(1);
     expect(plan.markdownPrepends[0].file).toBe("/home/u/.claude/CLAUDE.md");
     expect(plan.markdownPrepends[0].markerId).toBe("agent-brain");
-    expect(plan.markdownPrepends[0].snippet).toMatch(/^__fromFile:/);
+    const snippet = plan.markdownPrepends[0].snippet;
+    expect(snippet.kind).toBe("file");
+    if (snippet.kind === "file") {
+      expect(snippet.path).toContain("claude-md-snippet.md");
+    }
   });
 
   it("postInstructions include docker-compose command", () => {
@@ -81,7 +85,11 @@ describe("copilotTarget.plan", () => {
       "/home/u/.copilot/copilot-instructions.md",
     );
     expect(plan.markdownPrepends[0].markerId).toBe("agent-brain");
-    expect(plan.markdownPrepends[0].snippet).toMatch(/^__fromFile:/);
+    const snippet = plan.markdownPrepends[0].snippet;
+    expect(snippet.kind).toBe("file");
+    if (snippet.kind === "file") {
+      expect(snippet.path).toContain("instructions-snippet.md");
+    }
   });
 
   it("postInstructions include docker-compose command", () => {

--- a/tests/unit/installer/targets.test.ts
+++ b/tests/unit/installer/targets.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { claudeTarget } from "../../../scripts/installer/targets/claude.js";
+
+describe("claudeTarget.plan", () => {
+  const repoRoot = "/repo";
+  const home = "/home/u";
+
+  it("has expected copies", () => {
+    const plan = claudeTarget.plan(repoRoot, home);
+    expect(plan.target).toBe("claude");
+    const filenames = plan.copies.map((c) => c.dest.split("/").pop()).sort();
+    expect(filenames).toEqual([
+      "memory-autofill.sh",
+      "memory-guard.sh",
+      "memory-nudge.sh",
+      "memory-session-review.sh",
+      "memory-session-start.sh",
+    ]);
+    for (const c of plan.copies) {
+      expect(c.src.startsWith(`${repoRoot}/hooks/claude/`)).toBe(true);
+      expect(c.dest.startsWith(`${home}/.claude/hooks/`)).toBe(true);
+      expect(c.mode).toBe(0o755);
+    }
+  });
+
+  it("has one jsonMerge for settings.json", () => {
+    const plan = claudeTarget.plan(repoRoot, home);
+    expect(plan.jsonMerges).toHaveLength(1);
+    expect(plan.jsonMerges[0].file).toBe("/home/u/.claude/settings.json");
+    expect(plan.jsonMerges[0].patch).toBeTypeOf("object");
+  });
+
+  it("has one markdownPrepend for CLAUDE.md with agent-brain marker", () => {
+    const plan = claudeTarget.plan(repoRoot, home);
+    expect(plan.markdownPrepends).toHaveLength(1);
+    expect(plan.markdownPrepends[0].file).toBe("/home/u/.claude/CLAUDE.md");
+    expect(plan.markdownPrepends[0].markerId).toBe("agent-brain");
+    expect(plan.markdownPrepends[0].snippet).toMatch(/^__fromFile:/);
+  });
+
+  it("postInstructions include docker-compose command", () => {
+    const plan = claudeTarget.plan(repoRoot, home);
+    expect(
+      plan.postInstructions.some((s) => s.includes("docker compose")),
+    ).toBe(true);
+  });
+});

--- a/tests/unit/installer/uninstall.test.ts
+++ b/tests/unit/installer/uninstall.test.ts
@@ -24,7 +24,7 @@ describe("installer uninstall", () => {
 
   it("removes copied hook scripts for claude", async () => {
     await runInstaller(
-      { targets: ["claude"], dryRun: false, yes: true, uninstall: false },
+      { targets: ["claude"], dryRun: false, uninstall: false },
       { repoRoot: REPO_ROOT, home },
     );
     expect(
@@ -32,7 +32,7 @@ describe("installer uninstall", () => {
     ).toBe(true);
 
     await runInstaller(
-      { targets: ["claude"], dryRun: false, yes: true, uninstall: true },
+      { targets: ["claude"], dryRun: false, uninstall: true },
       { repoRoot: REPO_ROOT, home },
     );
     expect(
@@ -51,11 +51,11 @@ describe("installer uninstall", () => {
     );
 
     await runInstaller(
-      { targets: ["claude"], dryRun: false, yes: true, uninstall: false },
+      { targets: ["claude"], dryRun: false, uninstall: false },
       { repoRoot: REPO_ROOT, home },
     );
     await runInstaller(
-      { targets: ["claude"], dryRun: false, yes: true, uninstall: true },
+      { targets: ["claude"], dryRun: false, uninstall: true },
       { repoRoot: REPO_ROOT, home },
     );
 
@@ -78,7 +78,7 @@ describe("installer uninstall", () => {
 
   it("strips markers from CLAUDE.md, preserves user content", async () => {
     await runInstaller(
-      { targets: ["claude"], dryRun: false, yes: true, uninstall: false },
+      { targets: ["claude"], dryRun: false, uninstall: false },
       { repoRoot: REPO_ROOT, home },
     );
     const before = readFileSync(join(home, ".claude", "CLAUDE.md"), "utf8");
@@ -88,7 +88,7 @@ describe("installer uninstall", () => {
     );
 
     await runInstaller(
-      { targets: ["claude"], dryRun: false, yes: true, uninstall: true },
+      { targets: ["claude"], dryRun: false, uninstall: true },
       { repoRoot: REPO_ROOT, home },
     );
     const after = readFileSync(join(home, ".claude", "CLAUDE.md"), "utf8");
@@ -100,7 +100,7 @@ describe("installer uninstall", () => {
   it("uninstall of never-installed target is a no-op (ENOENT ignored)", async () => {
     await expect(
       runInstaller(
-        { targets: ["copilot"], dryRun: false, yes: true, uninstall: true },
+        { targets: ["copilot"], dryRun: false, uninstall: true },
         { repoRoot: REPO_ROOT, home },
       ),
     ).resolves.toBeUndefined();
@@ -108,11 +108,11 @@ describe("installer uninstall", () => {
 
   it("uninstall of copilot removes both JSON files' agent-brain keys", async () => {
     await runInstaller(
-      { targets: ["copilot"], dryRun: false, yes: true, uninstall: false },
+      { targets: ["copilot"], dryRun: false, uninstall: false },
       { repoRoot: REPO_ROOT, home },
     );
     await runInstaller(
-      { targets: ["copilot"], dryRun: false, yes: true, uninstall: true },
+      { targets: ["copilot"], dryRun: false, uninstall: true },
       { repoRoot: REPO_ROOT, home },
     );
 

--- a/tests/unit/installer/uninstall.test.ts
+++ b/tests/unit/installer/uninstall.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+  mkdirSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { runInstaller } from "../../../scripts/installer/index.js";
+
+const REPO_ROOT = process.cwd();
+
+describe("installer uninstall", () => {
+  let home: string;
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "abuninst-"));
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("removes copied hook scripts for claude", async () => {
+    await runInstaller(
+      { targets: ["claude"], dryRun: false, yes: true, uninstall: false },
+      { repoRoot: REPO_ROOT, home },
+    );
+    expect(
+      existsSync(join(home, ".claude", "hooks", "memory-session-start.sh")),
+    ).toBe(true);
+
+    await runInstaller(
+      { targets: ["claude"], dryRun: false, yes: true, uninstall: true },
+      { repoRoot: REPO_ROOT, home },
+    );
+    expect(
+      existsSync(join(home, ".claude", "hooks", "memory-session-start.sh")),
+    ).toBe(false);
+    expect(existsSync(join(home, ".claude", "hooks", "memory-guard.sh"))).toBe(
+      false,
+    );
+  });
+
+  it("removes agent-brain keys from settings.json, preserves foreign keys", async () => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(
+      join(home, ".claude", "settings.json"),
+      JSON.stringify({ theme: "dark", mcpServers: { other: { url: "x" } } }),
+    );
+
+    await runInstaller(
+      { targets: ["claude"], dryRun: false, yes: true, uninstall: false },
+      { repoRoot: REPO_ROOT, home },
+    );
+    await runInstaller(
+      { targets: ["claude"], dryRun: false, yes: true, uninstall: true },
+      { repoRoot: REPO_ROOT, home },
+    );
+
+    const settings = JSON.parse(
+      readFileSync(join(home, ".claude", "settings.json"), "utf8"),
+    );
+    expect(settings.theme).toBe("dark");
+    expect(settings.mcpServers.other).toEqual({ url: "x" });
+    expect(settings.mcpServers["agent-brain"]).toBeUndefined();
+    if (settings.hooks?.SessionStart) {
+      for (const group of settings.hooks.SessionStart as Array<{
+        hooks?: Array<{ command?: string }>;
+      }>) {
+        for (const h of group.hooks ?? []) {
+          expect(h.command).not.toMatch(/memory-.*\.sh/);
+        }
+      }
+    }
+  });
+
+  it("strips markers from CLAUDE.md, preserves user content", async () => {
+    await runInstaller(
+      { targets: ["claude"], dryRun: false, yes: true, uninstall: false },
+      { repoRoot: REPO_ROOT, home },
+    );
+    const before = readFileSync(join(home, ".claude", "CLAUDE.md"), "utf8");
+    writeFileSync(
+      join(home, ".claude", "CLAUDE.md"),
+      before + "\n# User section\nuser body\n",
+    );
+
+    await runInstaller(
+      { targets: ["claude"], dryRun: false, yes: true, uninstall: true },
+      { repoRoot: REPO_ROOT, home },
+    );
+    const after = readFileSync(join(home, ".claude", "CLAUDE.md"), "utf8");
+    expect(after).not.toContain("<!-- agent-brain:start -->");
+    expect(after).toContain("# User section");
+    expect(after).toContain("user body");
+  });
+
+  it("uninstall of never-installed target is a no-op (ENOENT ignored)", async () => {
+    await expect(
+      runInstaller(
+        { targets: ["copilot"], dryRun: false, yes: true, uninstall: true },
+        { repoRoot: REPO_ROOT, home },
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("uninstall of copilot removes both JSON files' agent-brain keys", async () => {
+    await runInstaller(
+      { targets: ["copilot"], dryRun: false, yes: true, uninstall: false },
+      { repoRoot: REPO_ROOT, home },
+    );
+    await runInstaller(
+      { targets: ["copilot"], dryRun: false, yes: true, uninstall: true },
+      { repoRoot: REPO_ROOT, home },
+    );
+
+    const mcp = JSON.parse(
+      readFileSync(join(home, ".copilot", "mcp-config.json"), "utf8"),
+    );
+    expect(mcp.mcpServers?.["agent-brain"]).toBeUndefined();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
   "include": [
     "src/**/*",
     "tests/**/*",
+    "scripts/**/*",
     "drizzle.config.ts",
     "vitest.config.ts",
     "vitest.ci.config.ts",


### PR DESCRIPTION
## Summary

- New `npm run install:agent` (and `uninstall:agent`) wires hooks, MCP config, and agent instructions into `~/.claude/` or `~/.copilot/` in one step — replaces the manual multi-step flow previously documented in `hooks/README.md`.
- Modular `scripts/installer/` with pure `plan()` per target, shared `mergeJson` / `prependWithMarkers` helpers, strict preflight (jq, writable dir, docker warn), `.bak` backups, idempotent re-run, symmetric uninstall.
- Docs (`README.md`, `hooks/README.md`) now lead with the fast path; manual steps retained for reference.
- Side-effect: `tsconfig.json` now includes `scripts/**/*`, which exposed stale `project_id`/API usage in `scripts/seed.ts` — fixed inline so typecheck stays green.

## Design + plan

- Spec: `docs/superpowers/specs/2026-04-21-installer-design.md`
- Plan: `docs/superpowers/plans/2026-04-21-installer.md`

## Test plan

- [x] `npm run test:unit` — 128/128 (44 new installer unit + integration tests under `tests/unit/installer/`)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run install:agent -- --target=claude --dry-run` — prints plan, writes nothing
- [ ] Manual: fresh `$HOME` sandbox, run `install:agent --target=claude`, verify hooks copied + `settings.json` merged + `CLAUDE.md` markers present
- [ ] Manual: same for `--target=copilot`
- [ ] Manual: re-run install → confirm no duplicates (idempotency)
- [ ] Manual: `uninstall:agent` → confirm foreign keys preserved in merged JSON, user content preserved in markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)