### PR TITLE
refactor: compress MCP tool descriptions + agent guidance snippets

### DIFF
--- a/hooks/claude/claude-md-snippet.md
+++ b/hooks/claude/claude-md-snippet.md
@@ -1,85 +1,85 @@
 ## Memory System
 
-This user uses [agent-brain](https://github.com/feigi/agent-brain) (MCP server) as their sole memory system across all projects. Do NOT use Claude Code's built-in file-based auto-memory system (`~/.claude/projects/**/memory/`). All memory operations go through agent-brain MCP tools (`memory_create`, `memory_search`, `memory_update`, etc.). Never write to MEMORY.md or create files in the memory/ directory.
+User use [agent-brain](https://github.com/feigi/agent-brain) (MCP server) as sole memory system all projects. Do NOT use Claude Code built-in file-based auto-memory (`~/.claude/projects/**/memory/`). All memory ops through agent-brain MCP tools (`memory_create`, `memory_search`, `memory_update`, etc.). Never write MEMORY.md or create files in memory/ directory.
 
 ### Session Start
 
-Relevant memories are loaded automatically at session start via the SessionStart hook. No manual `memory_session_start` call is needed. Use `memory_search` for additional lookups during the session.
+Relevant memories load auto at session start via SessionStart hook. No manual `memory_session_start` call needed. Use `memory_search` for extra lookups during session.
 
 ### Identity Parameters
 
-- **`user_id`**: The OS username, i.e. the output of `whoami`. This is the user's identity across all memory tools.
-- **`workspace_id`**: The repository directory name (e.g., `agent-brain` for `/Users/chris/dev/agent-brain`).
+- **`user_id`**: OS username, output of `whoami`. User identity across all memory tools.
+- **`workspace_id`**: Repo directory name (e.g., `agent-brain` for `/Users/chris/dev/agent-brain`).
 
 ### When to Call `memory_search`
 
-**Call `memory_search` before actions that affect shared systems.** This includes:
+**Call `memory_search` before actions affecting shared systems.** Includes:
 
-1. **The user asks about notes, context, or team knowledge** — e.g. "any notes?", "what should I know?"
-2. **Before actions that affect shared infrastructure** — deploys, database migrations, credential rotation, etc.
-3. **Before running shared/integration tests** (e.g. E2E, load tests) — but NOT local unit tests or builds
+1. **User asks about notes, context, team knowledge** — e.g. "any notes?", "what should I know?"
+2. **Before actions affecting shared infra** — deploys, DB migrations, credential rotation, etc.
+3. **Before shared/integration tests** (e.g. E2E, load tests) — NOT local unit tests or builds
 
-**Do NOT search for purely local actions** like editing files, installing dependencies, running local builds, linting, or formatting.
+**Do NOT search for purely local actions** like editing files, installing deps, local builds, linting, formatting.
 
 ### Saving Memories
 
-The goal is that nothing valuable is lost when a conversation ends. This includes team knowledge, but also user preferences, project context, and things you learn about how this codebase works.
+Goal: nothing valuable lost when conversation ends. Includes team knowledge, user preferences, project context, things learned about codebase.
 
-Save a memory (or suggest one) when you encounter:
+Save memory (or suggest) when encounter:
 
-- A decision and its rationale (architecture, tooling, approach)
-- A user preference about how they want you to work
-- A gotcha, workaround, or non-obvious constraint
-- Important project context that would help in a future session
+- Decision and rationale (architecture, tooling, approach)
+- User preference about how they want you to work
+- Gotcha, workaround, non-obvious constraint
+- Important project context useful in future session
 
-You don't need to ask permission for every memory — use judgment. For things that are clearly worth keeping, save directly. For anything uncertain, suggest it briefly and let the user confirm.
+No need ask permission every memory — use judgment. Clearly worth keeping, save direct. Uncertain, suggest briefly, let user confirm.
 
 ### Choosing `source`
 
-Every save must pick exactly one of three values:
+Every save pick exactly one of three values:
 
-- `manual` — the user explicitly told you to save this, in their most recent message ("remember X", "save that", "note that Y"). Bypasses write budget and project-scope guard. Do **not** use `manual` for things you decided to save yourself, even if they feel important.
-- `agent-auto` — you decided autonomously to save during a live conversation. This is the default for anything you initiate mid-session.
-- `session-review` — **only** when the Stop-hook end-of-session review is the triggering context. Never mid-session, never because the user asked.
+- `manual` — user explicitly told you save this, in most recent message ("remember X", "save that", "note that Y"). Bypasses write budget and project-scope guard. Do **not** use `manual` for things you decided save yourself, even if feel important.
+- `agent-auto` — you decided autonomously save during live conversation. Default for anything you initiate mid-session.
+- `session-review` — **only** when Stop-hook end-of-session review is triggering context. Never mid-session, never because user asked.
 
-Quick test: "did the user tell me to save this, right now, in their most recent message?" Yes → `manual`. No, and the Stop hook is running → `session-review`. Otherwise → `agent-auto`.
+Quick test: "did user tell me save this, right now, in most recent message?" Yes → `manual`. No, and Stop hook running → `session-review`. Otherwise → `agent-auto`.
 
 ### Choosing Scope
 
-Default to the **narrowest applicable scope** to reduce blast radius:
+Default **narrowest applicable scope** to reduce blast radius:
 
-- `workspace` — shared within the current workspace (default)
-- `user` — private to the user within the current workspace
+- `workspace` — shared within current workspace (default)
+- `user` — private to user within current workspace
 - `project` — cross-workspace, visible everywhere
 
-If a memory appears to be a global preference (e.g. uses words like "always", "never", "everywhere", or describes a workflow rule not tied to a specific repo), **ask the user** whether it should apply globally (`project` scope) or just to the current workspace. Do not assume global scope.
+If memory looks like global preference (e.g. uses "always", "never", "everywhere", or workflow rule not tied to specific repo), **ask user** whether apply globally (`project` scope) or current workspace only. Do not assume global.
 
 ### Verifying Memories
 
-When you encounter a memory during your work and can confirm it's still accurate, call `memory_verify`. This boosts older memories that remain relevant, informs future cleanup and consolidation, and builds user confidence in the knowledge base.
+When encounter memory during work and confirm still accurate, call `memory_verify`. Boosts older memories still relevant, informs future cleanup/consolidation, builds user confidence in knowledge base.
 
 ### Session End
 
-The Stop hook will prompt you to review the session for important memories before termination. Follow its guidance — no additional instructions needed here.
+Stop hook prompts review session for important memories before termination. Follow guidance — no extra instructions here.
 
 ### Presenting Memories
 
-Always **number** memories and include **author**, **date**, and **title**. The user may refer to memories by number (e.g. "archive memory 2", "comment on 1").
+Always **number** memories, include **author**, **date**, **title**. User may refer by number (e.g. "archive memory 2", "comment on 1").
 
 ### Memory Flags
 
-At session start, the response may include a `flags` array — issues detected by the consolidation engine. Handle them as follows:
+At session start, response may include `flags` array — issues detected by consolidation engine. Handle as:
 
-**Auto-resolve when certainty is high:**
+**Auto-resolve when certainty high:**
 
-- For `verify` flags: check the claim against the codebase (read files, grep code, check config). If you can confirm accuracy with high confidence, silently call `memory_verify` and `memory_resolve_flag` with `accepted`. No need to mention these to the user.
-- For `duplicate` / `superseded` flags: if the redundancy is obvious and unambiguous, silently archive and resolve.
+- `verify` flags: check claim against codebase (read files, grep code, check config). If confirm accuracy high confidence, silently call `memory_verify` and `memory_resolve_flag` with `accepted`. No need mention to user.
+- `duplicate` / `superseded` flags: redundancy obvious and unambiguous, silently archive and resolve.
 
-**Recommend a course of action for the rest:**
+**Recommend course of action for rest:**
 
-- For flags you cannot auto-resolve (low certainty, judgment calls, contradictions, overrides), present them to the user with a specific recommendation (archive, merge, update, or dismiss) and your reasoning. Don't just list options — say what you'd do and why.
-- Call `memory_resolve_flag` after the user confirms or overrides your recommendation.
+- Flags you cannot auto-resolve (low certainty, judgment calls, contradictions, overrides), present to user with specific recommendation (archive, merge, update, dismiss) and reasoning. Don't just list options — say what you'd do and why.
+- Call `memory_resolve_flag` after user confirms or overrides.
 
 **During normal work:**
 
-- If you encounter a flagged memory, mention its flag and recommend resolution in context.
+- Encounter flagged memory, mention flag and recommend resolution in context.

--- a/hooks/copilot/instructions-snippet.md
+++ b/hooks/copilot/instructions-snippet.md
@@ -1,76 +1,76 @@
 # Agent Memory
 
-This project uses [agent-brain](https://github.com/feigi/agent-brain) (MCP server) for shared team knowledge.
+Project use [agent-brain](https://github.com/feigi/agent-brain) (MCP server) for shared team knowledge.
 
 ## Session Start
 
-If the `memory-session-start.sh` hook (Copilot CLI v1.0.11+) is installed, recent memories are injected as `additionalContext` at session start — no manual call needed.
+If `memory-session-start.sh` hook (Copilot CLI v1.0.11+) installed, recent memories inject as `additionalContext` at session start — no manual call needed.
 
-If you are unsure whether the hook is active and no memories have appeared by the time of your first response, call `memory_session_start` yourself.
+Unsure if hook active and no memories appeared by first response, call `memory_session_start` yourself.
 
 ## Identity Parameters
 
-- **`user_id`**: The OS username (output of `whoami`).
-- **`workspace_id`**: The repository directory name (e.g., `agent-brain` for `/Users/chris/dev/agent-brain`).
+- **`user_id`**: OS username (output of `whoami`).
+- **`workspace_id`**: Repo directory name (e.g., `agent-brain` for `/Users/chris/dev/agent-brain`).
 
-When `memory-pretool.sh` is installed, these are auto-filled on every `mcp__agent-brain__*` call via `modifiedArgs`. Without the hook, you must provide them explicitly.
+When `memory-pretool.sh` installed, auto-filled on every `mcp__agent-brain__*` call via `modifiedArgs`. Without hook, provide explicitly.
 
 ## When to Call `memory_search`
 
-**Call `memory_search` before actions that affect shared systems.** This includes:
+**Call `memory_search` before actions affecting shared systems.** Includes:
 
-1. **The user asks about notes, context, or team knowledge** — e.g. "any notes?", "what should I know?"
-2. **Before actions that affect shared infrastructure** — deploys, database migrations, credential rotation, etc.
-3. **Before running shared/integration tests** (e.g. E2E, load tests) — but NOT local unit tests or builds
+1. **User asks about notes, context, team knowledge** — e.g. "any notes?", "what should I know?"
+2. **Before actions affecting shared infrastructure** — deploys, DB migrations, credential rotation, etc.
+3. **Before shared/integration tests** (e.g. E2E, load tests) — NOT local unit tests or builds
 
-**Do NOT search for purely local actions** like editing files, installing dependencies, running local builds, linting, or formatting.
+**Do NOT search for purely local actions** like editing files, installing deps, local builds, linting, formatting.
 
 ## Saving Memories
 
-The goal is that nothing valuable is lost when a conversation ends. This includes team knowledge, but also user preferences, project context, and things you learn about how this codebase works.
+Goal: nothing valuable lost when conversation ends. Includes team knowledge, user preferences, project context, things learned about codebase.
 
-Save a memory (or suggest one) when you encounter:
+Save memory (or suggest) when encounter:
 
-- A decision and its rationale (architecture, tooling, approach)
-- A user preference about how they want you to work
-- A gotcha, workaround, or non-obvious constraint
-- Important project context that would help in a future session
+- Decision and rationale (architecture, tooling, approach)
+- User preference about how they want you to work
+- Gotcha, workaround, non-obvious constraint
+- Important project context useful in future session
 
-You don't need to ask permission for every memory — use judgment. For things that are clearly worth keeping, save directly. For anything uncertain, suggest it briefly and let the user confirm.
+No need ask permission every memory — use judgment. Clearly worth keeping, save direct. Uncertain, suggest briefly, let user confirm.
 
 ## Verifying Memories
 
-When you encounter a memory during your work and can confirm it's still accurate, call `memory_verify`. This boosts older memories that remain relevant, informs future cleanup and consolidation, and builds user confidence in the knowledge base.
+Encounter memory during work and confirm still accurate, call `memory_verify`. Boosts older memories still relevant, informs future cleanup/consolidation, builds user confidence in knowledge base.
 
 ## Session End
 
-When the user signals they're done (e.g. "bye", "done", "that's all"), review the session for anything worth keeping before it ends. Consider saving:
+User signals done (e.g. "bye", "done", "that's all"), review session for anything worth keeping before end. Consider saving:
 
-- Decisions made and their rationale
-- User preferences you learned
+- Decisions made and rationale
+- User preferences learned
 - Gotchas or workarounds discovered
-- Important project context that would help in a future session
+- Important project context useful in future session
 
-Skip the review if the session was trivial (e.g. a single question with no lasting context).
+Skip review if session trivial (e.g. single question, no lasting context).
 
 ## Presenting Memories
 
-Always **number** memories and include **author**, **date**, and **title**. The user may refer to memories by number (e.g. "archive memory 2", "comment on 1").
+Always **number** memories, include **author**, **date**, **title**. User may refer by number (e.g. "archive memory 2", "comment on 1").
 
 ## Memory Flags
 
-At session start, the response may include a `flags` array — issues detected by the consolidation engine. Handle them as follows:
+At session start, response may include `flags` array — issues detected by consolidation engine. Handle as:
 
-**Auto-resolve when certainty is high:**
+**Auto-resolve when certainty high:**
 
-- For `verify` flags: check the claim against the codebase (read files, grep code, check config). If you can confirm accuracy with high confidence, silently call `memory_verify` and `memory_resolve_flag` with `accepted`. No need to mention these to the user.
-- For `duplicate` / `superseded` flags: if the redundancy is obvious and unambiguous, silently archive and resolve.
+- `verify` flags: check claim against codebase (read files, grep code, check config). If confirm accuracy high confidence, silently call `memory_verify` and `memory_resolve_flag` with `accepted`. No need mention to user.
+- `duplicate` / `superseded` flags: redundancy obvious and unambiguous, silently archive and resolve.
 
-**Recommend a course of action for the rest:**
+**Recommend course of action for rest:**
 
-- For flags you cannot auto-resolve (low certainty, judgment calls, contradictions, overrides), present them to the user with a specific recommendation (archive, merge, update, or dismiss) and your reasoning. Don't just list options — say what you'd do and why.
-- Call `memory_resolve_flag` after the user confirms or overrides your recommendation.
+- Flags you cannot auto-resolve (low certainty, judgment calls, contradictions, overrides), present to user with specific recommendation (archive, merge, update, dismiss) and reasoning. Don't just list options — say what you'd do and why.
+- Call `memory_resolve_flag` after user confirms or overrides.
 
 **During normal work:**
 
-- If you encounter a flagged memory, mention its flag and recommend resolution in context.
+- Encounter flagged memory, mention flag and recommend resolution in context.

--- a/hooks/copilot/instructions-snippet.md
+++ b/hooks/copilot/instructions-snippet.md
@@ -6,7 +6,7 @@ Project use [agent-brain](https://github.com/feigi/agent-brain) (MCP server) for
 
 If `memory-session-start.sh` hook (Copilot CLI v1.0.11+) installed, recent memories inject as `additionalContext` at session start — no manual call needed.
 
-Unsure if hook active and no memories appeared by first response, call `memory_session_start` yourself.
+If unsure hook active AND no memories appeared by first response, call `memory_session_start` yourself.
 
 ## Identity Parameters
 
@@ -44,7 +44,7 @@ Encounter memory during work and confirm still accurate, call `memory_verify`. B
 
 ## Session End
 
-User signals done (e.g. "bye", "done", "that's all"), review session for anything worth keeping before end. Consider saving:
+When user signals done (e.g. "bye", "done", "that's all"), review session for anything worth keeping before end. Consider saving:
 
 - Decisions made and rationale
 - User preferences learned

--- a/src/prompts/memory-guidance.ts
+++ b/src/prompts/memory-guidance.ts
@@ -5,7 +5,7 @@ export function registerMemoryGuidance(server: McpServer): void {
     "memory-guidance",
     {
       description:
-        "Guidelines for autonomous memory capture -- what to remember and when",
+        "Guidelines for autonomous memory capture — what to remember and when",
     },
     async () => ({
       messages: [
@@ -24,95 +24,95 @@ export function registerMemoryGuidance(server: McpServer): void {
 export const MEMORY_GUIDANCE_TEXT = `
 ## Memory Capture Guidelines
 
-You have access to a long-term memory system. Save insights that will be valuable in future sessions.
+Long-term memory system available. Save insights valuable in future sessions.
 
 ### Memory Scopes
 
-- **workspace** (default): Visible to all team members in this workspace. Requires workspace_id.
-- **user**: Private to you, visible across all your workspaces.
-- **project**: Visible to all users across ALL workspaces. Use for universal project knowledge (coding standards, architecture principles). Autonomous saves (source \`agent-auto\` or \`session-review\`) must first ask the user to confirm cross-workspace scope, then retry with \`user_confirmed_project_scope: true\`. Manual saves (source \`manual\`) bypass this guard.
+- **workspace** (default): Visible to team in this workspace. Requires workspace_id.
+- **user**: Private to you, visible across your workspaces.
+- **project**: Visible to all users across ALL workspaces. For universal project knowledge (coding standards, architecture principles). Autonomous saves (source \`agent-auto\` or \`session-review\`) must first ask user to confirm cross-workspace scope, then retry with \`user_confirmed_project_scope: true\`. Manual saves (source \`manual\`) bypass this guard.
 
 ### What to Capture
 
-All memory types are equal priority -- use your judgment based on context:
+All types equal priority — use judgment based on context:
 
 - **Decisions**: Architecture choices, technology selections, trade-off resolutions
-- **Conventions**: Naming patterns, file organization rules, coding standards agreed upon
-- **Gotchas**: Non-obvious bugs, workarounds, platform quirks discovered during work
-- **Architecture**: System boundaries, data flow patterns, integration points
+- **Conventions**: Naming patterns, file organization rules, agreed coding standards
+- **Gotchas**: Non-obvious bugs, workarounds, platform quirks
+- **Architecture**: System boundaries, data flow, integration points
 - **Patterns**: Reusable solutions that worked, anti-patterns to avoid
 - **Preferences**: User preferences for tools, approaches, communication style
 
 ### When to Save (Natural Breakpoints)
 
-Save at natural breakpoints throughout the session -- don't wait until the end:
+Save at natural breakpoints throughout session — don't wait until end:
 
-- After completing a task or subtask
-- After a commit that involved a non-obvious decision
-- When discovering something surprising about the codebase
-- After resolving a tricky bug (save the root cause + fix)
-- When the user shares team context, decisions, or background information
+- After completing task or subtask
+- After commit involving non-obvious decision
+- On discovering something surprising in the codebase
+- After resolving tricky bug (save root cause + fix)
+- When user shares team context, decisions, background info
 
 ### Choosing \`source\`
 
-Every autonomous or user-directed save must pick exactly one source. Get this right -- it drives budget accounting and project-scope guards.
+Every autonomous or user-directed save picks exactly one source. Get this right — drives budget accounting + project-scope guards.
 
-- \`manual\` -- the user explicitly told you to save ("remember this", "save that", "note that X"). Bypasses write budget and the project-scope confirmation guard. Do NOT use \`manual\` for inferences you made yourself, even if they feel important.
-- \`agent-auto\` -- you decided autonomously to save during a live conversation. This is the default for anything you initiate mid-session.
-- \`session-review\` -- ONLY use when the Stop-hook end-of-session review is the triggering context. Never mid-session, never because the user asked you to save something.
+- \`manual\` — user explicitly told you to save ("remember this", "save that", "note that X"). Bypasses write budget + project-scope confirmation guard. Do NOT use \`manual\` for your own inferences, even if they feel important.
+- \`agent-auto\` — you decided autonomously to save mid-conversation. Default for anything you initiate mid-session.
+- \`session-review\` — ONLY when Stop-hook end-of-session review is triggering context. Never mid-session, never because user asked.
 
-If in doubt between \`manual\` and \`agent-auto\`: ask "did the user tell me to save this, right now, in their most recent message?" If yes -> \`manual\`. If no -> \`agent-auto\`.
+If unsure between \`manual\` and \`agent-auto\`: ask "did user tell me to save this, right now, in their most recent message?" Yes → \`manual\`. No → \`agent-auto\`.
 
 ### When NOT to Save
 
 - Trivial facts easily found in code (import paths, obvious function signatures)
 - Temporary debugging observations that don't generalize
-- Information already captured in an existing memory (use memory_search first)
-- Task-specific details that won't be useful in future sessions
+- Info already captured in existing memory (use memory_search first)
+- Task-specific details not useful in future sessions
 
 ### Session-End Review
 
-When the session is ending, review your work and extract any remaining learnings not yet captured.
-This is the ONLY context in which \`source: 'session-review'\` is correct. Any save triggered mid-conversation -- even one made as part of a wrap-up summary before the Stop hook fires -- must use \`agent-auto\` or \`manual\` instead.
+When session ends, review work + extract remaining uncaptured learnings.
+ONLY context where \`source: 'session-review'\` is correct. Any save triggered mid-conversation — even from wrap-up summary before Stop hook fires — must use \`agent-auto\` or \`manual\`.
 
-Focus your review on:
-- Decisions made that aren't obvious from the code
+Focus review on:
+- Decisions not obvious from code
 - Patterns discovered during implementation
-- Gotchas or surprises encountered and resolved
-- Context shared by the user that future sessions would benefit from
+- Gotchas or surprises encountered + resolved
+- Context shared by user that future sessions need
 
 ### Budget Awareness
 
-You have a limited write budget per session (default: 10 autonomous saves).
-Prioritize the most impactful insights -- not every observation needs to be saved.
+Limited write budget per session (default: 10 autonomous saves).
+Prioritize most impactful insights — not every observation needs saving.
 
-If the budget is exceeded, the server will softly reject autonomous saves. You can still
-force-save critical information by using source: 'manual' -- this bypasses the budget limit
-and signals intentional user-directed saves.
+If budget exceeded, server softly rejects autonomous saves. Can still
+force-save critical info via source: 'manual' — bypasses budget limit,
+signals intentional user-directed saves.
 
 ### Memory Flags
 
-At session start, you may receive a \`flags\` array alongside memories. These are issues
-detected by the consolidation engine that need your attention.
+At session start, may receive a \`flags\` array alongside memories. Issues
+detected by consolidation engine needing attention.
 
 **Auto-resolve when certainty is high:**
-- For \`verify\` flags: check the claim against the codebase (read files, grep code, check config).
-  If you can confirm accuracy with high confidence, silently call \`memory_verify\` and
-  \`memory_resolve_flag\` with \`accepted\`. No need to mention these to the user.
-- For \`duplicate\` / \`superseded\` flags: if the redundancy is obvious and unambiguous,
-  silently archive and resolve.
+- \`verify\` flags: check claim against codebase (read files, grep code, check config).
+  If confirmed accurate with high confidence, silently call \`memory_verify\` +
+  \`memory_resolve_flag\` with \`accepted\`. No need to mention to user.
+- \`duplicate\` / \`superseded\` flags: if redundancy obvious + unambiguous,
+  silently archive + resolve.
 
-**Recommend a course of action for the rest:**
-- For flags you cannot auto-resolve (low certainty, judgment calls, contradictions, overrides),
-  present them to the user with a specific recommendation (archive, merge, update, or dismiss)
-  and your reasoning. Don't just list options — say what you'd do and why.
-- Call \`memory_resolve_flag\` after the user confirms or overrides your recommendation.
+**Recommend action for the rest:**
+- Flags you can't auto-resolve (low certainty, judgment calls, contradictions, overrides):
+  present to user with specific recommendation (archive, merge, update, dismiss)
+  + reasoning. Don't list options — say what you'd do and why.
+- Call \`memory_resolve_flag\` after user confirms or overrides.
 
 **During normal work:**
-- If you encounter a flagged memory, mention its flag and recommend resolution in context.
+- If you hit a flagged memory, mention its flag + recommend resolution in context.
 
 **Resolutions:**
-- \`accepted\`: You acted on the flag (archived, merged, updated)
-- \`dismissed\`: False positive, no action needed
-- \`deferred\`: Skip for now, will appear in next session
+- \`accepted\`: acted on flag (archived, merged, updated)
+- \`dismissed\`: false positive, no action needed
+- \`deferred\`: skip for now, reappears next session
 `.trim();

--- a/src/tools/memory-archive.ts
+++ b/src/tools/memory-archive.ts
@@ -12,7 +12,7 @@ export function registerMemoryArchive(
     "memory_archive",
     {
       description:
-        'Archive one or more memories (soft delete). Archived memories are excluded from search. user_id is required for access control -- only the owner can archive user-scoped memories. Example: memory_archive({ ids: "abc123", user_id: "alice" }) or memory_archive({ ids: ["abc123", "def456"], user_id: "alice" })',
+        'Archive memories (soft delete). Archived memories excluded from search. user_id required — only owner can archive user-scoped memories. Example: memory_archive({ ids: "abc123", user_id: "alice" }) or memory_archive({ ids: ["abc123", "def456"], user_id: "alice" })',
       inputSchema: {
         ids: z
           .union([

--- a/src/tools/memory-comment.ts
+++ b/src/tools/memory-comment.ts
@@ -13,13 +13,13 @@ export function registerMemoryComment(
     {
       // D-69: Description with usage example and guidance
       description:
-        "Add a comment to an existing memory. Use to add context, follow-up, or discussion. " +
-        "For correcting the memory itself, use memory_update instead. " +
-        "Comments are append-only and cannot be edited or deleted. " +
-        "Cannot comment on your own memories. " +
+        "Add comment to existing memory. Use for context, follow-up, or discussion. " +
+        "To correct memory itself, use memory_update. " +
+        "Comments are append-only — cannot edit or delete. " +
+        "Cannot comment on own memories. " +
         'Example: memory_comment({ memory_id: "abc123", content: "Confirmed this is still the case after migration.", user_id: "bob" })',
       inputSchema: {
-        memory_id: z.string().describe("ID of the memory to comment on"),
+        memory_id: z.string().describe("ID of memory to comment on"),
         content: contentSchema.describe(
           "Comment text. Soft limit ~1000 chars.",
         ),

--- a/src/tools/memory-consolidate.ts
+++ b/src/tools/memory-consolidate.ts
@@ -10,7 +10,7 @@ export function registerMemoryConsolidate(
     "memory_consolidate",
     {
       description:
-        "Run a full memory consolidation pass across all workspaces. Detects and auto-archives near-exact duplicates (0.95+), flags probable duplicates (0.90-0.95), flags superseded cross-scope memories, and flags stale memories needing verification. Returns counts of archived and flagged memories, plus enriched flag details.",
+        "Run full memory consolidation pass across all workspaces. Auto-archives near-exact duplicates (0.95+), flags probable duplicates (0.90-0.95), flags superseded cross-scope memories, flags stale memories needing verification. Returns counts of archived + flagged memories plus enriched flag details.",
       inputSchema: {},
     },
     async () => {

--- a/src/tools/memory-create.ts
+++ b/src/tools/memory-create.ts
@@ -54,7 +54,7 @@ export function registerMemoryCreate(
         source: memorySourceEnum
           .optional()
           .describe(
-            "Origin of save. Pick one: 'manual' = user explicitly asked to save (e.g. 'remember X', 'save that'); bypasses budget + project-scope guards. 'agent-auto' = autonomous save mid-conversation; default for agent-initiated captures. 'session-review' = ONLY for autonomous saves from end-of-session Stop-hook review; never mid-session.",
+            "Origin of save. Pick one: 'manual' = user explicitly asked to save (e.g. 'remember X', 'save that'); bypasses budget + project-scope guards. 'agent-auto' = autonomous save mid-conversation; default for agent-initiated captures. 'session-review' = ONLY for autonomous saves from end-of-session Stop-hook review; never mid-session, never because user asked.",
           ),
         session_id: z
           .string()

--- a/src/tools/memory-create.ts
+++ b/src/tools/memory-create.ts
@@ -19,7 +19,7 @@ export function registerMemoryCreate(
     "memory_create",
     {
       description:
-        'Save a new memory to the knowledge base. user_id is required for all operations and enforces scope-based access control. Include session_id from memory_session_start for budget tracking (optional). Example: memory_create({ workspace_id: "my-project", content: "Always run migrations before deploying", type: "decision", user_id: "alice" })',
+        'Save new memory. user_id required — enforces scope-based access control. Pass session_id from memory_session_start for budget tracking (optional). Example: memory_create({ workspace_id: "my-project", content: "Always run migrations before deploying", type: "decision", user_id: "alice" })',
       inputSchema: {
         workspace_id: slugSchema
           .optional()
@@ -27,7 +27,7 @@ export function registerMemoryCreate(
             "Workspace slug (e.g., 'my-project'). Required for workspace/user scope. Optional for project scope (cross-workspace).",
           ),
         content: contentSchema.describe(
-          "Memory content text. Must not be empty. Soft limit ~4000 chars.",
+          "Memory content. Non-empty. Soft limit ~4000 chars.",
         ),
         title: z
           .string()
@@ -42,19 +42,19 @@ export function registerMemoryCreate(
         scope: memoryScopeEnum
           .catch("workspace")
           .describe(
-            "'workspace' scopes to this workspace (shared with team), 'user' is private to you, 'project' is visible across all workspaces (set user_confirmed_project_scope:true after asking the user)",
+            "'workspace' = shared with team in this workspace, 'user' = private to you, 'project' = visible across all workspaces (set user_confirmed_project_scope:true after asking user)",
           ),
         user_confirmed_project_scope: z
           .boolean()
           .optional()
           .describe(
-            "Set true after the user has explicitly confirmed cross-workspace (project) scope. Required alongside scope:'project' when source is 'agent-auto' or 'session-review'.",
+            "Set true after user explicitly confirmed cross-workspace (project) scope. Required with scope:'project' when source is 'agent-auto' or 'session-review'.",
           ),
         user_id: userIdSchema,
         source: memorySourceEnum
           .optional()
           .describe(
-            "Origin of the save. Choose exactly one: 'manual' = user explicitly asked you to save (e.g. 'remember X', 'save that'); bypasses budget and project-scope guards. 'agent-auto' = autonomous save during a live conversation; use this as the default for agent-initiated captures. 'session-review' = ONLY for autonomous saves triggered by the end-of-session Stop-hook review; do not use mid-session.",
+            "Origin of save. Pick one: 'manual' = user explicitly asked to save (e.g. 'remember X', 'save that'); bypasses budget + project-scope guards. 'agent-auto' = autonomous save mid-conversation; default for agent-initiated captures. 'session-review' = ONLY for autonomous saves from end-of-session Stop-hook review; never mid-session.",
           ),
         session_id: z
           .string()

--- a/src/tools/memory-get.ts
+++ b/src/tools/memory-get.ts
@@ -12,7 +12,7 @@ export function registerMemoryGet(
     "memory_get",
     {
       description:
-        'Retrieve one or more memories by ID. Returns full details with comment_count, flag_count, and relationship_count. Use the include parameter to get full comments, flags, or relationships arrays instead of counts. With include: ["relationships"], there is no need to call memory_relationships separately (relationships are always fetched in both directions). For the common "get all memories" flow: memory_list → memory_get. IDs that are inaccessible or not found are silently omitted (check meta.omitted). Example: memory_get({ ids: ["abc123"], user_id: "alice", include: ["comments", "relationships"] })',
+        'Retrieve memories by ID. Returns full details with comment_count, flag_count, relationship_count. Use include param to get full comments/flags/relationships arrays instead of counts. With include: ["relationships"], no need to call memory_relationships separately (fetched in both directions). Common flow: memory_list → memory_get. Inaccessible or missing IDs silently omitted (check meta.omitted). Example: memory_get({ ids: ["abc123"], user_id: "alice", include: ["comments", "relationships"] })',
       inputSchema: {
         ids: z
           .array(z.string().min(1))
@@ -24,7 +24,7 @@ export function registerMemoryGet(
           .array(z.enum(["comments", "flags", "relationships"]))
           .optional()
           .describe(
-            'Optional: expand these fields to full arrays instead of counts. E.g. ["comments", "relationships"]',
+            'Expand these fields to full arrays instead of counts. E.g. ["comments", "relationships"]',
           ),
       },
     },

--- a/src/tools/memory-list-recent.ts
+++ b/src/tools/memory-list-recent.ts
@@ -12,8 +12,8 @@ export function registerMemoryListRecent(
     "memory_list_recent",
     {
       description:
-        "List memories created or updated after a given timestamp. Useful for team activity awareness. " +
-        "Each result includes a change_type indicating whether it was created, updated, or commented. " +
+        "List memories created or updated after a timestamp. For team activity awareness. " +
+        "Each result has change_type: created, updated, or commented. " +
         'Example: memory_list_recent({ workspace_id: "my-project", user_id: "alice", since: "2026-03-20T00:00:00Z" })',
       inputSchema: {
         workspace_id: slugSchema.describe("Workspace slug"),
@@ -21,7 +21,7 @@ export function registerMemoryListRecent(
         since: z
           .string()
           .datetime()
-          .describe("ISO timestamp -- return memories changed after this time"),
+          .describe("ISO timestamp — return memories changed after this time"),
         limit: z
           .number()
           .int()
@@ -33,7 +33,7 @@ export function registerMemoryListRecent(
           .boolean()
           .default(false)
           .describe(
-            "When true, exclude memories authored by you (useful for 'what did teammates do?')",
+            "If true, exclude memories authored by you (for 'what did teammates do?')",
           ),
       },
     },

--- a/src/tools/memory-list-stale.ts
+++ b/src/tools/memory-list-stale.ts
@@ -12,7 +12,7 @@ export function registerMemoryListStale(
     "memory_list_stale",
     {
       description:
-        'List memories that haven\'t been verified within a threshold. Helps identify knowledge that may be outdated. user_id is required -- only workspace/project-scoped memories and your own user-scoped memories are returned. Example: memory_list_stale({ workspace_id: "my-project", user_id: "alice", threshold_days: 30 })',
+        'List memories not verified within threshold. Surfaces possibly outdated knowledge. user_id required — returns workspace/project-scoped memories plus your own user-scoped memories. Example: memory_list_stale({ workspace_id: "my-project", user_id: "alice", threshold_days: 30 })',
       inputSchema: {
         workspace_id: slugSchema.describe(
           "Workspace slug (e.g., 'my-project')",

--- a/src/tools/memory-list.ts
+++ b/src/tools/memory-list.ts
@@ -19,7 +19,7 @@ export function registerMemoryList(
     "memory_list",
     {
       description:
-        'Browse memories with filtering, sorting, and pagination. Supports multiple scopes in one call, e.g. scope: ["workspace", "user", "project"]. Scope is honored literally — pass "project" explicitly to include cross-workspace (global) memories. Example: memory_list({ workspace_id: "my-project", user_id: "alice", scope: ["workspace", "user"] })',
+        'Browse memories with filter, sort, pagination. Multi-scope in one call, e.g. scope: ["workspace", "user", "project"]. Scope honored literally — pass "project" explicitly to include cross-workspace (global) memories. Example: memory_list({ workspace_id: "my-project", user_id: "alice", scope: ["workspace", "user"] })',
       inputSchema: {
         workspace_id: slugSchema
           .optional()
@@ -31,14 +31,14 @@ export function registerMemoryList(
           .min(1)
           .default(["workspace"])
           .describe(
-            'Scopes to include, e.g. ["workspace", "user", "project"]. Defaults to ["workspace"]. Scope is honored literally — pass "project" explicitly to include cross-workspace (global) memories.',
+            'Scopes to include, e.g. ["workspace", "user", "project"]. Defaults to ["workspace"]. Honored literally — pass "project" explicitly to include cross-workspace (global) memories.',
           ),
         user_id: userIdSchema,
         type: memoryTypeEnum.optional().describe("Filter by memory type"),
         tags: z
           .array(z.string())
           .optional()
-          .describe("Filter by tags (memories matching ANY of these tags)"),
+          .describe("Filter by tags (memories matching ANY tag)"),
         sort_by: z
           .enum(["created_at", "updated_at"])
           .default("created_at")

--- a/src/tools/memory-relate.ts
+++ b/src/tools/memory-relate.ts
@@ -14,28 +14,28 @@ export function registerMemoryRelate(
   server.registerTool(
     "memory_relate",
     {
-      description: `Create a directional relationship between two memories. Idempotent: if an identical relationship (same source, target, and type) already exists, returns the existing one. Well-known types: ${wellKnownList}. Any descriptive string is also valid.`,
+      description: `Create directional relationship between two memories. Idempotent: identical relationship (same source, target, type) returns existing one. Well-known types: ${wellKnownList}. Any descriptive string valid.`,
       inputSchema: {
-        source_id: z.string().describe("ID of the source memory"),
-        target_id: z.string().describe("ID of the target memory"),
+        source_id: z.string().describe("ID of source memory"),
+        target_id: z.string().describe("ID of target memory"),
         type: z
           .string()
           .min(1)
           .max(64)
           .describe(
-            `Relationship type. Well-known: ${wellKnownList}. Any descriptive string is also valid.`,
+            `Relationship type. Well-known: ${wellKnownList}. Any descriptive string valid.`,
           ),
         description: z
           .string()
           .max(500)
           .optional()
-          .describe("Optional human-readable description of the relationship"),
+          .describe("Human-readable description of relationship"),
         confidence: z
           .number()
           .min(0)
           .max(1)
           .optional()
-          .describe("Confidence score between 0 and 1 (default: 1.0)"),
+          .describe("Confidence score 0-1 (default: 1.0)"),
         user_id: userIdSchema,
         created_via: z
           .string()

--- a/src/tools/memory-relationships.ts
+++ b/src/tools/memory-relationships.ts
@@ -12,7 +12,7 @@ export function registerMemoryRelationships(
     "memory_relationships",
     {
       description:
-        'List relationships for one or more memories. Returns all relationships in the requested direction, optionally filtered by type. Example: memory_relationships({ memory_ids: ["abc123", "def456"], user_id: "alice", direction: "both" })',
+        'List relationships for memories. Returns all in requested direction, optionally filtered by type. Example: memory_relationships({ memory_ids: ["abc123", "def456"], user_id: "alice", direction: "both" })',
       inputSchema: {
         memory_ids: z
           .array(z.string().min(1))
@@ -23,12 +23,9 @@ export function registerMemoryRelationships(
           .enum(["outgoing", "incoming", "both"])
           .default("both")
           .describe(
-            'Direction to filter: "outgoing" (memory is source), "incoming" (memory is target), or "both" (default)',
+            'Direction: "outgoing" (memory is source), "incoming" (memory is target), or "both" (default)',
           ),
-        type: z
-          .string()
-          .optional()
-          .describe("Optional relationship type filter"),
+        type: z.string().optional().describe("Relationship type filter"),
         user_id: userIdSchema,
       },
     },

--- a/src/tools/memory-resolve-flag.ts
+++ b/src/tools/memory-resolve-flag.ts
@@ -12,16 +12,16 @@ export function registerMemoryResolveFlag(
     "memory_resolve_flag",
     {
       description:
-        "Resolve a flag on a memory. Use after the user has reviewed a flagged issue " +
-        "(duplicate, superseded, verify, etc.) and decided on an action. " +
+        "Resolve flag on memory. Use after user reviewed flagged issue " +
+        "(duplicate, superseded, verify, etc.) and decided action. " +
         "resolution: 'accepted' = acted on, 'dismissed' = false positive, 'deferred' = skip for now. " +
         'Example: memory_resolve_flag({ flag_id: "abc123", user_id: "alice", resolution: "accepted" })',
       inputSchema: {
-        flag_id: z.string().min(1).describe("The flag ID to resolve"),
+        flag_id: z.string().min(1).describe("Flag ID to resolve"),
         user_id: userIdSchema,
         resolution: z
           .enum(["accepted", "dismissed", "deferred"])
-          .describe("How the flag was resolved"),
+          .describe("How flag was resolved"),
       },
     },
     async (params) => {

--- a/src/tools/memory-search.ts
+++ b/src/tools/memory-search.ts
@@ -16,7 +16,7 @@ export function registerMemorySearch(
     "memory_search",
     {
       description:
-        'Search memories by semantic similarity across one or more scopes. Returns ranked results with relevance scores. user_id is required for all searches to enforce scope-based access control. Example: memory_search({ workspace_id: "my-project", query: "database migration patterns", user_id: "alice", scope: ["workspace", "user"] })',
+        'Search memories by semantic similarity across scopes. Returns ranked results with relevance scores. user_id required — enforces scope-based access control. Example: memory_search({ workspace_id: "my-project", query: "database migration patterns", user_id: "alice", scope: ["workspace", "user"] })',
       inputSchema: {
         workspace_id: slugSchema.describe(
           "Workspace slug to search within (e.g., 'my-project')",
@@ -27,7 +27,7 @@ export function registerMemorySearch(
           .min(1)
           .default(["workspace"])
           .describe(
-            'Scopes to search, e.g. ["workspace", "user", "project"]. Defaults to ["workspace"]. Scope is honored literally — pass "project" explicitly to include cross-workspace (global) memories.',
+            'Scopes to search, e.g. ["workspace", "user", "project"]. Defaults to ["workspace"]. Honored literally — pass "project" explicitly to include cross-workspace (global) memories.',
           ),
         user_id: userIdSchema,
         limit: z
@@ -36,13 +36,13 @@ export function registerMemorySearch(
           .min(1)
           .max(100)
           .default(10)
-          .describe("Max results to return (default 10)"),
+          .describe("Max results (default 10)"),
         min_similarity: z
           .number()
           .min(0)
           .max(1)
           .default(0.3)
-          .describe("Minimum similarity threshold (default 0.3)"),
+          .describe("Min similarity threshold (default 0.3)"),
       },
     },
     async (params) => {

--- a/src/tools/memory-session-start.ts
+++ b/src/tools/memory-session-start.ts
@@ -16,9 +16,9 @@ export function registerMemorySessionStart(
     "memory_session_start",
     {
       description:
-        "Load relevant memories at session start. Searches workspace + user scopes (ranked) and always includes all project-scoped (global) memories. " +
-        "user_id is required -- use your OS username in lowercase (run 'whoami' and convert to lowercase if needed). " +
-        "Provide context for relevance-ranked results, or omit for recent memories. " +
+        "Load relevant memories at session start. Searches workspace + user scopes (ranked); always includes all project-scoped (global) memories. " +
+        "user_id required — use OS username in lowercase (run 'whoami', lowercase it). " +
+        "Pass context for relevance-ranked results, or omit for recent memories. " +
         'Example: memory_session_start({ workspace_id: "my-project", user_id: "alice" })',
       inputSchema: {
         workspace_id: slugSchema.describe(
@@ -29,7 +29,7 @@ export function registerMemorySessionStart(
           .string()
           .optional()
           .describe(
-            "What the agent is working on (used for semantic relevance ranking)",
+            "What agent is working on (drives semantic relevance ranking)",
           ),
         limit: z
           .number()
@@ -38,10 +38,10 @@ export function registerMemorySessionStart(
           .max(50)
           .default(10)
           .describe(
-            "Max workspace/user-scoped memories to return (default 10). Project-scoped memories are returned separately, bounded by project_limit. Total response may contain up to limit + project_limit memories.",
+            "Max workspace/user-scoped memories (default 10). Project-scoped returned separately, bounded by project_limit. Response may contain up to limit + project_limit memories.",
           ),
         project_limit: projectLimitSchema.describe(
-          `Max project-scoped (global) memories to always include (default ${PROJECT_LIMIT_DEFAULT})`,
+          `Max project-scoped (global) memories always included (default ${PROJECT_LIMIT_DEFAULT})`,
         ),
       },
     },

--- a/src/tools/memory-unrelate.ts
+++ b/src/tools/memory-unrelate.ts
@@ -12,7 +12,7 @@ export function registerMemoryUnrelate(
     "memory_unrelate",
     {
       description:
-        'Remove (soft-delete) a relationship by relationship ID. The relationship is archived and excluded from all queries. Example: memory_unrelate({ id: "abc123", user_id: "alice" })',
+        'Remove (soft-delete) relationship by ID. Archived and excluded from all queries. Example: memory_unrelate({ id: "abc123", user_id: "alice" })',
       inputSchema: {
         id: z.string().describe("Relationship ID to remove"),
         user_id: userIdSchema,

--- a/src/tools/memory-update.ts
+++ b/src/tools/memory-update.ts
@@ -16,18 +16,16 @@ export function registerMemoryUpdate(
     "memory_update",
     {
       description:
-        'Update an existing memory. Send only the fields you want to change (PATCH-style). Requires version for optimistic locking. user_id is required for access control -- only the owner can update user-scoped memories. Example: memory_update({ id: "abc123", version: 1, content: "Updated content", user_id: "alice" })',
+        'Update existing memory. Send only fields to change (PATCH-style). Requires version for optimistic locking. user_id required — only owner can update user-scoped memories. Example: memory_update({ id: "abc123", version: 1, content: "Updated content", user_id: "alice" })',
       inputSchema: {
         id: z.string().describe("Memory ID to update"),
         version: z
           .number()
           .int()
-          .describe(
-            "Current version of the memory (for optimistic locking, prevents conflicts)",
-          ),
+          .describe("Current version (optimistic locking, prevents conflicts)"),
         content: contentSchema
           .optional()
-          .describe("New content text. Must not be empty if provided."),
+          .describe("New content. Non-empty if provided."),
         title: z.string().optional().describe("New title"),
         type: memoryTypeEnum
           .optional()

--- a/src/tools/memory-verify.ts
+++ b/src/tools/memory-verify.ts
@@ -12,7 +12,7 @@ export function registerMemoryVerify(
     "memory_verify",
     {
       description:
-        'Mark a memory as still accurate. Updates the verified_at timestamp and records who verified it. user_id is required. Project-scoped memories can be verified by anyone; user-scoped memories only by the owner. Example: memory_verify({ id: "abc123", user_id: "alice" })',
+        'Mark memory as still accurate. Updates verified_at timestamp, records verifier. user_id required. Project-scoped memories verifiable by anyone; user-scoped only by owner. Example: memory_verify({ id: "abc123", user_id: "alice" })',
       inputSchema: {
         id: z.string().describe("Memory ID to verify"),
         user_id: userIdSchema,

--- a/src/tools/memory-verify.ts
+++ b/src/tools/memory-verify.ts
@@ -12,7 +12,7 @@ export function registerMemoryVerify(
     "memory_verify",
     {
       description:
-        'Mark memory as still accurate. Updates verified_at timestamp, records verifier. user_id required. Project-scoped memories verifiable by anyone; user-scoped only by owner. Example: memory_verify({ id: "abc123", user_id: "alice" })',
+        'Mark memory as still accurate. Updates verified_at timestamp, records verifier. user_id required — project-scoped memories verifiable by anyone; user-scoped only by owner. Example: memory_verify({ id: "abc123", user_id: "alice" })',
       inputSchema: {
         id: z.string().describe("Memory ID to verify"),
         user_id: userIdSchema,

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -16,7 +16,7 @@ export const slugSchema = z
 
 // Shared schema for user_id parameters — instructs agents to pass the OS username in lowercase
 export const userIdSchema = slugSchema.describe(
-  "Your OS username in lowercase. Run 'whoami' and convert to lowercase if needed (e.g., 'alice', not 'Alice' or 'ALICE'). Required for access control and to load user-scoped memories.",
+  "Your OS username, lowercase. Run 'whoami', lowercase it (e.g., 'alice', not 'Alice' or 'ALICE'). Required for access control + to load user-scoped memories.",
 );
 
 // D-75: Non-empty content validation for memory_create, memory_update, memory_comment
@@ -38,10 +38,10 @@ export const memoryTypeEnum = z.enum([
 export const memoryScopeEnum = z.enum(["workspace", "user", "project"]);
 
 // Source-of-save enum — locked to three values to prevent label drift.
-// - "manual": user explicitly asked the agent to save ("remember X", "save that").
-//   Bypasses write budget and project-scope confirmation guard.
-// - "agent-auto": autonomous save during a live conversation. Default for agent-initiated captures.
-// - "session-review": autonomous save triggered ONLY by the end-of-session Stop-hook review.
+// - "manual": user explicitly asked agent to save ("remember X", "save that").
+//   Bypasses write budget + project-scope confirmation guard.
+// - "agent-auto": autonomous save mid-conversation. Default for agent-initiated captures.
+// - "session-review": autonomous save triggered ONLY by end-of-session Stop-hook review.
 export const memorySourceEnum = z.enum([
   "manual",
   "agent-auto",


### PR DESCRIPTION
## Summary
- Caveman-style compression of MCP tool `description` fields, Zod `.describe()` strings, and `MEMORY_GUIDANCE_TEXT` prompt across `src/tools/memory-*.ts` + `src/utils/validation.ts`.
- Same treatment for agent-facing snippets in `hooks/claude/claude-md-snippet.md` and `hooks/copilot/instructions-snippet.md` (~14% byte reduction each).
- Drops articles/filler/hedging; preserves structure, code, paths, enum values, and load-bearing semantics (source-field when-each mapping, project-scope confirmation rules).
- Reduces input tokens on every MCP handshake and guidance-snippet load. No behavior change.

## Test plan
- [ ] `npm run typecheck` clean
- [ ] `npm run test:unit` green
- [ ] `npm run lint` clean
- [ ] Spot-check one tool description in a live MCP session renders sensibly
- [ ] Diff review confirms no enum / default / code-path wording altered

🤖 Generated with [Claude Code](https://claude.com/claude-code)