### PR TITLE
refactor(backend): extract StorageBackend abstraction (vault Phase 0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,9 @@
 # Project identifier (required) — identifies this server deployment
 PROJECT_ID=my-project
 
+# Storage backend: postgres (default) | vault (planned, not yet implemented)
+AGENT_BRAIN_BACKEND=postgres
+
 # Database
 DATABASE_URL=postgresql://agentic:agentic@localhost:5432/agent_brain
 

--- a/docs/superpowers/plans/2026-04-21-vault-backend-phase-0-abstraction.md
+++ b/docs/superpowers/plans/2026-04-21-vault-backend-phase-0-abstraction.md
@@ -1,0 +1,617 @@
+# Vault Backend Phase 0 — StorageBackend Abstraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract a `StorageBackend` abstraction that wraps the 8 existing repository interfaces so the Postgres backend is selected via factory rather than wired directly in `server.ts`. No behavior change. Unblocks later phases that will add a `VaultBackend` implementation.
+
+**Architecture:** Introduce `src/backend/` tree: (a) `types.ts` declares a `StorageBackend` interface that bundles all repositories plus a `close()` lifecycle hook; (b) `postgres/index.ts` wraps the existing `Drizzle*Repository` classes in a `PostgresBackend` class; (c) `factory.ts` reads `AGENT_BRAIN_BACKEND` and returns the configured backend. `server.ts` replaces its 8 ad-hoc `new DrizzleXRepository(db)` lines with a single `await createBackend(config)` call and destructures repos from the result. Scheduler wiring stays pg-specific via a type guard (the scheduler uses pg advisory locks; vault won't need them).
+
+**Tech Stack:** TypeScript, drizzle-orm, postgres-js, zod, vitest.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-21-vault-backend-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+
+- `src/backend/types.ts` — `StorageBackend` interface + `BackendName` string literal union
+- `src/backend/postgres/index.ts` — `PostgresBackend` class implementing `StorageBackend`
+- `src/backend/factory.ts` — `createBackend(config)` factory
+- `tests/unit/backend/factory.test.ts` — factory unit tests
+
+**Modify:**
+
+- `src/config.ts` — add `backend` field to config schema (zod enum, `postgres` default)
+- `src/server.ts` — replace repo construction with `createBackend()`, destructure repos from result, move `db.$client.end()` into `PostgresBackend.close()`
+- `.env.example` — document `AGENT_BRAIN_BACKEND`
+
+**Unchanged (imported by new code):**
+
+- `src/repositories/types.ts` — repo interfaces (already clean abstractions)
+- `src/repositories/*.ts` — drizzle implementations
+- `src/services/*.ts` — services already depend on repo interfaces, not drizzle classes
+
+---
+
+## Task 1: Create StorageBackend interface
+
+**Files:**
+
+- Create: `src/backend/types.ts`
+
+- [ ] **Step 1: Create the backend types file**
+
+```typescript
+// src/backend/types.ts
+import type {
+  MemoryRepository,
+  WorkspaceRepository,
+  CommentRepository,
+  SessionTrackingRepository,
+  SessionRepository,
+  AuditRepository,
+  FlagRepository,
+  RelationshipRepository,
+  SchedulerStateRepository,
+} from "../repositories/types.js";
+
+export type BackendName = "postgres" | "vault";
+
+/**
+ * Storage backend abstraction. Bundles the eight repository interfaces
+ * plus a lifecycle hook. `server.ts` constructs one of these via
+ * `createBackend()` and passes the individual repos to services.
+ *
+ * New backends (e.g. vault) implement this interface without touching
+ * service or tool code.
+ */
+export interface StorageBackend {
+  readonly name: BackendName;
+  readonly memoryRepo: MemoryRepository;
+  readonly workspaceRepo: WorkspaceRepository;
+  readonly commentRepo: CommentRepository;
+  readonly sessionRepo: SessionTrackingRepository;
+  readonly sessionLifecycleRepo: SessionRepository;
+  readonly auditRepo: AuditRepository;
+  readonly flagRepo: FlagRepository;
+  readonly relationshipRepo: RelationshipRepository;
+  readonly schedulerStateRepo: SchedulerStateRepository;
+  close(): Promise<void>;
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS (no references yet — file exists but nothing imports it).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/backend/types.ts
+git commit -m "feat(backend): introduce StorageBackend interface"
+```
+
+---
+
+## Task 2: Create PostgresBackend implementation
+
+**Files:**
+
+- Create: `src/backend/postgres/index.ts`
+
+- [ ] **Step 1: Create the PostgresBackend class**
+
+```typescript
+// src/backend/postgres/index.ts
+import { createDb, type Database } from "../../db/index.js";
+import { runMigrations } from "../../db/migrate.js";
+import { DrizzleMemoryRepository } from "../../repositories/memory-repository.js";
+import { DrizzleWorkspaceRepository } from "../../repositories/workspace-repository.js";
+import { DrizzleCommentRepository } from "../../repositories/comment-repository.js";
+import {
+  DrizzleSessionTrackingRepository,
+  DrizzleSessionRepository,
+} from "../../repositories/session-repository.js";
+import { DrizzleAuditRepository } from "../../repositories/audit-repository.js";
+import { DrizzleFlagRepository } from "../../repositories/flag-repository.js";
+import { DrizzleRelationshipRepository } from "../../repositories/relationship-repository.js";
+import { DrizzleSchedulerStateRepository } from "../../repositories/scheduler-state-repository.js";
+import type { StorageBackend, BackendName } from "../types.js";
+import type {
+  MemoryRepository,
+  WorkspaceRepository,
+  CommentRepository,
+  SessionTrackingRepository,
+  SessionRepository,
+  AuditRepository,
+  FlagRepository,
+  RelationshipRepository,
+  SchedulerStateRepository,
+} from "../../repositories/types.js";
+
+/**
+ * Postgres + pgvector backend. Holds the drizzle Database handle and the
+ * eight Drizzle* repository instances. `close()` ends the postgres-js
+ * connection pool.
+ *
+ * Construct via `PostgresBackend.create(databaseUrl)` — it runs migrations
+ * before returning, matching the prior inline behavior in `server.ts`.
+ */
+export class PostgresBackend implements StorageBackend {
+  readonly name: BackendName = "postgres";
+  readonly memoryRepo: MemoryRepository;
+  readonly workspaceRepo: WorkspaceRepository;
+  readonly commentRepo: CommentRepository;
+  readonly sessionRepo: SessionTrackingRepository;
+  readonly sessionLifecycleRepo: SessionRepository;
+  readonly auditRepo: AuditRepository;
+  readonly flagRepo: FlagRepository;
+  readonly relationshipRepo: RelationshipRepository;
+  readonly schedulerStateRepo: SchedulerStateRepository;
+
+  private constructor(readonly db: Database) {
+    this.memoryRepo = new DrizzleMemoryRepository(db);
+    this.workspaceRepo = new DrizzleWorkspaceRepository(db);
+    this.commentRepo = new DrizzleCommentRepository(db);
+    this.sessionRepo = new DrizzleSessionTrackingRepository(db);
+    this.sessionLifecycleRepo = new DrizzleSessionRepository(db);
+    this.auditRepo = new DrizzleAuditRepository(db);
+    this.flagRepo = new DrizzleFlagRepository(db);
+    this.relationshipRepo = new DrizzleRelationshipRepository(db);
+    this.schedulerStateRepo = new DrizzleSchedulerStateRepository(db);
+  }
+
+  static async create(databaseUrl: string): Promise<PostgresBackend> {
+    const db = createDb(databaseUrl);
+    await runMigrations(db);
+    return new PostgresBackend(db);
+  }
+
+  async close(): Promise<void> {
+    await this.db.$client.end();
+  }
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/backend/postgres/index.ts
+git commit -m "feat(backend): add PostgresBackend wrapping existing drizzle repos"
+```
+
+---
+
+## Task 3: Add `backend` field to config
+
+**Files:**
+
+- Modify: `src/config.ts`
+
+- [ ] **Step 1: Add the backend field to the zod schema**
+
+Edit `src/config.ts`. Insert the new field after `projectId` and before `databaseUrl` (roughly lines 5-6 area) and add the env-var mapping in the `configSchema.parse({...})` call.
+
+Change in schema (insert new field):
+
+```typescript
+const configSchema = z.object({
+  projectId: z.string().default(""),
+  backend: z.enum(["postgres", "vault"]).default("postgres"),
+  databaseUrl: z
+    .string()
+    .default("postgresql://agentic:agentic@localhost:5432/agent_brain"),
+  // ... (unchanged fields below)
+```
+
+Change in the `parse({...})` call (insert new mapping):
+
+```typescript
+export const config = configSchema.parse({
+  projectId: process.env.PROJECT_ID ?? "",
+  backend: process.env.AGENT_BRAIN_BACKEND,
+  databaseUrl: process.env.DATABASE_URL,
+  // ... (unchanged fields below)
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Run unit tests**
+
+Run: `npm run test:unit`
+Expected: PASS — 143 tests, unchanged.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/config.ts
+git commit -m "feat(config): add AGENT_BRAIN_BACKEND selector"
+```
+
+---
+
+## Task 4: Create backend factory — TDD
+
+**Files:**
+
+- Create: `src/backend/factory.ts`
+- Create: `tests/unit/backend/factory.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/backend/factory.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { createBackend } from "../../../src/backend/factory.js";
+
+describe("createBackend", () => {
+  it("throws when given the vault backend name (not yet implemented)", async () => {
+    await expect(
+      createBackend({ backend: "vault", databaseUrl: "postgresql://unused" }),
+    ).rejects.toThrow(/vault backend is not yet implemented/i);
+  });
+
+  it("throws when given an unknown backend name", async () => {
+    await expect(
+      createBackend({
+        // @ts-expect-error — intentionally exercising a runtime-only bad value
+        backend: "nosuch",
+        databaseUrl: "postgresql://unused",
+      }),
+    ).rejects.toThrow(/unknown backend/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test:unit -- tests/unit/backend/factory.test.ts`
+Expected: FAIL with "Cannot find module" (factory.ts doesn't exist yet).
+
+- [ ] **Step 3: Create the factory**
+
+Create `src/backend/factory.ts`:
+
+```typescript
+// src/backend/factory.ts
+import type { BackendName, StorageBackend } from "./types.js";
+import { PostgresBackend } from "./postgres/index.js";
+
+export interface BackendConfig {
+  backend: BackendName;
+  databaseUrl: string;
+}
+
+/**
+ * Select and construct the configured storage backend.
+ *
+ * Phase 0 only ships the postgres backend. The vault backend is
+ * declared in the type enum so downstream code can already switch on
+ * it, but `createBackend({ backend: "vault" })` throws until Phase 1+
+ * lands the implementation.
+ */
+export async function createBackend(
+  config: BackendConfig,
+): Promise<StorageBackend> {
+  switch (config.backend) {
+    case "postgres":
+      return PostgresBackend.create(config.databaseUrl);
+    case "vault":
+      throw new Error(
+        "vault backend is not yet implemented — set AGENT_BRAIN_BACKEND=postgres",
+      );
+    default: {
+      // Exhaustiveness + runtime guard for an env-var typo that slipped past zod.
+      const _exhaustive: never = config.backend;
+      throw new Error(`unknown backend: ${String(_exhaustive)}`);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify the "vault" case passes**
+
+Run: `npm run test:unit -- tests/unit/backend/factory.test.ts`
+Expected: The "vault" test passes. The "unknown backend" test may still fail because zod rejects `"nosuch"` before reaching the factory — but this test bypasses zod entirely (direct call to `createBackend`) so it should reach the `default` branch and pass.
+
+If both pass: proceed. If not: inspect the failure; fix factory to match expected error messages. Do not change the test's expected regexes.
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/backend/factory.ts tests/unit/backend/factory.test.ts
+git commit -m "feat(backend): add createBackend factory with vault stub"
+```
+
+---
+
+## Task 5: Refactor server.ts to use the factory
+
+**Files:**
+
+- Modify: `src/server.ts`
+
+This task re-wires the existing server code. Behavior MUST NOT change; all integration tests run against pg and must stay green.
+
+- [ ] **Step 1: Replace repo + db construction with the factory**
+
+In `src/server.ts`, delete the existing imports for individual Drizzle repos and `createDb` / `runMigrations`. Replace with factory import.
+
+Remove these lines (around lines 7-20):
+
+```typescript
+import { createDb } from "./db/index.js";
+import { runMigrations } from "./db/migrate.js";
+// ... and all Drizzle*Repository imports
+```
+
+Add:
+
+```typescript
+import { createBackend } from "./backend/factory.js";
+import { PostgresBackend } from "./backend/postgres/index.js";
+```
+
+- [ ] **Step 2: Replace the inline db+migration+repos block with `createBackend()`**
+
+Replace the block from roughly line 46 (`// Initialize database`) through line 95 (last `const relationshipRepo = ...`) with:
+
+```typescript
+// Initialize storage backend (runs migrations for postgres)
+let backend;
+try {
+  backend = await createBackend({
+    backend: config.backend,
+    databaseUrl: config.databaseUrl,
+  });
+} catch (err: unknown) {
+  const msg = err instanceof Error ? err.message : String(err);
+  const code =
+    err != null && typeof err === "object" && "code" in err
+      ? (err as { code: string }).code
+      : "";
+  const isConnectionError =
+    code === "ECONNREFUSED" ||
+    code === "ENOTFOUND" ||
+    code === "ECONNRESET" ||
+    code.startsWith("08"); // PostgreSQL connection exception class
+  if (isConnectionError) {
+    logger.error(
+      `Database connection failed: ${msg}. Is PostgreSQL running? Try: docker compose up -d`,
+    );
+  } else {
+    logger.error(`Backend initialization failed: ${msg}`);
+  }
+  throw err;
+}
+logger.info(`Backend ready: ${backend.name}`);
+
+// Initialize embedding provider
+const embedder = createEmbeddingProvider();
+logger.info(
+  `Embedding provider: ${embedder.modelName} (${embedder.dimensions}d)`,
+);
+
+// Validate project ID
+if (!config.projectId) {
+  logger.error("PROJECT_ID environment variable is required");
+  process.exit(1);
+}
+logger.info(`Project: ${config.projectId}`);
+
+// Destructure repositories from the backend
+const {
+  memoryRepo,
+  workspaceRepo,
+  commentRepo,
+  sessionRepo,
+  sessionLifecycleRepo,
+  auditRepo,
+  flagRepo,
+  relationshipRepo,
+} = backend;
+```
+
+- [ ] **Step 3: Update the scheduler-wiring block to use the backend**
+
+Around the `if (config.consolidationEnabled) {` block (roughly line 132), replace the body. The scheduler currently uses `db` directly for advisory locks — that's pg-specific, so we only wire it when the backend is actually `PostgresBackend`.
+
+Replace:
+
+```typescript
+if (config.consolidationEnabled) {
+  const schedulerStateRepo = new DrizzleSchedulerStateRepository(db);
+  const consolidationJob = new ConsolidationJob(
+    consolidationService,
+    db,
+    schedulerStateRepo,
+  );
+  // ...
+}
+```
+
+With:
+
+```typescript
+if (config.consolidationEnabled) {
+  if (!(backend instanceof PostgresBackend)) {
+    logger.warn(
+      `Consolidation scheduler requires postgres backend; current backend is '${backend.name}'. Scheduler disabled.`,
+    );
+  } else {
+    const consolidationJob = new ConsolidationJob(
+      consolidationService,
+      backend.db,
+      backend.schedulerStateRepo,
+    );
+    consolidationScheduler = new ConsolidationScheduler(
+      consolidationJob,
+      config.consolidationCron,
+      backend.schedulerStateRepo,
+      {
+        enabled: config.consolidationCatchupEnabled,
+        graceSeconds: config.consolidationCatchupGraceSeconds,
+      },
+    );
+    await consolidationScheduler.start();
+  }
+}
+```
+
+- [ ] **Step 4: Replace the shutdown hook with backend.close()**
+
+Replace:
+
+```typescript
+const shutdown = async () => {
+  logger.info("Shutting down...");
+  if (consolidationScheduler) {
+    await consolidationScheduler.stop();
+  }
+  await db.$client.end();
+  process.exit(0);
+};
+```
+
+With:
+
+```typescript
+const shutdown = async () => {
+  logger.info("Shutting down...");
+  if (consolidationScheduler) {
+    await consolidationScheduler.stop();
+  }
+  await backend.close();
+  process.exit(0);
+};
+```
+
+- [ ] **Step 5: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS. Fix any dangling references to the removed `db` local (only inside the scheduler block and shutdown hook should have used it — both now use `backend.db` / `backend.close()`).
+
+- [ ] **Step 6: Run the server-boot smoke test**
+
+Run: `npm run test:unit -- tests/unit/server-boot.test.ts`
+Expected: PASS. This test spawns `node --import tsx` and imports `src/server.ts` under the real Node ESM loader (no boot, just graph resolution). Catches the most common regression source in this file (CJS/ESM interop).
+
+- [ ] **Step 7: Run the full unit suite**
+
+Run: `npm run test:unit`
+Expected: PASS — 143 tests + 2 new factory tests = 145.
+
+- [ ] **Step 8: Run integration tests (requires docker pg)**
+
+Run: `docker compose up -d db && npm run test:integration`
+Expected: PASS. All existing integration tests use a live postgres; the refactor must preserve their behavior byte-for-byte.
+
+- [ ] **Step 9: Boot the server locally to smoke-test**
+
+Run: `AGENT_BRAIN_BACKEND=postgres npm run dev`
+Expected: log line `Backend ready: postgres`, followed by `Server ready on http://127.0.0.1:19898/mcp`. Ctrl-C to stop.
+
+- [ ] **Step 10: Verify the vault path fails cleanly**
+
+Run: `AGENT_BRAIN_BACKEND=vault npm run dev`
+Expected: Fatal error with message `vault backend is not yet implemented — set AGENT_BRAIN_BACKEND=postgres`. Process exits non-zero.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/server.ts
+git commit -m "refactor(server): wire storage via createBackend factory"
+```
+
+---
+
+## Task 6: Document the new env var
+
+**Files:**
+
+- Modify: `.env.example`
+
+- [ ] **Step 1: Add AGENT_BRAIN_BACKEND to .env.example**
+
+Edit `.env.example`. Insert immediately above the existing `DATABASE_URL` line:
+
+```
+# Storage backend: postgres (default) | vault (planned, not yet implemented)
+AGENT_BRAIN_BACKEND=postgres
+
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .env.example
+git commit -m "docs(env): document AGENT_BRAIN_BACKEND selector"
+```
+
+---
+
+## Task 7: Final verification
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npm run test:unit`
+Expected: 145 tests pass.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Lint**
+
+Run: `npm run lint`
+Expected: no errors.
+
+- [ ] **Step 4: Format**
+
+Run: `npm run format`
+Expected: no diff (if any, commit as chore).
+
+- [ ] **Step 5: Review the diff**
+
+Run: `git diff main...HEAD --stat`
+Expected: only these paths changed:
+
+```
+.env.example
+docs/superpowers/plans/2026-04-21-vault-backend-phase-0-abstraction.md
+docs/superpowers/specs/2026-04-21-vault-backend-design.md
+src/backend/factory.ts
+src/backend/postgres/index.ts
+src/backend/types.ts
+src/config.ts
+src/server.ts
+tests/unit/backend/factory.test.ts
+```
+
+Any other modified file = regression. Investigate before proceeding.
+
+---
+
+## Notes for the next phase
+
+- Phase 1 (parser) adds `src/backend/vault/parser/*` — pure functions. No wiring into the factory yet.
+- Phase 2 (vault repos without git/vector) adds `src/backend/vault/repositories/*` + replaces the factory's `"vault"` branch with an actual `VaultBackend.create(...)` call. Factory tests switch from "throws" to "returns backend".
+- The `PostgresBackend instanceof` check in `server.ts` is intentional and survives Phase 1-3. Only when vault-appropriate scheduling (Phase 4+) is designed does that branch change.

--- a/docs/superpowers/specs/2026-04-21-vault-backend-design.md
+++ b/docs/superpowers/specs/2026-04-21-vault-backend-design.md
@@ -1,0 +1,461 @@
+# Vault Backend Design
+
+**Status:** design (pre-implementation)
+**Date:** 2026-04-21
+**Author:** chris
+
+## Purpose
+
+Provide a local-first, zero-infra storage backend for agent-brain as an alternative to the existing Postgres + pgvector backend. The backend uses a git-tracked Obsidian-compatible markdown vault as the source of truth, a file-based LanceDB vector index as a derived cache, and git push/pull as the team sync mechanism.
+
+## Drivers (ranked)
+
+1. **Kill the Postgres/Docker dependency.** Self-contained install so a developer can run agent-brain with just `npm i -g agent-brain` (or equivalent) + a git remote. No database, no container runtime, no separate service.
+2. **Human-readable, co-editable memories.** Memories are plain markdown files. A user opens the vault root in Obsidian and sees memories, relationships, comments, and flags rendered natively. The agent and the user write to the same files.
+3. **Portable team knowledge base.** The vault is a git repository. It can be shared, forked, cloned, reviewed in PRs, and moved between machines with zero infrastructure.
+
+Postgres remains a supported, first-class backend. The vault backend is an additional option selected per deployment.
+
+## Scope
+
+**In scope:**
+
+- A new `vault` storage backend implementing the existing `StorageBackend` interface.
+- Markdown schema for memories, comments, flags, relationships, workspaces that round-trips through an Obsidian vault.
+- LanceDB-backed vector index, gitignored and rebuildable from the vault.
+- Git sync layer: commit-per-write, debounced async push, pull on session start.
+- Chokidar watcher for external edits (e.g., edits made in Obsidian).
+- Bidirectional migration CLI (pg ⇄ vault).
+- Parameterized test suite that runs repository contract tests against both backends.
+
+**Out of scope:**
+
+- Centralized multi-client deployments against a shared vault (distributed topology only — each user runs their own server against their own clone).
+- Cross-device sync for `user`-scope memories by default. An opt-in symlink pattern is documented but not automated.
+- Real-time push (commits are debounced; team members see writes seconds later, not sub-second).
+- Per-workspace backend switching — the backend is chosen once per deployment.
+
+## Decisions (locked during brainstorm)
+
+| Decision                         | Value                                                                                                                |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| Runtime shape                    | Long-running HTTP MCP server (unchanged from today)                                                                  |
+| Topology                         | Distributed: each user runs their own server against their own vault clone; git remote = sync                        |
+| User-scope privacy               | `users/` directory gitignored by default; optional symlink to a separately-managed private git repo for cross-device |
+| Git sync cadence                 | Commit-per-write; push debounced (5s coalesce, async, retried on failure); pull on `memory_session_start`            |
+| Vector index                     | LanceDB (`@lancedb/lancedb`), file-based, HNSW                                                                       |
+| Postgres fate                    | Kept as supported option; vault is additive, opt-in                                                                  |
+| Backend selection granularity    | Per-deployment, via `AGENT_BRAIN_BACKEND=postgres\|vault` env var                                                    |
+| Abstraction seam                 | Repository-level: new `StorageBackend` interface wraps the existing 8 repository interfaces                          |
+| Relationships + comments storage | Inline in the source memory file — Dataview fields under `## Relationships`, Obsidian callouts under `## Comments`   |
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│             MCP Clients (Claude Code, Copilot, …)            │
+└──────────────────────────────┬───────────────────────────────┘
+                               │ HTTP JSON-RPC
+┌──────────────────────────────▼───────────────────────────────┐
+│                     agent-brain MCP server                   │
+│  ┌─────────────┐  ┌─────────────┐  ┌──────────────────────┐  │
+│  │   Tools     │→ │  Services   │→ │  StorageBackend      │  │
+│  │ (unchanged) │  │ (unchanged) │  │  (new interface)     │  │
+│  └─────────────┘  └─────────────┘  └──────────┬───────────┘  │
+│                                               │              │
+│                   ┌───────────────────────────┴──────────┐   │
+│           ┌───────▼─────────┐                  ┌─────────▼─────────┐
+│           │ PostgresBackend │                  │   VaultBackend    │
+│           │ (existing repos)│                  │                   │
+│           └───────┬─────────┘                  └────┬──────────────┘
+│                   │                                 │
+│         ┌─────────▼────────┐           ┌────────────┼───────────────┐
+│         │ Postgres +       │           │            │               │
+│         │ pgvector         │   ┌───────▼────┐ ┌─────▼────┐  ┌───────▼─────┐
+│         └──────────────────┘   │ Vault FS   │ │ LanceDB  │  │ Git ops     │
+│                                │ (markdown) │ │ (vectors)│  │ (commit,    │
+│                                └────────────┘ └──────────┘  │  push, pull)│
+│                                                             └─────────────┘
+└──────────────────────────────────────────────────────────────┘
+                                                              │
+                                                  ┌───────────▼────────────┐
+                                                  │   git remote (origin)  │
+                                                  │   shared vault repo    │
+                                                  └────────────────────────┘
+```
+
+**Key properties:**
+
+- **Single backend per deployment**, chosen by `AGENT_BRAIN_BACKEND`.
+- **Tools and services layer untouched.** New code is localized under `src/backend/vault/`.
+- **Vault = source of truth.** LanceDB index is a derived cache (rebuildable). Git history is the audit log. Runtime state (sessions, scheduler, vector index) lives under `.agent-brain/` and is gitignored.
+- **Distributed topology.** Each user runs their own server against their own clone. Writes commit locally and are pushed asynchronously. `memory_session_start` pulls before serving.
+- **Obsidian-native.** Opening the vault root in Obsidian presents a first-class knowledge graph: files per memory, wikilinks between them, callouts for comments, nested tags for flags, Dataview inline fields for typed relationships.
+
+## Vault layout
+
+```
+<vault-root>/
+├── .obsidian/                       # optional, checked in or gitignored per user pref
+├── .agent-brain/                    # runtime state, gitignored
+│   ├── index.lance/                 # LanceDB vector index
+│   ├── sessions.json                # live session budgets + session_tracking
+│   ├── scheduler.json               # scheduler_state
+│   └── config.json                  # project_id, embedding model/dims
+├── workspaces/
+│   └── <workspace-slug>/
+│       ├── _workspace.md            # workspace metadata (frontmatter only)
+│       └── memories/
+│           └── <memory-id>.md       # one file per workspace-scoped memory
+├── project/                         # project-scope memories (cross-workspace)
+│   └── memories/
+│       └── <memory-id>.md
+├── users/                           # user-scope (private) memories — gitignored by default
+│   └── <user-id>/
+│       └── <workspace-slug>/
+│           └── <memory-id>.md
+├── .gitignore                       # ignores .agent-brain/ and (default) users/
+└── .gitattributes                   # *.md merge=union for append-friendly merges
+```
+
+**Rationale:**
+
+- One file per memory. Folder path encodes scope + workspace. The repository infers scope from path, not only frontmatter — defence in depth against misfiled or manually moved files.
+- Filename is the nanoid memory id, not the title. Stable across title changes; no rename churn in git.
+- Obsidian sees the whole vault. Wikilinks `[[<id>]]` resolve across scopes.
+- `users/` gitignored by default keeps private memories local. Users who want cross-device sync symlink `users/<id>/` to a separately-cloned private git repo; from Obsidian's perspective the vault looks unified, while git sees two independent repositories.
+
+## Memory file schema
+
+```markdown
+---
+id: n86khHlXf88S8Fq4i1NwT
+title: Keep claude + copilot instruction snippets in sync
+type: pattern # fact | decision | learning | pattern | preference | architecture
+scope: workspace # workspace | user | project
+workspace_id: agent-brain # null for project-scope
+user_id: null # set for user-scope
+project_id: PERSONAL_PROJECTS
+author: chris
+source: manual # manual | agent-auto | session-review | consolidation
+session_id: s_abc123 # null if not applicable
+tags: [hooks, snippets, claude, copilot]
+version: 3
+created: 2026-04-21T10:15:00Z
+updated: 2026-04-21T11:02:00Z
+verified: 2026-04-21T11:02:00Z
+verified_by: chris
+archived: null
+last_comment: 2026-04-21T11:00:00Z
+embedding_model: amazon.titan-embed-text-v2:0
+embedding_dimensions: 1024
+metadata: {}
+flags:
+  - id: f_xyz
+    type: verify # duplicate | contradiction | override | superseded | verify
+    severity: needs_review # auto_resolved | needs_review
+    reason: referenced file may be renamed
+    related: n_other123
+    similarity: 0.91
+    created: 2026-04-21T10:20:00Z
+    resolved: null
+    resolved_by: null
+---
+
+# Keep claude + copilot instruction snippets in sync
+
+Body markdown. Link to other memories with `[[n_other123|Title]]`.
+
+## Relationships
+
+- supersedes:: [[n_oldversion]] — confidence: 1.0, via: consolidation
+- related:: [[n_sibling]] — confidence: 0.8, via: manual
+
+## Comments
+
+> [!comment] chris · 2026-04-21T11:00:00Z · c_abc
+> Confirmed still accurate after April sync.
+
+> [!comment] alice · 2026-04-21T11:30:00Z · c_def
+> Added CI check, see PR #42.
+```
+
+**Notes:**
+
+- Embedding vectors are **not** stored in the file. They live only in the LanceDB index (rebuildable). This keeps memory files small and diff-friendly.
+- Frontmatter `flags` array is the canonical flag store. A derived `#flag/<type>` tag is emitted into the body tag list for Obsidian tag-pane grouping.
+- `## Relationships` uses Dataview inline-field syntax (`type:: [[target]]`) so Dataview queries work, while plain-Obsidian users still see sensible markdown and wikilinks.
+- Comments use Obsidian callouts. The header line encodes `author · ISO timestamp · comment_id` deterministically so the parser can round-trip.
+
+## Entity mapping (vault vs runtime vs git history)
+
+| Current table      | Vault location  | Format                                                                                                                                                                                             |
+| ------------------ | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `memories`         | vault markdown  | per-file, as above                                                                                                                                                                                 |
+| `comments`         | vault markdown  | callout blocks inside memory file                                                                                                                                                                  |
+| `flags`            | vault markdown  | `flags:` array in frontmatter of memory file                                                                                                                                                       |
+| `relationships`    | vault markdown  | inline Dataview fields under `## Relationships` in the source-side memory file                                                                                                                     |
+| `workspaces`       | vault markdown  | `workspaces/<slug>/_workspace.md` (frontmatter only)                                                                                                                                               |
+| `audit_log`        | **git history** | every mutation is a commit; commit trailers `AB-Action:`, `AB-Memory:`, `AB-Actor:`, `AB-Reason:` carry structured audit fields; `git log --follow <file>` serves `AuditRepository.findByMemoryId` |
+| `sessions`         | runtime JSON    | `.agent-brain/sessions.json`, gitignored                                                                                                                                                           |
+| `session_tracking` | runtime JSON    | same file                                                                                                                                                                                          |
+| `scheduler_state`  | runtime JSON    | `.agent-brain/scheduler.json`, gitignored                                                                                                                                                          |
+
+## Components
+
+```
+src/backend/
+├── types.ts                        # StorageBackend interface + factory type
+├── factory.ts                      # reads config, returns backend instance
+├── postgres/
+│   ├── index.ts                    # PostgresBackend: wraps existing repos
+│   └── (re-exports src/repositories/* unchanged)
+└── vault/
+    ├── index.ts                    # VaultBackend: wires everything, implements StorageBackend
+    ├── config.ts                   # vault path, remote URL, sync cadence
+    │
+    ├── io/
+    │   ├── paths.ts                # scope → folder path resolver
+    │   ├── vault-fs.ts             # read/write markdown files (atomic writes via rename)
+    │   └── lock.ts                 # per-file write lock (proper-lockfile)
+    │
+    ├── parser/
+    │   ├── memory-parser.ts        # .md ⇄ Memory (gray-matter for frontmatter)
+    │   ├── flag-parser.ts          # frontmatter flags array ⇄ Flag[]
+    │   ├── relationship-parser.ts  # "## Relationships" section ⇄ Relationship[]
+    │   ├── comment-parser.ts       # callout blocks ⇄ Comment[]
+    │   └── roundtrip.test.ts       # property-based roundtrip coverage
+    │
+    ├── repositories/
+    │   ├── memory-repository.ts            # implements MemoryRepository
+    │   ├── comment-repository.ts           # append callout to source memory file
+    │   ├── flag-repository.ts              # mutate frontmatter flags
+    │   ├── relationship-repository.ts      # mutate "## Relationships" in source file
+    │   ├── workspace-repository.ts         # _workspace.md
+    │   ├── audit-repository.ts             # git log parser
+    │   ├── session-repository.ts           # .agent-brain/sessions.json
+    │   ├── session-tracking-repository.ts  # same file
+    │   └── scheduler-state-repository.ts   # .agent-brain/scheduler.json
+    │
+    ├── vector/
+    │   ├── lance-index.ts          # LanceDB wrapper: upsert, delete, query, rebuild
+    │   ├── embedding-cache.ts      # sha256(body) → embedding, skip re-embed on no-op
+    │   └── reindex.ts              # scan vault, diff against index, embed changed
+    │
+    ├── git/
+    │   ├── git-ops.ts              # commit, pull --rebase --autostash, push, status
+    │   ├── trailers.ts             # AB-Action: / AB-Memory: / AB-Actor: commit trailers
+    │   ├── push-queue.ts           # debounced async push (5s coalesce, single-flight)
+    │   └── merge-driver.ts         # installer for union merge on markdown
+    │
+    ├── watcher.ts                  # chokidar: external file changes → reindex + cache invalidate
+    │
+    └── migrate/
+        ├── pg-to-vault.ts          # CLI: stream pg → vault files (preserves timestamps)
+        └── vault-to-pg.ts          # reverse
+```
+
+### Unit boundaries
+
+| Unit                        | Purpose                                                                     | Depends on                       | Interface                                               |
+| --------------------------- | --------------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------------- |
+| `parser/*`                  | Pure functions: markdown ⇄ domain objects. No I/O.                          | `gray-matter`, regex only        | `parse(str): T`, `serialize(T): str`                    |
+| `io/vault-fs.ts`            | File reads/writes, atomic rename, per-file locks                            | `fs/promises`, `proper-lockfile` | `readMemory(path)`, `writeMemory(path, content, lock)`  |
+| `vector/lance-index.ts`     | Vector upsert/query/delete. No business logic.                              | `@lancedb/lancedb`               | `upsert(Memory[])`, `query(emb, filter)`, `delete(ids)` |
+| `git/git-ops.ts`            | Shell to `git`. No domain knowledge.                                        | `simple-git`                     | `commit(paths, trailer)`, `pull()`, `push()`            |
+| `git/push-queue.ts`         | Debounce + single-flight push                                               | `git-ops`                        | `request()`                                             |
+| `watcher.ts`                | File change events → callback                                               | `chokidar`                       | `onChange(cb)`                                          |
+| `repositories/*`            | Compose io + parser + vector + git. Implement the existing repo interfaces. | all of the above                 | matches `src/repositories/types.ts`                     |
+| `VaultBackend` (`index.ts`) | DI root. Wires repos, starts watcher + push queue, handles shutdown.        | all                              | `StorageBackend`                                        |
+
+Each repository write method follows the same pipeline: read file → parse → mutate → serialize → atomic write → update LanceDB → stage + commit → enqueue push.
+
+### New dependencies
+
+- `@lancedb/lancedb` — vector index
+- `gray-matter` — YAML frontmatter parse
+- `simple-git` — git wrapper
+- `chokidar` — file watch
+- `proper-lockfile` — per-file locks
+
+## Data flow
+
+### Write: `memory_create`
+
+```
+memory_create → MemoryService.create
+  ├─ embed(content) via EmbeddingProvider (unchanged)
+  ├─ repo.create(memory, embedding)  — vault impl:
+  │    ├─ paths.forScope(scope, ws, user) → file path
+  │    ├─ lock.acquire(path)
+  │    ├─ parser.serialize(memory) → markdown
+  │    ├─ vault-fs.writeAtomic(path, md)     # tmp → rename
+  │    ├─ lance.upsert({id, vec, meta, hash})
+  │    ├─ git.stage(path)
+  │    ├─ git.commit("AB-Action: created\nAB-Memory: <id>\nAB-Actor: <author>")
+  │    ├─ lock.release(path)
+  │    └─ pushQueue.request()                # debounced async
+  └─ return Memory
+```
+
+- Commit is synchronous on the write path. Push is fire-and-forget and retried.
+- Embedding is computed once; `content_hash` is stored in LanceDB so `memory_update` can skip re-embedding when the body is unchanged.
+- The lock is per-file, not per-vault, so concurrent writes to different memories do not serialize.
+
+### Write: `memory_comment`
+
+Same shape, but the repository loads the source memory file, appends a callout block, writes back, stages, commits. Comment id (nanoid) is embedded in the callout header for round-trip. LanceDB is not touched (embedding unchanged).
+
+### Write: `memory_relate`
+
+Loads the source memory file, parses `## Relationships`, inserts a Dataview inline-field line, writes back. Target file is untouched (backlinks are auto-derived from the wikilink).
+
+### Read: `memory_search`
+
+```
+memory_search → MemoryService.search
+  ├─ embed(query)
+  └─ repo.search({embedding, filters})   — vault impl:
+       ├─ lance.query(embedding, filter) → [{id, score, path}, …]
+       ├─ for each id: vault-fs.read(path) + parser.parse (parallel)
+       └─ return MemoryWithRelevance[]
+```
+
+Hot path = LanceDB query + parallel file reads. Git is not touched.
+
+### Read: `memory_session_start`
+
+```
+memory_session_start
+  ├─ git.pull(--rebase --autostash)
+  │   ├─ ok               → proceed
+  │   ├─ conflict (auto)  → merge=union resolves; proceed
+  │   ├─ conflict (hard)  → rebase --abort; serve stale; flag affected memories
+  │   └─ offline          → serve local; meta.offline = true
+  ├─ detect changed paths since last pull (git diff)
+  ├─ reindex diff via lance.upsert
+  └─ normal session_start flow (MemoryService unchanged)
+```
+
+### External edit (user edits a memory file in Obsidian)
+
+```
+chokidar event → watcher.ts
+  ├─ debounce(200ms)
+  ├─ parser.parse(file)
+  ├─ if parse error: log + include path in parse_errors; serve previous index entry
+  ├─ if content_hash changed → re-embed + lance.upsert
+  └─ if only flags/relationships/comments changed → lance.upsert(metadata only)
+```
+
+**Decision:** external edits are **not** auto-committed. The user running Obsidian is expected to commit manually (or via the Obsidian Git plugin). Agent-brain auto-commits only writes originating from MCP tools, keeping actor attribution clean and avoiding fights with the user's own git workflow.
+
+### Shutdown
+
+`VaultBackend.close()`:
+
+1. Drain pending writes.
+2. Force-flush the push queue.
+3. Wait for in-flight git ops.
+4. Close the LanceDB connection.
+5. Persist `sessions.json` and `scheduler.json`.
+
+## Error handling
+
+### Failure modes
+
+| Failure                                             | Detection                   | Response                                                                                                                                          |
+| --------------------------------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Atomic rename mid-write                             | `.tmp` left behind          | Sweep on startup; caller sees error and retries                                                                                                   |
+| LanceDB upsert fails after successful fs write      | `lance.upsert` throws       | Log + enqueue repair; background reindex picks it up. Caller sees success (vault = source of truth)                                               |
+| `git commit` fails after fs + lance succeed         | non-zero exit               | Repair queue retries on next write or session_start. Caller sees success                                                                          |
+| `git push` fails                                    | non-zero exit               | push-queue marks dirty and retries (5s → 30s → 5m → 30m backoff). Writes never block. `meta.unpushed_commits` exposed on `session_start` envelope |
+| Pull conflict (auto-resolvable)                     | merge=union on markdown     | Logged and merged                                                                                                                                 |
+| Pull conflict (unresolvable)                        | post-rebase `git status`    | `git rebase --abort`; serve stale; create `verify` flag on affected memories; `meta.pull_conflict = true`                                         |
+| Offline on pull                                     | network error               | Serve local; `meta.offline = true`; writes queue for push                                                                                         |
+| Parse error (invalid frontmatter after manual edit) | `parser.parse` throws       | Skip file; `meta.parse_errors` includes path; previous index entry still served                                                                   |
+| LanceDB corruption / schema mismatch                | startup check               | Full reindex from vault; blocks startup until complete; vault is source of truth so no data loss                                                  |
+| Vault missing or not a git repo                     | startup validation          | Hard fail with remediation text; no silent recovery                                                                                               |
+| Disk full                                           | fs write error              | Propagate as tool error; no partial index update                                                                                                  |
+| Concurrent writes to same memory                    | per-file lock               | Second write waits up to 5s then throws; tool retries or surfaces timeout                                                                         |
+| Race: external edit + tool write                    | lock + watcher queue        | Tool holds lock during its path; watcher reindex queues after lock release                                                                        |
+| Optimistic version mismatch                         | parsed `version` ≠ expected | Existing `OptimisticLockError` contract — unchanged                                                                                               |
+| Malformed commit trailers on migration              | audit-log parser            | Skip for audit purposes, treat as external commit                                                                                                 |
+
+### Invariants
+
+- Write ordering: **lock → fs → lance → git stage → git commit → lock release → push queue**. If any step before `git commit` fails, compensating action rolls back the lance write before raising.
+- `git commit --no-verify` is never used unless the user's own hooks interfere; hook failures surface, not silently bypassed.
+- No destructive recovery at runtime (`reset --hard`, `rm -rf`, `rebase --abort --hard`). Destructive repair only happens under explicit `agent-brain repair` CLI invocation.
+- `users/` privacy: the write path verifies the `.gitignore` rule is still present before writing a user-scope memory. Missing ignore aborts the write.
+
+### Envelope surface (exposed via `memory_session_start` response)
+
+```
+meta: {
+  offline?: true,
+  unpushed_commits?: number,
+  pull_conflict?: true,
+  parse_errors?: string[],
+  lance_reindexed?: true
+}
+```
+
+Agents show non-empty fields to the user.
+
+## Testing
+
+**1. Parser roundtrip (pure, fast).** `vitest` + `fast-check`. `parse(serialize(x)) === x` for Memory, Comment, Flag, Relationship. Plus golden-file fixtures under `tests/fixtures/vault/` for byte-for-byte stability.
+
+**2. Repository contract parity.** The existing pg repo test suite is parameterized over both backends:
+
+```ts
+describe.each([
+  ["postgres", () => new PostgresBackend(testPgUrl)],
+  ["vault", () => new VaultBackend(tmpVaultPath)],
+])("MemoryRepository (%s)", (name, factory) => {
+  /* existing tests */
+});
+```
+
+Forces behavioral parity; divergence = test failure.
+
+**3. Vector parity.** ~500 memories embedded with the same model, inserted into pg + lance, same query set. Assert top-K overlap ≥ 95% and per-match score delta ≤ 0.01.
+
+**4. Git sync integration.** Local bare repo as "remote", two ephemeral clones, simulate: single-writer, concurrent non-conflicting writes, auto-resolvable conflict, unresolvable conflict (flag raised), offline.
+
+**5. Watcher / external edit.** Modify file on disk, wait for debounce, assert repo sees new content. Invalid frontmatter → parse_errors logged, previous version still served.
+
+**6. Migration E2E.** Seed pg with ~200 memories + comments/flags/relationships. Run pg→vault. Start VaultBackend against migrated vault. `findById` returns structurally-equal objects. Reverse vault→pg and compare to original dump.
+
+**7. Server-boot smoke (extend existing).** `tests/unit/server-boot.test.ts` already spawns `node --import tsx` on `src/server.ts`. Extend to run twice with `AGENT_BRAIN_BACKEND=postgres` and `AGENT_BRAIN_BACKEND=vault` to catch ESM/CJS interop on new native deps (`@lancedb/lancedb`).
+
+**8. Performance regression.** Budget targets:
+
+- Cold start ≤ 2s up to 10k memories.
+- Search p99 ≤ 50ms.
+- Write p99 ≤ 200ms (including sync commit).
+
+### CI layering
+
+- Unit + parser on every push.
+- Integration (both backends) on PR — requires pg container + git.
+- Benchmarks nightly (or on `perf:` label).
+- Coverage gate: parsers ≥ 95%, repositories ≥ 85%.
+
+## Phased rollout
+
+| Phase | Deliverable                                                                                                                     |
+| ----- | ------------------------------------------------------------------------------------------------------------------------------- |
+| 0     | `StorageBackend` interface extraction. Move existing drizzle repos behind factory. No behavior change. Green tests.             |
+| 1     | Vault parser + serializer (pure). Roundtrip property tests for all entity types.                                                |
+| 2     | Vault repositories against a local directory (no git, no vector). Parameterized repo contract tests pass against both backends. |
+| 3     | LanceDB index integration. Vector parity tests.                                                                                 |
+| 4     | Git sync layer. Commit-on-write, pull-on-session_start, conflict handling. Two-clone integration test.                          |
+| 5     | Chokidar watcher. External edit E2E.                                                                                            |
+| 6     | Migration CLI + reverse migration.                                                                                              |
+| 7     | Docs, recommended Obsidian vault template (Dataview, Tasks plugins), README updates.                                            |
+
+## Open questions
+
+None required before writing the implementation plan. All architectural decisions are locked in the "Decisions" section above. Implementation-level choices (e.g. exact LanceDB schema column list, exact trailer grammar) are plan-time details.

--- a/src/backend/factory.ts
+++ b/src/backend/factory.ts
@@ -1,0 +1,34 @@
+// src/backend/factory.ts
+import type { BackendName, StorageBackend } from "./types.js";
+import { PostgresBackend } from "./postgres/index.js";
+
+export interface BackendConfig {
+  backend: BackendName;
+  databaseUrl: string;
+}
+
+/**
+ * Select and construct the configured storage backend.
+ *
+ * Phase 0 only ships the postgres backend. The vault backend is
+ * declared in the type enum so downstream code can already switch on
+ * it, but `createBackend({ backend: "vault" })` throws until Phase 1+
+ * lands the implementation.
+ */
+export async function createBackend(
+  config: BackendConfig,
+): Promise<StorageBackend> {
+  switch (config.backend) {
+    case "postgres":
+      return PostgresBackend.create(config.databaseUrl);
+    case "vault":
+      throw new Error(
+        "vault backend is not yet implemented — set AGENT_BRAIN_BACKEND=postgres",
+      );
+    default: {
+      // Exhaustiveness + runtime guard for an env-var typo that slipped past zod.
+      const _exhaustive: never = config.backend;
+      throw new Error(`unknown backend: ${String(_exhaustive)}`);
+    }
+  }
+}

--- a/src/backend/postgres/index.ts
+++ b/src/backend/postgres/index.ts
@@ -1,0 +1,69 @@
+// src/backend/postgres/index.ts
+import { createDb, type Database } from "../../db/index.js";
+import { runMigrations } from "../../db/migrate.js";
+import { DrizzleMemoryRepository } from "../../repositories/memory-repository.js";
+import { DrizzleWorkspaceRepository } from "../../repositories/workspace-repository.js";
+import { DrizzleCommentRepository } from "../../repositories/comment-repository.js";
+import {
+  DrizzleSessionTrackingRepository,
+  DrizzleSessionRepository,
+} from "../../repositories/session-repository.js";
+import { DrizzleAuditRepository } from "../../repositories/audit-repository.js";
+import { DrizzleFlagRepository } from "../../repositories/flag-repository.js";
+import { DrizzleRelationshipRepository } from "../../repositories/relationship-repository.js";
+import { DrizzleSchedulerStateRepository } from "../../repositories/scheduler-state-repository.js";
+import type { StorageBackend, BackendName } from "../types.js";
+import type {
+  MemoryRepository,
+  WorkspaceRepository,
+  CommentRepository,
+  SessionTrackingRepository,
+  SessionRepository,
+  AuditRepository,
+  FlagRepository,
+  RelationshipRepository,
+  SchedulerStateRepository,
+} from "../../repositories/types.js";
+
+/**
+ * Postgres + pgvector backend. Holds the drizzle Database handle and the
+ * eight Drizzle* repository instances. `close()` ends the postgres-js
+ * connection pool.
+ *
+ * Construct via `PostgresBackend.create(databaseUrl)` — it runs migrations
+ * before returning, matching the prior inline behavior in `server.ts`.
+ */
+export class PostgresBackend implements StorageBackend {
+  readonly name: BackendName = "postgres";
+  readonly memoryRepo: MemoryRepository;
+  readonly workspaceRepo: WorkspaceRepository;
+  readonly commentRepo: CommentRepository;
+  readonly sessionRepo: SessionTrackingRepository;
+  readonly sessionLifecycleRepo: SessionRepository;
+  readonly auditRepo: AuditRepository;
+  readonly flagRepo: FlagRepository;
+  readonly relationshipRepo: RelationshipRepository;
+  readonly schedulerStateRepo: SchedulerStateRepository;
+
+  private constructor(readonly db: Database) {
+    this.memoryRepo = new DrizzleMemoryRepository(db);
+    this.workspaceRepo = new DrizzleWorkspaceRepository(db);
+    this.commentRepo = new DrizzleCommentRepository(db);
+    this.sessionRepo = new DrizzleSessionTrackingRepository(db);
+    this.sessionLifecycleRepo = new DrizzleSessionRepository(db);
+    this.auditRepo = new DrizzleAuditRepository(db);
+    this.flagRepo = new DrizzleFlagRepository(db);
+    this.relationshipRepo = new DrizzleRelationshipRepository(db);
+    this.schedulerStateRepo = new DrizzleSchedulerStateRepository(db);
+  }
+
+  static async create(databaseUrl: string): Promise<PostgresBackend> {
+    const db = createDb(databaseUrl);
+    await runMigrations(db);
+    return new PostgresBackend(db);
+  }
+
+  async close(): Promise<void> {
+    await this.db.$client.end();
+  }
+}

--- a/src/backend/types.ts
+++ b/src/backend/types.ts
@@ -1,0 +1,36 @@
+// src/backend/types.ts
+import type {
+  MemoryRepository,
+  WorkspaceRepository,
+  CommentRepository,
+  SessionTrackingRepository,
+  SessionRepository,
+  AuditRepository,
+  FlagRepository,
+  RelationshipRepository,
+  SchedulerStateRepository,
+} from "../repositories/types.js";
+
+export type BackendName = "postgres" | "vault";
+
+/**
+ * Storage backend abstraction. Bundles the eight repository interfaces
+ * plus a lifecycle hook. `server.ts` constructs one of these via
+ * `createBackend()` and passes the individual repos to services.
+ *
+ * New backends (e.g. vault) implement this interface without touching
+ * service or tool code.
+ */
+export interface StorageBackend {
+  readonly name: BackendName;
+  readonly memoryRepo: MemoryRepository;
+  readonly workspaceRepo: WorkspaceRepository;
+  readonly commentRepo: CommentRepository;
+  readonly sessionRepo: SessionTrackingRepository;
+  readonly sessionLifecycleRepo: SessionRepository;
+  readonly auditRepo: AuditRepository;
+  readonly flagRepo: FlagRepository;
+  readonly relationshipRepo: RelationshipRepository;
+  readonly schedulerStateRepo: SchedulerStateRepository;
+  close(): Promise<void>;
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 const configSchema = z.object({
   projectId: z.string().default(""),
+  backend: z.enum(["postgres", "vault"]).default("postgres"),
   databaseUrl: z
     .string()
     .default("postgresql://agentic:agentic@localhost:5432/agent_brain"),
@@ -49,6 +50,7 @@ const configSchema = z.object({
 
 export const config = configSchema.parse({
   projectId: process.env.PROJECT_ID ?? "",
+  backend: process.env.AGENT_BRAIN_BACKEND,
   databaseUrl: process.env.DATABASE_URL,
   embeddingProvider: process.env.EMBEDDING_PROVIDER,
   embeddingDimensions: process.env.EMBEDDING_DIMENSIONS,

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,20 +4,9 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
 import { config } from "./config.js";
-import { createDb } from "./db/index.js";
-import { runMigrations } from "./db/migrate.js";
+import { createBackend } from "./backend/factory.js";
+import { PostgresBackend } from "./backend/postgres/index.js";
 import { createEmbeddingProvider } from "./providers/embedding/index.js";
-import { DrizzleMemoryRepository } from "./repositories/memory-repository.js";
-import { DrizzleWorkspaceRepository } from "./repositories/workspace-repository.js";
-import { DrizzleCommentRepository } from "./repositories/comment-repository.js";
-import {
-  DrizzleSessionTrackingRepository,
-  DrizzleSessionRepository,
-} from "./repositories/session-repository.js";
-import { DrizzleAuditRepository } from "./repositories/audit-repository.js";
-import { DrizzleFlagRepository } from "./repositories/flag-repository.js";
-import { DrizzleRelationshipRepository } from "./repositories/relationship-repository.js";
-import { DrizzleSchedulerStateRepository } from "./repositories/scheduler-state-repository.js";
 import { MemoryService } from "./services/memory-service.js";
 import { RelationshipService } from "./services/relationship-service.js";
 import { AuditService } from "./services/audit-service.js";
@@ -43,10 +32,13 @@ async function main() {
 
   logger.info(`v${config.version} starting...`);
 
-  // Initialize database
-  const db = createDb(config.databaseUrl);
+  // Initialize storage backend (runs migrations for postgres)
+  let backend;
   try {
-    await runMigrations(db);
+    backend = await createBackend({
+      backend: config.backend,
+      databaseUrl: config.databaseUrl,
+    });
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     const code =
@@ -63,11 +55,11 @@ async function main() {
         `Database connection failed: ${msg}. Is PostgreSQL running? Try: docker compose up -d`,
       );
     } else {
-      logger.error(`Database migration failed: ${msg}`);
+      logger.error(`Backend initialization failed: ${msg}`);
     }
     throw err;
   }
-  logger.info("Database connected, migrations applied");
+  logger.info(`Backend ready: ${backend.name}`);
 
   // Initialize embedding provider
   const embedder = createEmbeddingProvider();
@@ -82,17 +74,20 @@ async function main() {
   }
   logger.info(`Project: ${config.projectId}`);
 
-  // Initialize repositories and service
-  const memoryRepo = new DrizzleMemoryRepository(db);
-  const workspaceRepo = new DrizzleWorkspaceRepository(db);
-  const commentRepo = new DrizzleCommentRepository(db);
-  const sessionRepo = new DrizzleSessionTrackingRepository(db);
-  const sessionLifecycleRepo = new DrizzleSessionRepository(db);
-  const auditRepo = new DrizzleAuditRepository(db);
+  // Destructure repositories from the backend
+  const {
+    memoryRepo,
+    workspaceRepo,
+    commentRepo,
+    sessionRepo,
+    sessionLifecycleRepo,
+    auditRepo,
+    flagRepo,
+    relationshipRepo,
+  } = backend;
+
   const auditService = new AuditService(auditRepo, config.projectId);
-  const flagRepo = new DrizzleFlagRepository(db);
   const flagService = new FlagService(flagRepo, auditService, config.projectId);
-  const relationshipRepo = new DrizzleRelationshipRepository(db);
   const relationshipService = new RelationshipService(
     relationshipRepo,
     memoryRepo,
@@ -130,22 +125,27 @@ async function main() {
   let consolidationScheduler: ConsolidationScheduler | null = null;
 
   if (config.consolidationEnabled) {
-    const schedulerStateRepo = new DrizzleSchedulerStateRepository(db);
-    const consolidationJob = new ConsolidationJob(
-      consolidationService,
-      db,
-      schedulerStateRepo,
-    );
-    consolidationScheduler = new ConsolidationScheduler(
-      consolidationJob,
-      config.consolidationCron,
-      schedulerStateRepo,
-      {
-        enabled: config.consolidationCatchupEnabled,
-        graceSeconds: config.consolidationCatchupGraceSeconds,
-      },
-    );
-    await consolidationScheduler.start();
+    if (!(backend instanceof PostgresBackend)) {
+      logger.warn(
+        `Consolidation scheduler requires postgres backend; current backend is '${backend.name}'. Scheduler disabled.`,
+      );
+    } else {
+      const consolidationJob = new ConsolidationJob(
+        consolidationService,
+        backend.db,
+        backend.schedulerStateRepo,
+      );
+      consolidationScheduler = new ConsolidationScheduler(
+        consolidationJob,
+        config.consolidationCron,
+        backend.schedulerStateRepo,
+        {
+          enabled: config.consolidationCatchupEnabled,
+          graceSeconds: config.consolidationCatchupGraceSeconds,
+        },
+      );
+      await consolidationScheduler.start();
+    }
   }
 
   // Factory: creates a fresh MCP server per session (tools + prompts registered)
@@ -225,7 +225,7 @@ async function main() {
     if (consolidationScheduler) {
       await consolidationScheduler.stop();
     }
-    await db.$client.end();
+    await backend.close();
     process.exit(0);
   };
   process.on("SIGTERM", shutdown);

--- a/tests/unit/backend/factory.test.ts
+++ b/tests/unit/backend/factory.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { createBackend } from "../../../src/backend/factory.js";
+
+describe("createBackend", () => {
+  it("throws when given the vault backend name (not yet implemented)", async () => {
+    await expect(
+      createBackend({ backend: "vault", databaseUrl: "postgresql://unused" }),
+    ).rejects.toThrow(/vault backend is not yet implemented/i);
+  });
+
+  it("throws when given an unknown backend name", async () => {
+    await expect(
+      createBackend({
+        // @ts-expect-error — intentionally exercising a runtime-only bad value
+        backend: "nosuch",
+        databaseUrl: "postgresql://unused",
+      }),
+    ).rejects.toThrow(/unknown backend/i);
+  });
+});


### PR DESCRIPTION
## Summary

- Phase 0 of the vault-backend work: extract a `StorageBackend` interface that bundles the 8 existing repository interfaces, and wrap the current drizzle repos in a `PostgresBackend` class behind a `createBackend()` factory selected by `AGENT_BRAIN_BACKEND`.
- Pure refactor — no behavior change. Services, tools, repositories, and DB schema untouched.
- Unblocks later phases (vault parser, vault repos, LanceDB vector index, git sync, watcher, migration CLI) that will add a second backend alongside Postgres.

See `docs/superpowers/specs/2026-04-21-vault-backend-design.md` for the full design and `docs/superpowers/plans/2026-04-21-vault-backend-phase-0-abstraction.md` for the step-by-step plan this implements.

## Test Plan

- [x] `npm run typecheck` — pass
- [x] `npm run lint` — pass
- [x] `npm run test:unit` — 145 tests pass (up from 143: +2 factory tests)
- [x] `tests/unit/server-boot.test.ts` — smoke test boots refactored `src/server.ts` under real Node ESM loader
- [ ] `npm run test:integration` — run in CI against Postgres container (skipped locally)
- [ ] Manual boot: `AGENT_BRAIN_BACKEND=postgres npm run dev` — expect `Backend ready: postgres` log, server on :19898
- [ ] Manual boot: `AGENT_BRAIN_BACKEND=vault npm run dev` — expect clean "vault backend is not yet implemented" error and non-zero exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)