### PR TITLE
feat(vault): Phase 2b.1 — Audit / Scheduler / Session repositories

### DIFF
--- a/docs/superpowers/plans/2026-04-21-vault-backend-phase-2b-secondary-repos.md
+++ b/docs/superpowers/plans/2026-04-21-vault-backend-phase-2b-secondary-repos.md
@@ -4,11 +4,11 @@
 
 **Approach:** Split into three sub-phases to keep PRs reviewable and unblock dependents incrementally.
 
-| Sub-phase | Scope | Storage style | Depends on |
-| --------- | ----- | ------------- | ---------- |
-| **2b.1** | AuditRepository · SchedulerStateRepository · SessionTrackingRepository · SessionRepository | Standalone JSON files under the vault root | Phase 2a IO primitives only |
-| **2b.2** | CommentRepository · FlagRepository · RelationshipRepository | Embedded in the hosting memory markdown file | 2b.1 + shared id→path index access |
-| **2b.3** | `VaultBackend` class · factory registration · integration contract tests | Composes 2a + 2b.1 + 2b.2 | 2b.1 and 2b.2 |
+| Sub-phase | Scope                                                                                      | Storage style                                | Depends on                         |
+| --------- | ------------------------------------------------------------------------------------------ | -------------------------------------------- | ---------------------------------- |
+| **2b.1**  | AuditRepository · SchedulerStateRepository · SessionTrackingRepository · SessionRepository | Standalone JSON files under the vault root   | Phase 2a IO primitives only        |
+| **2b.2**  | CommentRepository · FlagRepository · RelationshipRepository                                | Embedded in the hosting memory markdown file | 2b.1 + shared id→path index access |
+| **2b.3**  | `VaultBackend` class · factory registration · integration contract tests                   | Composes 2a + 2b.1 + 2b.2                    | 2b.1 and 2b.2                      |
 
 ---
 

--- a/docs/superpowers/plans/2026-04-21-vault-backend-phase-2b-secondary-repos.md
+++ b/docs/superpowers/plans/2026-04-21-vault-backend-phase-2b-secondary-repos.md
@@ -78,7 +78,7 @@ findById(sessionId): Promise<{...} | null>;
 ```
 
 - File per session: `_sessions/<session_id>.json`.
-- `createSession`: write with `wx` flag; throw if exists (match pg PK constraint → but pg actually doesn't wrap 23505 here; Phase 2a work leaves pg unchanged; if pg doesn't wrap, neither do we — just let it surface as an error).
+- `createSession`: write via `writeJsonExclusive` (O_EXCL). Concurrent same-id creates: exactly one winner; the loser's EEXIST is translated to `session already exists: <id>`. Mirrors pg's PK constraint semantics.
 - `incrementBudgetUsed`: under lock, read, if `budget_used < limit` increment and write, else return `exceeded: true`. Mirrors pg atomic CAS semantics.
 - `findById` / `getBudget`: plain reads; ENOENT → null.
 
@@ -86,8 +86,8 @@ findById(sessionId): Promise<{...} | null>;
 
 Add to `src/backend/vault/io/`:
 
-- `json-fs.ts`: `readJson<T>(root, rel): Promise<T | null>` (ENOENT → null), `writeJsonAtomic(root, rel, obj)` (serialize + `writeMarkdownAtomic`-style tmp+rename), `appendLine(root, rel, line)` (under lock).
-- Reuse existing `withFileLock` + path-segment validation.
+- `json-fs.ts`: `readJson<T>(root, rel): Promise<T | null>` (ENOENT or empty file → null), `writeJsonAtomic(root, rel, obj)` (tmp + rename, atomic vs. concurrent readers), `writeJsonExclusive(root, rel, obj)` (O_EXCL write, throws `EEXIST` on collision — used by `createSession`), `appendJsonLine(root, rel, value)` (under lock), `readJsonLines<T>(root, rel): Promise<T[]>` (skips a partial trailing line as crashed-writer debris; middle-of-file malformed lines throw).
+- `safeSegment` / `UNSAFE_SEGMENT` are exported from `io/paths.ts` and reused by all four repos.
 
 ### Tests
 
@@ -96,13 +96,13 @@ Add to `src/backend/vault/io/`:
 
 ### Task breakdown
 
-- [ ] Task 1 — `io/json-fs.ts` + unit tests
-- [ ] Task 2 — `VaultAuditRepository` + unit tests + contract test
-- [ ] Task 3 — `VaultSchedulerStateRepository` + unit tests + contract test
-- [ ] Task 4 — `VaultSessionTrackingRepository` + unit tests + contract test
-- [ ] Task 5 — `VaultSessionRepository` + unit tests + contract test
-- [ ] Task 6 — Verify Phase 2a `inferScopeFromPath` still returns `null` for `_audit/` / `_scheduler-state.json` / `_sessions/` / `_session-tracking/` paths
-- [ ] Task 7 — typecheck + lint + prettier + full test suite green
+- [x] Task 1 — `io/json-fs.ts` + unit tests
+- [x] Task 2 — `VaultAuditRepository` + unit tests + contract test
+- [x] Task 3 — `VaultSchedulerStateRepository` + unit tests + contract test
+- [x] Task 4 — `VaultSessionTrackingRepository` + unit tests + contract test
+- [x] Task 5 — `VaultSessionRepository` + unit tests + contract test
+- [x] Task 6 — Verify Phase 2a `inferScopeFromPath` still returns `null` for `_audit/` / `_scheduler-state.json` / `_sessions/` / `_session-tracking/` paths (tested via parseIso + `inferScopeFromPath` unit tests — `_`-prefixed segments never match the three memory layouts)
+- [x] Task 7 — typecheck + lint + prettier + full test suite green
 
 ---
 

--- a/docs/superpowers/plans/2026-04-21-vault-backend-phase-2b-secondary-repos.md
+++ b/docs/superpowers/plans/2026-04-21-vault-backend-phase-2b-secondary-repos.md
@@ -1,0 +1,139 @@
+# Vault Backend Phase 2b — Secondary Repositories
+
+**Goal:** Land the six remaining StorageBackend repository interfaces on the vault backend so `createBackend({ backend: "vault" })` can hand back a complete `StorageBackend`. Phase 2a shipped `VaultMemoryRepository` + `VaultWorkspaceRepository`; Phase 2b covers everything else plus the backend-level wiring.
+
+**Approach:** Split into three sub-phases to keep PRs reviewable and unblock dependents incrementally.
+
+| Sub-phase | Scope | Storage style | Depends on |
+| --------- | ----- | ------------- | ---------- |
+| **2b.1** | AuditRepository · SchedulerStateRepository · SessionTrackingRepository · SessionRepository | Standalone JSON files under the vault root | Phase 2a IO primitives only |
+| **2b.2** | CommentRepository · FlagRepository · RelationshipRepository | Embedded in the hosting memory markdown file | 2b.1 + shared id→path index access |
+| **2b.3** | `VaultBackend` class · factory registration · integration contract tests | Composes 2a + 2b.1 + 2b.2 | 2b.1 and 2b.2 |
+
+---
+
+## 2b.1 — Standalone repositories (this plan)
+
+The four "standalone" repos don't mutate memory markdown files — they keep their own state under a dedicated directory in the vault root. JSON over markdown: these are internal records, not user-editable, and don't benefit from Obsidian rendering.
+
+### Storage layout
+
+```
+<vault-root>/
+├── _audit/<memory_id>.jsonl        # append-only, one JSON entry per line
+├── _scheduler-state.json           # { [job_name]: ISO timestamp }
+├── _sessions/<session_id>.json     # { id, user_id, project_id, workspace_id, budget_used }
+└── _session-tracking/<user>/<workspace>/<project>.json   # { last_session_at }
+```
+
+All under `_`-prefixed paths so they never collide with the three memory-layout directories (`workspaces/`, `project/`, `users/`) consumed by `inferScopeFromPath`. The indexer in Phase 2a already skips non-memory files — verify with a test.
+
+### VaultAuditRepository
+
+Interface:
+
+```ts
+create(entry: AuditEntry): Promise<void>;
+findByMemoryId(memoryId: string): Promise<AuditEntry[]>;
+```
+
+- `create` appends one line to `_audit/<memory_id>.jsonl` under `withFileLock`.
+- `findByMemoryId` reads the file, splits on `\n`, JSON-parses each non-empty line, re-hydrates `created_at` via `new Date(...)` with `Number.isNaN` guard, sorts `created_at` desc.
+- Missing file → empty array (ENOENT).
+
+### VaultSchedulerStateRepository
+
+Interface:
+
+```ts
+getLastRun(jobName): Promise<Date | null>;
+recordRun(jobName, runAt): Promise<void>;
+```
+
+- Single JSON file `_scheduler-state.json` keyed by job name.
+- `recordRun` is **monotonic** — matches pg `setWhere lt(last_run_at, runAt)`. Under file lock, read current value, only write if `runAt > current`.
+- Missing file → empty map on read; written lazily.
+
+### VaultSessionTrackingRepository
+
+Interface:
+
+```ts
+upsert(userId, projectId, workspaceId): Promise<Date | null>;
+```
+
+- One JSON file per composite key: `_session-tracking/<user_id>/<workspace_id>/<project_id>.json`.
+- Under lock: read existing `last_session_at` (null if missing), write new `last_session_at = now()`, return the previous value.
+- Path segments sanitized via `safeSegment` (reuse `io/paths.ts` helper).
+
+### VaultSessionRepository
+
+Interface:
+
+```ts
+createSession(id, userId, projectId, workspaceId): Promise<void>;
+getBudget(sessionId): Promise<{used, limit} | null>;
+incrementBudgetUsed(sessionId, limit): Promise<{used, exceeded}>;
+findById(sessionId): Promise<{...} | null>;
+```
+
+- File per session: `_sessions/<session_id>.json`.
+- `createSession`: write with `wx` flag; throw if exists (match pg PK constraint → but pg actually doesn't wrap 23505 here; Phase 2a work leaves pg unchanged; if pg doesn't wrap, neither do we — just let it surface as an error).
+- `incrementBudgetUsed`: under lock, read, if `budget_used < limit` increment and write, else return `exceeded: true`. Mirrors pg atomic CAS semantics.
+- `findById` / `getBudget`: plain reads; ENOENT → null.
+
+### Shared helpers
+
+Add to `src/backend/vault/io/`:
+
+- `json-fs.ts`: `readJson<T>(root, rel): Promise<T | null>` (ENOENT → null), `writeJsonAtomic(root, rel, obj)` (serialize + `writeMarkdownAtomic`-style tmp+rename), `appendLine(root, rel, line)` (under lock).
+- Reuse existing `withFileLock` + path-segment validation.
+
+### Tests
+
+- **Contract tests** (`tests/contract/repositories/`): parameterize over pg + vault factories. Each repo gets its own file mirroring the Phase 2a pattern. Factories extend `TestBackend` with the new repos.
+- **Unit tests** (`tests/unit/backend/vault/repositories/`): per-repo edge cases — monotonic regression for scheduler, concurrent `incrementBudgetUsed` races for session, append-only ordering for audit, composite-key path sanitization for session tracking.
+
+### Task breakdown
+
+- [ ] Task 1 — `io/json-fs.ts` + unit tests
+- [ ] Task 2 — `VaultAuditRepository` + unit tests + contract test
+- [ ] Task 3 — `VaultSchedulerStateRepository` + unit tests + contract test
+- [ ] Task 4 — `VaultSessionTrackingRepository` + unit tests + contract test
+- [ ] Task 5 — `VaultSessionRepository` + unit tests + contract test
+- [ ] Task 6 — Verify Phase 2a `inferScopeFromPath` still returns `null` for `_audit/` / `_scheduler-state.json` / `_sessions/` / `_session-tracking/` paths
+- [ ] Task 7 — typecheck + lint + prettier + full test suite green
+
+---
+
+## 2b.2 — Embedded repositories (follow-up plan)
+
+`CommentRepository`, `FlagRepository`, `RelationshipRepository` all persist inside the owning memory's markdown file. They need:
+
+1. Access to the `id → path` index maintained by `VaultMemoryRepository` (or rebuild their own on construction).
+2. Read-modify-write of the hosting markdown file under the file lock, including re-serializing the full memory + sections.
+3. Parity with pg side-effects — e.g. `CommentRepository.create` bumps `last_comment_at` + `updated_at` on the parent memory (but not `version`); `FlagRepository.autoResolveByMemoryId` sets `resolved_at: now()` on all matching flags.
+
+**Design question to resolve at 2b.2 start:** whether the three embedded repos share a single "MemoryFileEditor" service (holding the index + lock coordination) or each walks the vault independently. Separate repos with a shared reader is probably cleaner and avoids singleton coupling.
+
+Cross-memory query on vault: `FlagRepository.findOpenByWorkspace` and `RelationshipRepository.findBetweenMemories` need to scan multiple memory files. Acceptable at Phase 2 scale (`#loadAll` already does this for listings); document the O(N) cost.
+
+---
+
+## 2b.3 — Backend wiring (follow-up plan)
+
+- `src/backend/vault/index.ts` — `VaultBackend` class composing all eight repos; `close()` releases anything that needs releasing (likely nothing, since all IO is per-op).
+- `src/backend/factory.ts` — switch the `vault` arm to `VaultBackend.create({ root })` instead of throwing.
+- `src/backend/vault/config.ts` — resolve vault root from env/config.
+- Integration contract tests: add `backendFactory` suite that instantiates a full `VaultBackend` and runs a small cross-repo scenario (create memory → add comment → flag → resolve flag).
+- Update `README.md` / env docs if needed.
+
+---
+
+## Out of scope (deferred)
+
+- LanceDB / embedding store (Phase 3 — Memory vector methods remain `NotImplementedError`).
+- Git commit / push / pull (Phase 4).
+- `users/` gitignore guidance (Phase 4).
+- Chokidar file watcher (Phase 5).
+- Migration CLI (Phase 6).

--- a/src/backend/vault/io/json-fs.ts
+++ b/src/backend/vault/io/json-fs.ts
@@ -2,15 +2,15 @@ import {
   appendFile,
   mkdir,
   readFile,
-  writeFile,
   rename,
+  rm,
+  writeFile,
 } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
-// Read a JSON file. Returns null if the file is missing or empty
-// (the latter covers the placeholder-then-lock pattern, where a
-// zero-byte file is created so proper-lockfile has a target before
-// the first write). Rethrows other errors (EACCES, EISDIR, etc).
+// Read a JSON file. Returns null on ENOENT or empty file. Rethrows
+// other errors (EACCES, EISDIR, etc). Empty-file handling lets callers
+// use an "ensure the lock target exists before writing" pattern.
 export async function readJson<T>(
   root: string,
   relPath: string,
@@ -19,15 +19,17 @@ export async function readJson<T>(
   try {
     raw = await readFile(join(root, relPath), "utf8");
   } catch (err: unknown) {
-    if (isNodeEnoent(err)) return null;
+    if (isNodeCode(err, "ENOENT")) return null;
     throw err;
   }
   if (raw.length === 0) return null;
   return JSON.parse(raw) as T;
 }
 
-// Write a JSON file atomically (tmp + rename). Callers hold the file
-// lock; this helper just handles the serialize + atomic write.
+// Write a JSON file atomically (tmp + rename) — concurrent readers
+// see either the old file or the new file, never a half-written one.
+// Not crash-durable: no fsync on the fd or parent directory, so a
+// power loss between rename and page-cache flush can lose the write.
 export async function writeJsonAtomic(
   root: string,
   relPath: string,
@@ -36,8 +38,26 @@ export async function writeJsonAtomic(
   const abs = join(root, relPath);
   await mkdir(dirname(abs), { recursive: true });
   const tmp = `${abs}.tmp`;
-  await writeFile(tmp, JSON.stringify(value, null, 2), "utf8");
-  await rename(tmp, abs);
+  try {
+    await writeFile(tmp, JSON.stringify(value, null, 2), "utf8");
+    await rename(tmp, abs);
+  } catch (err) {
+    await rm(tmp, { force: true }).catch(() => undefined);
+    throw err;
+  }
+}
+
+// Write a JSON file that must not already exist (O_EXCL). Throws a
+// Node error with `code === "EEXIST"` if the file is present; callers
+// translate that to a domain error. Parent directories are created.
+export async function writeJsonExclusive(
+  root: string,
+  relPath: string,
+  value: unknown,
+): Promise<void> {
+  const abs = join(root, relPath);
+  await mkdir(dirname(abs), { recursive: true });
+  await writeFile(abs, JSON.stringify(value, null, 2), { flag: "wx" });
 }
 
 // Append a single JSON-encoded line (plus newline) to a JSONL file.
@@ -52,8 +72,10 @@ export async function appendJsonLine(
   await appendFile(abs, `${JSON.stringify(value)}\n`, "utf8");
 }
 
-// Read a JSONL file and parse each non-empty line. Returns [] if the
-// file does not exist. A malformed line throws — we never silently drop.
+// Read a JSONL file and parse each non-empty line. Returns [] on ENOENT.
+// appendJsonLine always terminates each entry with "\n", so any non-empty
+// trailing chunk after the last newline means the writer crashed mid-line;
+// we drop it rather than throw. Middle-of-file malformed lines still throw.
 export async function readJsonLines<T>(
   root: string,
   relPath: string,
@@ -62,11 +84,15 @@ export async function readJsonLines<T>(
   try {
     raw = await readFile(join(root, relPath), "utf8");
   } catch (err: unknown) {
-    if (isNodeEnoent(err)) return [];
+    if (isNodeCode(err, "ENOENT")) return [];
     throw err;
   }
-  return raw
-    .split("\n")
+  // split("\n") always produces N+1 elements where N = newline count.
+  // If the file ended in "\n" the last element is "" (a normal terminator);
+  // if it ended mid-line the last element is the partial content. Both
+  // cases are discarded — empty via filter, partial via this slice.
+  const candidates = raw.split("\n").slice(0, -1);
+  return candidates
     .filter((l) => l.length > 0)
     .map((line, i) => {
       try {
@@ -77,10 +103,10 @@ export async function readJsonLines<T>(
     });
 }
 
-function isNodeEnoent(err: unknown): boolean {
+function isNodeCode(err: unknown, code: string): boolean {
   return (
     typeof err === "object" &&
     err !== null &&
-    (err as { code?: string }).code === "ENOENT"
+    (err as { code?: string }).code === code
   );
 }

--- a/src/backend/vault/io/json-fs.ts
+++ b/src/backend/vault/io/json-fs.ts
@@ -1,0 +1,86 @@
+import {
+  appendFile,
+  mkdir,
+  readFile,
+  writeFile,
+  rename,
+} from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+// Read a JSON file. Returns null if the file is missing or empty
+// (the latter covers the placeholder-then-lock pattern, where a
+// zero-byte file is created so proper-lockfile has a target before
+// the first write). Rethrows other errors (EACCES, EISDIR, etc).
+export async function readJson<T>(
+  root: string,
+  relPath: string,
+): Promise<T | null> {
+  let raw: string;
+  try {
+    raw = await readFile(join(root, relPath), "utf8");
+  } catch (err: unknown) {
+    if (isNodeEnoent(err)) return null;
+    throw err;
+  }
+  if (raw.length === 0) return null;
+  return JSON.parse(raw) as T;
+}
+
+// Write a JSON file atomically (tmp + rename). Callers hold the file
+// lock; this helper just handles the serialize + atomic write.
+export async function writeJsonAtomic(
+  root: string,
+  relPath: string,
+  value: unknown,
+): Promise<void> {
+  const abs = join(root, relPath);
+  await mkdir(dirname(abs), { recursive: true });
+  const tmp = `${abs}.tmp`;
+  await writeFile(tmp, JSON.stringify(value, null, 2), "utf8");
+  await rename(tmp, abs);
+}
+
+// Append a single JSON-encoded line (plus newline) to a JSONL file.
+// Caller holds the file lock. Parent directories are created lazily.
+export async function appendJsonLine(
+  root: string,
+  relPath: string,
+  value: unknown,
+): Promise<void> {
+  const abs = join(root, relPath);
+  await mkdir(dirname(abs), { recursive: true });
+  await appendFile(abs, `${JSON.stringify(value)}\n`, "utf8");
+}
+
+// Read a JSONL file and parse each non-empty line. Returns [] if the
+// file does not exist. A malformed line throws — we never silently drop.
+export async function readJsonLines<T>(
+  root: string,
+  relPath: string,
+): Promise<T[]> {
+  let raw: string;
+  try {
+    raw = await readFile(join(root, relPath), "utf8");
+  } catch (err: unknown) {
+    if (isNodeEnoent(err)) return [];
+    throw err;
+  }
+  return raw
+    .split("\n")
+    .filter((l) => l.length > 0)
+    .map((line, i) => {
+      try {
+        return JSON.parse(line) as T;
+      } catch {
+        throw new Error(`invalid JSONL entry at line ${i + 1} of ${relPath}`);
+      }
+    });
+}
+
+function isNodeEnoent(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { code?: string }).code === "ENOENT"
+  );
+}

--- a/src/backend/vault/io/paths.ts
+++ b/src/backend/vault/io/paths.ts
@@ -10,9 +10,9 @@ export interface MemoryLocation {
 // Any segment interpolated into a vault path must not contain path
 // separators or `.`/`..` traversal tokens — otherwise a crafted id or
 // workspace slug could escape the vault root.
-const UNSAFE_SEGMENT = /[/\\]|^\.\.?$|\0/;
+export const UNSAFE_SEGMENT = /[/\\]|^\.\.?$|\0/;
 
-function safeSegment(value: string, name: string): string {
+export function safeSegment(value: string, name: string): string {
   if (value.length === 0 || UNSAFE_SEGMENT.test(value))
     throw new Error(`invalid ${name}: ${JSON.stringify(value)}`);
   return value;

--- a/src/backend/vault/io/vault-fs.ts
+++ b/src/backend/vault/io/vault-fs.ts
@@ -37,6 +37,29 @@ export async function deleteMarkdown(
   await rm(join(root, relPath));
 }
 
+// Ensure the parent directory of an absolute path exists.
+export async function ensureParentDir(abs: string): Promise<void> {
+  await mkdir(dirname(abs), { recursive: true });
+}
+
+// Ensure a file exists so proper-lockfile has a target. Creates parent
+// directories and a zero-byte file if missing; EEXIST is swallowed as
+// a racing creator won.
+export async function ensureFileExists(abs: string): Promise<void> {
+  await mkdir(dirname(abs), { recursive: true });
+  try {
+    await writeFile(abs, "", { flag: "wx" });
+  } catch (err: unknown) {
+    if (
+      typeof err === "object" &&
+      err !== null &&
+      (err as { code?: string }).code === "EEXIST"
+    )
+      return;
+    throw err;
+  }
+}
+
 // Recursively list all *.md files under root, returning POSIX-style
 // relative paths so callers can concatenate with `/` portably.
 export async function listMarkdownFiles(root: string): Promise<string[]> {

--- a/src/backend/vault/io/vault-fs.ts
+++ b/src/backend/vault/io/vault-fs.ts
@@ -37,7 +37,6 @@ export async function deleteMarkdown(
   await rm(join(root, relPath));
 }
 
-// Ensure the parent directory of an absolute path exists.
 export async function ensureParentDir(abs: string): Promise<void> {
   await mkdir(dirname(abs), { recursive: true });
 }

--- a/src/backend/vault/repositories/audit-repository.ts
+++ b/src/backend/vault/repositories/audit-repository.ts
@@ -1,0 +1,81 @@
+import { join } from "node:path";
+import type { AuditEntry } from "../../../types/audit.js";
+import type { AuditRepository } from "../../../repositories/types.js";
+import { withFileLock } from "../io/lock.js";
+import { appendJsonLine, readJsonLines } from "../io/json-fs.js";
+import { ensureParentDir } from "../io/vault-fs.js";
+
+export interface VaultAuditConfig {
+  root: string;
+}
+
+interface AuditRecord {
+  id: string;
+  project_id: string;
+  memory_id: string;
+  action: AuditEntry["action"];
+  actor: string;
+  reason: string | null;
+  diff: Record<string, unknown> | null;
+  created_at: string;
+}
+
+export class VaultAuditRepository implements AuditRepository {
+  constructor(private readonly cfg: VaultAuditConfig) {}
+
+  async create(entry: AuditEntry): Promise<void> {
+    const rel = auditPath(entry.memory_id);
+    const abs = join(this.cfg.root, rel);
+    // appendFile opens in append mode which is atomic on POSIX for
+    // writes smaller than PIPE_BUF, but we take the lock regardless
+    // to serialize concurrent writers on the same file (cross-platform).
+    await ensureParentDir(abs);
+    await withFileLock(abs, async () => {
+      const record: AuditRecord = {
+        id: entry.id,
+        project_id: entry.project_id,
+        memory_id: entry.memory_id,
+        action: entry.action,
+        actor: entry.actor,
+        reason: entry.reason,
+        diff: entry.diff,
+        created_at: entry.created_at.toISOString(),
+      };
+      await appendJsonLine(this.cfg.root, rel, record);
+    });
+  }
+
+  async findByMemoryId(memoryId: string): Promise<AuditEntry[]> {
+    const records = await readJsonLines<AuditRecord>(
+      this.cfg.root,
+      auditPath(memoryId),
+    );
+    const entries = records.map((r) => {
+      const created = new Date(r.created_at);
+      if (Number.isNaN(created.getTime()))
+        throw new Error(
+          `audit entry ${r.id} has invalid created_at: ${r.created_at}`,
+        );
+      return {
+        id: r.id,
+        project_id: r.project_id,
+        memory_id: r.memory_id,
+        action: r.action,
+        actor: r.actor,
+        reason: r.reason,
+        diff: r.diff,
+        created_at: created,
+      } satisfies AuditEntry;
+    });
+    return entries.sort(
+      (a, b) => b.created_at.getTime() - a.created_at.getTime(),
+    );
+  }
+}
+
+function auditPath(memoryId: string): string {
+  // Reject traversal so a malicious id can't escape _audit/.
+  if (memoryId.length === 0 || /[/\\]|^\.\.?$|\0/.test(memoryId))
+    throw new Error(`invalid memory_id: ${JSON.stringify(memoryId)}`);
+  return `_audit/${memoryId}.jsonl`;
+}

--- a/src/backend/vault/repositories/audit-repository.ts
+++ b/src/backend/vault/repositories/audit-repository.ts
@@ -4,6 +4,7 @@ import type { AuditRepository } from "../../../repositories/types.js";
 import { withFileLock } from "../io/lock.js";
 import { appendJsonLine, readJsonLines } from "../io/json-fs.js";
 import { ensureParentDir } from "../io/vault-fs.js";
+import { safeSegment } from "../io/paths.js";
 
 export interface VaultAuditConfig {
   root: string;
@@ -26,9 +27,8 @@ export class VaultAuditRepository implements AuditRepository {
   async create(entry: AuditEntry): Promise<void> {
     const rel = auditPath(entry.memory_id);
     const abs = join(this.cfg.root, rel);
-    // appendFile opens in append mode which is atomic on POSIX for
-    // writes smaller than PIPE_BUF, but we take the lock regardless
-    // to serialize concurrent writers on the same file (cross-platform).
+    // Lock serializes concurrent writers cross-platform; don't rely
+    // on O_APPEND atomicity (which only holds below PIPE_BUF on POSIX).
     await ensureParentDir(abs);
     await withFileLock(abs, async () => {
       const record: AuditRecord = {
@@ -74,8 +74,5 @@ export class VaultAuditRepository implements AuditRepository {
 }
 
 function auditPath(memoryId: string): string {
-  // Reject traversal so a malicious id can't escape _audit/.
-  if (memoryId.length === 0 || /[/\\]|^\.\.?$|\0/.test(memoryId))
-    throw new Error(`invalid memory_id: ${JSON.stringify(memoryId)}`);
-  return `_audit/${memoryId}.jsonl`;
+  return `_audit/${safeSegment(memoryId, "memory_id")}.jsonl`;
 }

--- a/src/backend/vault/repositories/scheduler-state-repository.ts
+++ b/src/backend/vault/repositories/scheduler-state-repository.ts
@@ -1,0 +1,49 @@
+import { join } from "node:path";
+import type { SchedulerStateRepository } from "../../../repositories/types.js";
+import type { SchedulerJobName } from "../../../db/schema.js";
+import { withFileLock } from "../io/lock.js";
+import { readJson, writeJsonAtomic } from "../io/json-fs.js";
+import { ensureFileExists } from "../io/vault-fs.js";
+
+export interface VaultSchedulerStateConfig {
+  root: string;
+}
+
+const STATE_PATH = "_scheduler-state.json";
+
+type StateMap = Record<string, string>;
+
+export class VaultSchedulerStateRepository implements SchedulerStateRepository {
+  constructor(private readonly cfg: VaultSchedulerStateConfig) {}
+
+  async getLastRun(jobName: SchedulerJobName): Promise<Date | null> {
+    const map = await readJson<StateMap>(this.cfg.root, STATE_PATH);
+    const raw = map?.[jobName];
+    if (!raw) return null;
+    const d = new Date(raw);
+    if (Number.isNaN(d.getTime()))
+      throw new Error(
+        `scheduler-state ${jobName} has invalid timestamp: ${raw}`,
+      );
+    return d;
+  }
+
+  async recordRun(jobName: SchedulerJobName, runAt: Date): Promise<void> {
+    const abs = join(this.cfg.root, STATE_PATH);
+    // proper-lockfile requires the target file to exist.
+    await ensureFileExists(abs);
+    await withFileLock(abs, async () => {
+      const current =
+        (await readJson<StateMap>(this.cfg.root, STATE_PATH)) ?? {};
+      const existing = current[jobName];
+      // Monotonic: never regress last_run_at. Matches pg `setWhere lt(...)`.
+      if (existing) {
+        const prev = new Date(existing);
+        if (!Number.isNaN(prev.getTime()) && prev.getTime() >= runAt.getTime())
+          return;
+      }
+      current[jobName] = runAt.toISOString();
+      await writeJsonAtomic(this.cfg.root, STATE_PATH, current);
+    });
+  }
+}

--- a/src/backend/vault/repositories/session-repository.ts
+++ b/src/backend/vault/repositories/session-repository.ts
@@ -2,8 +2,12 @@ import { join } from "node:path";
 import type { SessionRepository } from "../../../repositories/types.js";
 import { config } from "../../../config.js";
 import { withFileLock } from "../io/lock.js";
-import { readJson, writeJsonAtomic } from "../io/json-fs.js";
-import { ensureFileExists } from "../io/vault-fs.js";
+import {
+  readJson,
+  writeJsonAtomic,
+  writeJsonExclusive,
+} from "../io/json-fs.js";
+import { safeSegment } from "../io/paths.js";
 
 export interface VaultSessionConfig {
   root: string;
@@ -17,12 +21,8 @@ interface SessionRecord {
   budget_used: number;
 }
 
-const UNSAFE_SEGMENT = /[/\\]|^\.\.?$|\0/;
-
 function sessionPath(id: string): string {
-  if (id.length === 0 || UNSAFE_SEGMENT.test(id))
-    throw new Error(`invalid session id: ${JSON.stringify(id)}`);
-  return `_sessions/${id}.json`;
+  return `_sessions/${safeSegment(id, "session id")}.json`;
 }
 
 export class VaultSessionRepository implements SessionRepository {
@@ -42,11 +42,19 @@ export class VaultSessionRepository implements SessionRepository {
       workspace_id: workspaceId,
       budget_used: 0,
     };
-    // pg has a PK on id — writeJsonAtomic would silently overwrite.
-    // Reject a pre-existing session so callers see a consistent error.
-    const existing = await readJson<SessionRecord>(this.cfg.root, rel);
-    if (existing !== null) throw new Error(`session already exists: ${id}`);
-    await writeJsonAtomic(this.cfg.root, rel, record);
+    // O_EXCL matches pg's PK — concurrent same-id creates give exactly
+    // one winner; the loser gets the thrown "already exists" error.
+    try {
+      await writeJsonExclusive(this.cfg.root, rel, record);
+    } catch (err: unknown) {
+      if (
+        typeof err === "object" &&
+        err !== null &&
+        (err as { code?: string }).code === "EEXIST"
+      )
+        throw new Error(`session already exists: ${id}`, { cause: err });
+      throw err;
+    }
   }
 
   async getBudget(
@@ -68,16 +76,18 @@ export class VaultSessionRepository implements SessionRepository {
     limit: number,
   ): Promise<{ used: number; exceeded: boolean }> {
     const rel = sessionPath(sessionId);
+    // Short-circuit unknown sessions without creating a placeholder file.
+    // Mirrors pg's UPDATE ... WHERE id=? returning 0 rows → exceeded.
+    const exists = await readJson<SessionRecord>(this.cfg.root, rel);
+    if (!exists) return { used: limit, exceeded: true };
+
     const abs = join(this.cfg.root, rel);
-    await ensureFileExists(abs);
     return await withFileLock(abs, async () => {
       const record = await readJson<SessionRecord>(this.cfg.root, rel);
-      if (!record) {
-        // Pre-existing file was empty or unreadable — mirror pg's
-        // "session not found" path by returning `exceeded: true` with
-        // used === limit so the caller short-circuits.
-        return { used: limit, exceeded: true };
-      }
+      // The row must exist — we checked above outside the lock, and
+      // session files are never deleted. A null here indicates corruption.
+      if (!record)
+        throw new Error(`session record vanished under lock: ${sessionId}`);
       if (record.budget_used >= limit) {
         return { used: record.budget_used, exceeded: true };
       }
@@ -97,10 +107,6 @@ export class VaultSessionRepository implements SessionRepository {
     workspace_id: string;
     budget_used: number;
   } | null> {
-    const record = await readJson<SessionRecord>(
-      this.cfg.root,
-      sessionPath(sessionId),
-    );
-    return record ?? null;
+    return await readJson<SessionRecord>(this.cfg.root, sessionPath(sessionId));
   }
 }

--- a/src/backend/vault/repositories/session-repository.ts
+++ b/src/backend/vault/repositories/session-repository.ts
@@ -1,0 +1,106 @@
+import { join } from "node:path";
+import type { SessionRepository } from "../../../repositories/types.js";
+import { config } from "../../../config.js";
+import { withFileLock } from "../io/lock.js";
+import { readJson, writeJsonAtomic } from "../io/json-fs.js";
+import { ensureFileExists } from "../io/vault-fs.js";
+
+export interface VaultSessionConfig {
+  root: string;
+}
+
+interface SessionRecord {
+  id: string;
+  user_id: string;
+  project_id: string;
+  workspace_id: string;
+  budget_used: number;
+}
+
+const UNSAFE_SEGMENT = /[/\\]|^\.\.?$|\0/;
+
+function sessionPath(id: string): string {
+  if (id.length === 0 || UNSAFE_SEGMENT.test(id))
+    throw new Error(`invalid session id: ${JSON.stringify(id)}`);
+  return `_sessions/${id}.json`;
+}
+
+export class VaultSessionRepository implements SessionRepository {
+  constructor(private readonly cfg: VaultSessionConfig) {}
+
+  async createSession(
+    id: string,
+    userId: string,
+    projectId: string,
+    workspaceId: string,
+  ): Promise<void> {
+    const rel = sessionPath(id);
+    const record: SessionRecord = {
+      id,
+      user_id: userId,
+      project_id: projectId,
+      workspace_id: workspaceId,
+      budget_used: 0,
+    };
+    // pg has a PK on id — writeJsonAtomic would silently overwrite.
+    // Reject a pre-existing session so callers see a consistent error.
+    const existing = await readJson<SessionRecord>(this.cfg.root, rel);
+    if (existing !== null) throw new Error(`session already exists: ${id}`);
+    await writeJsonAtomic(this.cfg.root, rel, record);
+  }
+
+  async getBudget(
+    sessionId: string,
+  ): Promise<{ used: number; limit: number } | null> {
+    const record = await readJson<SessionRecord>(
+      this.cfg.root,
+      sessionPath(sessionId),
+    );
+    if (!record) return null;
+    return {
+      used: record.budget_used,
+      limit: config.writeBudgetPerSession,
+    };
+  }
+
+  async incrementBudgetUsed(
+    sessionId: string,
+    limit: number,
+  ): Promise<{ used: number; exceeded: boolean }> {
+    const rel = sessionPath(sessionId);
+    const abs = join(this.cfg.root, rel);
+    await ensureFileExists(abs);
+    return await withFileLock(abs, async () => {
+      const record = await readJson<SessionRecord>(this.cfg.root, rel);
+      if (!record) {
+        // Pre-existing file was empty or unreadable — mirror pg's
+        // "session not found" path by returning `exceeded: true` with
+        // used === limit so the caller short-circuits.
+        return { used: limit, exceeded: true };
+      }
+      if (record.budget_used >= limit) {
+        return { used: record.budget_used, exceeded: true };
+      }
+      const next: SessionRecord = {
+        ...record,
+        budget_used: record.budget_used + 1,
+      };
+      await writeJsonAtomic(this.cfg.root, rel, next);
+      return { used: next.budget_used, exceeded: false };
+    });
+  }
+
+  async findById(sessionId: string): Promise<{
+    id: string;
+    user_id: string;
+    project_id: string;
+    workspace_id: string;
+    budget_used: number;
+  } | null> {
+    const record = await readJson<SessionRecord>(
+      this.cfg.root,
+      sessionPath(sessionId),
+    );
+    return record ?? null;
+  }
+}

--- a/src/backend/vault/repositories/session-tracking-repository.ts
+++ b/src/backend/vault/repositories/session-tracking-repository.ts
@@ -1,0 +1,65 @@
+import { join } from "node:path";
+import type { SessionTrackingRepository } from "../../../repositories/types.js";
+import { withFileLock } from "../io/lock.js";
+import { readJson, writeJsonAtomic } from "../io/json-fs.js";
+import { ensureFileExists } from "../io/vault-fs.js";
+
+export interface VaultSessionTrackingConfig {
+  root: string;
+}
+
+interface TrackingRecord {
+  last_session_at: string;
+}
+
+// Segments interpolated into the tracking path must not contain path
+// separators or traversal tokens — otherwise a crafted user_id could
+// escape the tracking directory.
+const UNSAFE_SEGMENT = /[/\\]|^\.\.?$|\0/;
+
+function safeSegment(value: string, name: string): string {
+  if (value.length === 0 || UNSAFE_SEGMENT.test(value))
+    throw new Error(`invalid ${name}: ${JSON.stringify(value)}`);
+  return value;
+}
+
+function trackingPath(
+  userId: string,
+  workspaceId: string,
+  projectId: string,
+): string {
+  return `_session-tracking/${safeSegment(userId, "userId")}/${safeSegment(
+    workspaceId,
+    "workspaceId",
+  )}/${safeSegment(projectId, "projectId")}.json`;
+}
+
+export class VaultSessionTrackingRepository implements SessionTrackingRepository {
+  constructor(private readonly cfg: VaultSessionTrackingConfig) {}
+
+  async upsert(
+    userId: string,
+    projectId: string,
+    workspaceId: string,
+  ): Promise<Date | null> {
+    const rel = trackingPath(userId, workspaceId, projectId);
+    const abs = join(this.cfg.root, rel);
+    await ensureFileExists(abs);
+    return await withFileLock(abs, async () => {
+      const prev = await readJson<TrackingRecord>(this.cfg.root, rel);
+      const previousSession = prev
+        ? parseIsoOrNull(prev.last_session_at)
+        : null;
+      const now = new Date();
+      await writeJsonAtomic(this.cfg.root, rel, {
+        last_session_at: now.toISOString(),
+      });
+      return previousSession;
+    });
+  }
+}
+
+function parseIsoOrNull(raw: string): Date | null {
+  const d = new Date(raw);
+  return Number.isNaN(d.getTime()) ? null : d;
+}

--- a/src/backend/vault/repositories/session-tracking-repository.ts
+++ b/src/backend/vault/repositories/session-tracking-repository.ts
@@ -3,6 +3,7 @@ import type { SessionTrackingRepository } from "../../../repositories/types.js";
 import { withFileLock } from "../io/lock.js";
 import { readJson, writeJsonAtomic } from "../io/json-fs.js";
 import { ensureFileExists } from "../io/vault-fs.js";
+import { safeSegment } from "../io/paths.js";
 
 export interface VaultSessionTrackingConfig {
   root: string;
@@ -10,17 +11,6 @@ export interface VaultSessionTrackingConfig {
 
 interface TrackingRecord {
   last_session_at: string;
-}
-
-// Segments interpolated into the tracking path must not contain path
-// separators or traversal tokens — otherwise a crafted user_id could
-// escape the tracking directory.
-const UNSAFE_SEGMENT = /[/\\]|^\.\.?$|\0/;
-
-function safeSegment(value: string, name: string): string {
-  if (value.length === 0 || UNSAFE_SEGMENT.test(value))
-    throw new Error(`invalid ${name}: ${JSON.stringify(value)}`);
-  return value;
 }
 
 function trackingPath(
@@ -47,9 +37,7 @@ export class VaultSessionTrackingRepository implements SessionTrackingRepository
     await ensureFileExists(abs);
     return await withFileLock(abs, async () => {
       const prev = await readJson<TrackingRecord>(this.cfg.root, rel);
-      const previousSession = prev
-        ? parseIsoOrNull(prev.last_session_at)
-        : null;
+      const previousSession = prev ? parseIso(prev.last_session_at, rel) : null;
       const now = new Date();
       await writeJsonAtomic(this.cfg.root, rel, {
         last_session_at: now.toISOString(),
@@ -59,7 +47,11 @@ export class VaultSessionTrackingRepository implements SessionTrackingRepository
   }
 }
 
-function parseIsoOrNull(raw: string): Date | null {
+function parseIso(raw: string, rel: string): Date {
   const d = new Date(raw);
-  return Number.isNaN(d.getTime()) ? null : d;
+  if (Number.isNaN(d.getTime()))
+    throw new Error(
+      `session-tracking ${rel} has invalid last_session_at: ${raw}`,
+    );
+  return d;
 }

--- a/src/repositories/audit-repository.ts
+++ b/src/repositories/audit-repository.ts
@@ -16,6 +16,7 @@ export class DrizzleAuditRepository implements AuditRepository {
       actor: entry.actor,
       reason: entry.reason,
       diff: entry.diff,
+      created_at: entry.created_at,
     });
   }
 

--- a/tests/contract/repositories/_factories.ts
+++ b/tests/contract/repositories/_factories.ts
@@ -3,8 +3,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { VaultMemoryRepository } from "../../../src/backend/vault/repositories/memory-repository.js";
 import { VaultWorkspaceRepository } from "../../../src/backend/vault/repositories/workspace-repository.js";
+import { VaultAuditRepository } from "../../../src/backend/vault/repositories/audit-repository.js";
+import { VaultSchedulerStateRepository } from "../../../src/backend/vault/repositories/scheduler-state-repository.js";
 import type {
+  AuditRepository,
   MemoryRepository,
+  SchedulerStateRepository,
   WorkspaceRepository,
 } from "../../../src/repositories/types.js";
 import { getTestDb, truncateAll } from "../../helpers.js";
@@ -13,6 +17,8 @@ export interface TestBackend {
   name: "postgres" | "vault";
   memoryRepo: MemoryRepository;
   workspaceRepo: WorkspaceRepository;
+  auditRepo: AuditRepository;
+  schedulerStateRepo: SchedulerStateRepository;
   close(): Promise<void>;
 }
 
@@ -33,10 +39,16 @@ export const pgFactory: Factory = {
       await import("../../../src/repositories/memory-repository.js");
     const { DrizzleWorkspaceRepository } =
       await import("../../../src/repositories/workspace-repository.js");
+    const { DrizzleAuditRepository } =
+      await import("../../../src/repositories/audit-repository.js");
+    const { DrizzleSchedulerStateRepository } =
+      await import("../../../src/repositories/scheduler-state-repository.js");
     return {
       name: "postgres",
       memoryRepo: new DrizzleMemoryRepository(db),
       workspaceRepo: new DrizzleWorkspaceRepository(db),
+      auditRepo: new DrizzleAuditRepository(db),
+      schedulerStateRepo: new DrizzleSchedulerStateRepository(db),
       close: async () => {},
     };
   },
@@ -48,10 +60,14 @@ export const vaultFactory: Factory = {
     const root = await mkdtemp(join(tmpdir(), "contract-vault-"));
     const memoryRepo = await VaultMemoryRepository.create({ root });
     const workspaceRepo = new VaultWorkspaceRepository({ root });
+    const auditRepo = new VaultAuditRepository({ root });
+    const schedulerStateRepo = new VaultSchedulerStateRepository({ root });
     return {
       name: "vault",
       memoryRepo,
       workspaceRepo,
+      auditRepo,
+      schedulerStateRepo,
       close: async () => {
         await rm(root, { recursive: true, force: true });
       },

--- a/tests/contract/repositories/_factories.ts
+++ b/tests/contract/repositories/_factories.ts
@@ -5,10 +5,14 @@ import { VaultMemoryRepository } from "../../../src/backend/vault/repositories/m
 import { VaultWorkspaceRepository } from "../../../src/backend/vault/repositories/workspace-repository.js";
 import { VaultAuditRepository } from "../../../src/backend/vault/repositories/audit-repository.js";
 import { VaultSchedulerStateRepository } from "../../../src/backend/vault/repositories/scheduler-state-repository.js";
+import { VaultSessionTrackingRepository } from "../../../src/backend/vault/repositories/session-tracking-repository.js";
+import { VaultSessionRepository } from "../../../src/backend/vault/repositories/session-repository.js";
 import type {
   AuditRepository,
   MemoryRepository,
   SchedulerStateRepository,
+  SessionRepository,
+  SessionTrackingRepository,
   WorkspaceRepository,
 } from "../../../src/repositories/types.js";
 import { getTestDb, truncateAll } from "../../helpers.js";
@@ -19,6 +23,8 @@ export interface TestBackend {
   workspaceRepo: WorkspaceRepository;
   auditRepo: AuditRepository;
   schedulerStateRepo: SchedulerStateRepository;
+  sessionTrackingRepo: SessionTrackingRepository;
+  sessionRepo: SessionRepository;
   close(): Promise<void>;
 }
 
@@ -43,12 +49,16 @@ export const pgFactory: Factory = {
       await import("../../../src/repositories/audit-repository.js");
     const { DrizzleSchedulerStateRepository } =
       await import("../../../src/repositories/scheduler-state-repository.js");
+    const { DrizzleSessionTrackingRepository, DrizzleSessionRepository } =
+      await import("../../../src/repositories/session-repository.js");
     return {
       name: "postgres",
       memoryRepo: new DrizzleMemoryRepository(db),
       workspaceRepo: new DrizzleWorkspaceRepository(db),
       auditRepo: new DrizzleAuditRepository(db),
       schedulerStateRepo: new DrizzleSchedulerStateRepository(db),
+      sessionTrackingRepo: new DrizzleSessionTrackingRepository(db),
+      sessionRepo: new DrizzleSessionRepository(db),
       close: async () => {},
     };
   },
@@ -62,12 +72,16 @@ export const vaultFactory: Factory = {
     const workspaceRepo = new VaultWorkspaceRepository({ root });
     const auditRepo = new VaultAuditRepository({ root });
     const schedulerStateRepo = new VaultSchedulerStateRepository({ root });
+    const sessionTrackingRepo = new VaultSessionTrackingRepository({ root });
+    const sessionRepo = new VaultSessionRepository({ root });
     return {
       name: "vault",
       memoryRepo,
       workspaceRepo,
       auditRepo,
       schedulerStateRepo,
+      sessionTrackingRepo,
+      sessionRepo,
       close: async () => {
         await rm(root, { recursive: true, force: true });
       },

--- a/tests/contract/repositories/audit-repository.test.ts
+++ b/tests/contract/repositories/audit-repository.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { factories, type TestBackend } from "./_factories.js";
+import type { AuditEntry } from "../../../src/types/audit.js";
+import type { Memory } from "../../../src/types/memory.js";
+
+const ZERO_EMB = new Array(768).fill(0);
+
+function makeEntry(overrides: Partial<AuditEntry> = {}): AuditEntry {
+  return {
+    id: "a1",
+    project_id: "p1",
+    memory_id: "m1",
+    action: "created",
+    actor: "chris",
+    reason: null,
+    diff: null,
+    created_at: new Date("2026-04-21T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function makeMemory(overrides: Partial<Memory> = {}): Memory {
+  const now = new Date("2026-04-21T00:00:00.000Z");
+  return {
+    id: "m1",
+    project_id: "p1",
+    workspace_id: "ws1",
+    content: "body",
+    title: "T",
+    type: "fact",
+    scope: "workspace",
+    tags: null,
+    author: "chris",
+    source: null,
+    session_id: null,
+    metadata: null,
+    embedding_model: null,
+    embedding_dimensions: null,
+    version: 1,
+    created_at: now,
+    updated_at: now,
+    verified_at: null,
+    archived_at: null,
+    comment_count: 0,
+    flag_count: 0,
+    relationship_count: 0,
+    last_comment_at: null,
+    verified_by: null,
+    ...overrides,
+  };
+}
+
+describe.each(factories)("AuditRepository contract — $name", (factory) => {
+  let backend: TestBackend;
+  beforeEach(async () => {
+    backend = await factory.create();
+    // pg enforces FK audit_log.memory_id → memories.id — seed a memory
+    // so create() doesn't fail on pg. Vault tolerates missing memories.
+    await backend.workspaceRepo.findOrCreate("ws1");
+    await backend.memoryRepo.create({ ...makeMemory(), embedding: ZERO_EMB });
+  });
+  afterEach(async () => {
+    await backend.close();
+  });
+
+  it("create + findByMemoryId returns the entry", async () => {
+    await backend.auditRepo.create(makeEntry());
+    const found = await backend.auditRepo.findByMemoryId("m1");
+    expect(found).toHaveLength(1);
+    expect(found[0]!.action).toBe("created");
+    expect(found[0]!.actor).toBe("chris");
+  });
+
+  it("findByMemoryId returns empty array for unknown memory", async () => {
+    expect(await backend.auditRepo.findByMemoryId("nope")).toEqual([]);
+  });
+
+  it("findByMemoryId returns entries ordered by created_at desc", async () => {
+    const base = new Date("2026-04-21T00:00:00.000Z").getTime();
+    await backend.auditRepo.create(
+      makeEntry({ id: "a1", created_at: new Date(base) }),
+    );
+    await backend.auditRepo.create(
+      makeEntry({ id: "a2", created_at: new Date(base + 1000) }),
+    );
+    await backend.auditRepo.create(
+      makeEntry({ id: "a3", created_at: new Date(base + 500) }),
+    );
+    const found = await backend.auditRepo.findByMemoryId("m1");
+    expect(found.map((e) => e.id)).toEqual(["a2", "a3", "a1"]);
+  });
+
+  it("preserves diff and reason payloads across roundtrip", async () => {
+    const diff = { content: ["old", "new"], tags: [["x"], ["x", "y"]] };
+    await backend.auditRepo.create(
+      makeEntry({
+        action: "updated",
+        reason: "refactor",
+        diff,
+      }),
+    );
+    const [entry] = await backend.auditRepo.findByMemoryId("m1");
+    expect(entry?.reason).toBe("refactor");
+    expect(entry?.diff).toEqual(diff);
+    expect(entry?.action).toBe("updated");
+  });
+});

--- a/tests/contract/repositories/audit-repository.test.ts
+++ b/tests/contract/repositories/audit-repository.test.ts
@@ -104,4 +104,11 @@ describe.each(factories)("AuditRepository contract — $name", (factory) => {
     expect(entry?.diff).toEqual(diff);
     expect(entry?.action).toBe("updated");
   });
+
+  it("preserves caller-supplied created_at byte-for-byte", async () => {
+    const iso = "2020-01-01T00:00:00.000Z";
+    await backend.auditRepo.create(makeEntry({ created_at: new Date(iso) }));
+    const [entry] = await backend.auditRepo.findByMemoryId("m1");
+    expect(entry?.created_at.toISOString()).toBe(iso);
+  });
 });

--- a/tests/contract/repositories/scheduler-state-repository.test.ts
+++ b/tests/contract/repositories/scheduler-state-repository.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { factories, type TestBackend } from "./_factories.js";
+
+describe.each(factories)(
+  "SchedulerStateRepository contract — $name",
+  (factory) => {
+    let backend: TestBackend;
+    beforeEach(async () => {
+      backend = await factory.create();
+    });
+    afterEach(async () => {
+      await backend.close();
+    });
+
+    it("getLastRun returns null before any recordRun", async () => {
+      expect(
+        await backend.schedulerStateRepo.getLastRun("consolidation"),
+      ).toBeNull();
+    });
+
+    it("recordRun then getLastRun round-trips", async () => {
+      const t = new Date("2026-04-21T10:00:00.000Z");
+      await backend.schedulerStateRepo.recordRun("consolidation", t);
+      const got = await backend.schedulerStateRepo.getLastRun("consolidation");
+      expect(got?.toISOString()).toBe(t.toISOString());
+    });
+
+    it("recordRun is monotonic — never regresses on older runAt", async () => {
+      const newer = new Date("2026-04-21T10:00:00.000Z");
+      const older = new Date("2026-04-20T10:00:00.000Z");
+      await backend.schedulerStateRepo.recordRun("consolidation", newer);
+      await backend.schedulerStateRepo.recordRun("consolidation", older);
+      const got = await backend.schedulerStateRepo.getLastRun("consolidation");
+      expect(got?.toISOString()).toBe(newer.toISOString());
+    });
+
+    it("recordRun advances to a later runAt", async () => {
+      const t1 = new Date("2026-04-21T10:00:00.000Z");
+      const t2 = new Date("2026-04-21T11:00:00.000Z");
+      await backend.schedulerStateRepo.recordRun("consolidation", t1);
+      await backend.schedulerStateRepo.recordRun("consolidation", t2);
+      const got = await backend.schedulerStateRepo.getLastRun("consolidation");
+      expect(got?.toISOString()).toBe(t2.toISOString());
+    });
+  },
+);

--- a/tests/contract/repositories/session-repository.test.ts
+++ b/tests/contract/repositories/session-repository.test.ts
@@ -54,4 +54,58 @@ describe.each(factories)("SessionRepository contract — $name", (factory) => {
     expect(r.exceeded).toBe(true);
     expect(r.used).toBe(1);
   });
+
+  it("createSession rejects a duplicate id", async () => {
+    await backend.sessionRepo.createSession("s1", "u1", "p1", "ws1");
+    await expect(
+      backend.sessionRepo.createSession("s1", "u1", "p1", "ws1"),
+    ).rejects.toThrow();
+  });
+
+  it("concurrent createSession: exactly one wins", async () => {
+    const results = await Promise.allSettled([
+      backend.sessionRepo.createSession("s-race", "u1", "p1", "ws1"),
+      backend.sessionRepo.createSession("s-race", "u1", "p1", "ws1"),
+    ]);
+    const fulfilled = results.filter((r) => r.status === "fulfilled").length;
+    const rejected = results.filter((r) => r.status === "rejected").length;
+    expect(fulfilled).toBe(1);
+    expect(rejected).toBe(1);
+  });
+
+  it("incrementBudgetUsed on unknown session returns exceeded with used===limit", async () => {
+    const r = await backend.sessionRepo.incrementBudgetUsed("nope", 10);
+    expect(r).toEqual({ used: 10, exceeded: true });
+    // Should not create any record as a side-effect.
+    expect(await backend.sessionRepo.findById("nope")).toBeNull();
+  });
+
+  it("concurrent incrementBudgetUsed serializes into a consistent used count", async () => {
+    await backend.sessionRepo.createSession("s-cas", "u1", "p1", "ws1");
+    const N = 25;
+    const results = await Promise.all(
+      Array.from({ length: N }, () =>
+        backend.sessionRepo.incrementBudgetUsed("s-cas", N),
+      ),
+    );
+    const successes = results.filter((r) => !r.exceeded).length;
+    expect(successes).toBe(N);
+    const final = await backend.sessionRepo.findById("s-cas");
+    expect(final?.budget_used).toBe(N);
+  });
+
+  it("concurrent incrementBudgetUsed past the limit stops at limit", async () => {
+    await backend.sessionRepo.createSession("s-cap", "u1", "p1", "ws1");
+    const LIMIT = 5;
+    const CALLS = 20;
+    const results = await Promise.all(
+      Array.from({ length: CALLS }, () =>
+        backend.sessionRepo.incrementBudgetUsed("s-cap", LIMIT),
+      ),
+    );
+    const successes = results.filter((r) => !r.exceeded).length;
+    expect(successes).toBe(LIMIT);
+    const final = await backend.sessionRepo.findById("s-cap");
+    expect(final?.budget_used).toBe(LIMIT);
+  });
 });

--- a/tests/contract/repositories/session-repository.test.ts
+++ b/tests/contract/repositories/session-repository.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { factories, type TestBackend } from "./_factories.js";
+
+describe.each(factories)("SessionRepository contract — $name", (factory) => {
+  let backend: TestBackend;
+  beforeEach(async () => {
+    backend = await factory.create();
+    // pg enforces workspace FK on sessions.
+    await backend.workspaceRepo.findOrCreate("ws1");
+  });
+  afterEach(async () => {
+    await backend.close();
+  });
+
+  it("createSession + findById round-trips", async () => {
+    await backend.sessionRepo.createSession("s1", "u1", "p1", "ws1");
+    const found = await backend.sessionRepo.findById("s1");
+    expect(found).toMatchObject({
+      id: "s1",
+      user_id: "u1",
+      project_id: "p1",
+      workspace_id: "ws1",
+      budget_used: 0,
+    });
+  });
+
+  it("findById returns null for unknown id", async () => {
+    expect(await backend.sessionRepo.findById("nope")).toBeNull();
+  });
+
+  it("getBudget returns null for unknown id", async () => {
+    expect(await backend.sessionRepo.getBudget("nope")).toBeNull();
+  });
+
+  it("getBudget returns used + limit for created session", async () => {
+    await backend.sessionRepo.createSession("s1", "u1", "p1", "ws1");
+    const b = await backend.sessionRepo.getBudget("s1");
+    expect(b?.used).toBe(0);
+    expect(b?.limit).toBeGreaterThan(0);
+  });
+
+  it("incrementBudgetUsed advances used up to limit", async () => {
+    await backend.sessionRepo.createSession("s1", "u1", "p1", "ws1");
+    const r1 = await backend.sessionRepo.incrementBudgetUsed("s1", 2);
+    expect(r1).toEqual({ used: 1, exceeded: false });
+    const r2 = await backend.sessionRepo.incrementBudgetUsed("s1", 2);
+    expect(r2).toEqual({ used: 2, exceeded: false });
+  });
+
+  it("incrementBudgetUsed returns exceeded once at limit", async () => {
+    await backend.sessionRepo.createSession("s1", "u1", "p1", "ws1");
+    await backend.sessionRepo.incrementBudgetUsed("s1", 1);
+    const r = await backend.sessionRepo.incrementBudgetUsed("s1", 1);
+    expect(r.exceeded).toBe(true);
+    expect(r.used).toBe(1);
+  });
+});

--- a/tests/contract/repositories/session-tracking-repository.test.ts
+++ b/tests/contract/repositories/session-tracking-repository.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { factories, type TestBackend } from "./_factories.js";
+
+describe.each(factories)(
+  "SessionTrackingRepository contract — $name",
+  (factory) => {
+    let backend: TestBackend;
+    beforeEach(async () => {
+      backend = await factory.create();
+      // pg enforces workspace FK on session_tracking.
+      await backend.workspaceRepo.findOrCreate("ws1");
+      await backend.workspaceRepo.findOrCreate("ws2");
+    });
+    afterEach(async () => {
+      await backend.close();
+    });
+
+    it("first upsert returns null (no previous session)", async () => {
+      const prev = await backend.sessionTrackingRepo.upsert("u1", "p1", "ws1");
+      expect(prev).toBeNull();
+    });
+
+    it("second upsert returns the first session timestamp", async () => {
+      const first = new Date();
+      await backend.sessionTrackingRepo.upsert("u1", "p1", "ws1");
+      // Small wait to ensure the second call's now() is clearly later.
+      await new Promise((r) => setTimeout(r, 10));
+      const prev = await backend.sessionTrackingRepo.upsert("u1", "p1", "ws1");
+      expect(prev).toBeInstanceOf(Date);
+      expect(prev!.getTime()).toBeGreaterThanOrEqual(first.getTime() - 1);
+    });
+
+    it("different users do not share tracking state", async () => {
+      await backend.sessionTrackingRepo.upsert("u1", "p1", "ws1");
+      const prev = await backend.sessionTrackingRepo.upsert("u2", "p1", "ws1");
+      expect(prev).toBeNull();
+    });
+
+    it("different workspaces do not share tracking state", async () => {
+      await backend.sessionTrackingRepo.upsert("u1", "p1", "ws1");
+      const prev = await backend.sessionTrackingRepo.upsert("u1", "p1", "ws2");
+      expect(prev).toBeNull();
+    });
+  },
+);

--- a/tests/unit/backend/vault/io/json-fs.test.ts
+++ b/tests/unit/backend/vault/io/json-fs.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  readJson,
+  writeJsonAtomic,
+  appendJsonLine,
+  readJsonLines,
+} from "../../../../../src/backend/vault/io/json-fs.js";
+
+describe("json-fs", () => {
+  let root: string;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "vault-json-fs-"));
+  });
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("readJson returns null for a missing file", async () => {
+    expect(await readJson(root, "missing.json")).toBeNull();
+  });
+
+  it("writeJsonAtomic + readJson round-trips a value", async () => {
+    await writeJsonAtomic(root, "nested/dir/state.json", { a: 1, b: [2, 3] });
+    expect(await readJson(root, "nested/dir/state.json")).toEqual({
+      a: 1,
+      b: [2, 3],
+    });
+  });
+
+  it("writeJsonAtomic removes the .tmp sibling on success", async () => {
+    await writeJsonAtomic(root, "x.json", { ok: true });
+    const dir = await readFile(join(root, "x.json"), "utf8");
+    expect(JSON.parse(dir)).toEqual({ ok: true });
+    // No .tmp file should be left behind.
+    await expect(readFile(join(root, "x.json.tmp"), "utf8")).rejects.toThrow(
+      /ENOENT/,
+    );
+  });
+
+  it("appendJsonLine + readJsonLines preserves order", async () => {
+    await appendJsonLine(root, "log.jsonl", { i: 1 });
+    await appendJsonLine(root, "log.jsonl", { i: 2 });
+    await appendJsonLine(root, "log.jsonl", { i: 3 });
+    const rows = await readJsonLines<{ i: number }>(root, "log.jsonl");
+    expect(rows.map((r) => r.i)).toEqual([1, 2, 3]);
+  });
+
+  it("readJsonLines returns [] for missing file", async () => {
+    expect(await readJsonLines(root, "missing.jsonl")).toEqual([]);
+  });
+
+  it("readJsonLines throws on a malformed line", async () => {
+    await writeFile(join(root, "bad.jsonl"), '{"ok":1}\nnot-json\n', "utf8");
+    await expect(readJsonLines(root, "bad.jsonl")).rejects.toThrow(
+      /invalid JSONL entry at line 2/,
+    );
+  });
+});

--- a/tests/unit/backend/vault/io/json-fs.test.ts
+++ b/tests/unit/backend/vault/io/json-fs.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   readJson,
   writeJsonAtomic,
+  writeJsonExclusive,
   appendJsonLine,
   readJsonLines,
 } from "../../../../../src/backend/vault/io/json-fs.js";
@@ -20,6 +21,11 @@ describe("json-fs", () => {
 
   it("readJson returns null for a missing file", async () => {
     expect(await readJson(root, "missing.json")).toBeNull();
+  });
+
+  it("readJson returns null for an empty file", async () => {
+    await writeFile(join(root, "empty.json"), "", "utf8");
+    expect(await readJson(root, "empty.json")).toBeNull();
   });
 
   it("writeJsonAtomic + readJson round-trips a value", async () => {
@@ -57,5 +63,23 @@ describe("json-fs", () => {
     await expect(readJsonLines(root, "bad.jsonl")).rejects.toThrow(
       /invalid JSONL entry at line 2/,
     );
+  });
+
+  it("readJsonLines drops a partial trailing line (no newline)", async () => {
+    await writeFile(
+      join(root, "partial.jsonl"),
+      '{"i":1}\n{"i":2}\n{"i":3',
+      "utf8",
+    );
+    const rows = await readJsonLines<{ i: number }>(root, "partial.jsonl");
+    expect(rows).toEqual([{ i: 1 }, { i: 2 }]);
+  });
+
+  it("writeJsonExclusive throws EEXIST when the file already exists", async () => {
+    await writeJsonExclusive(root, "only-once.json", { n: 1 });
+    await expect(
+      writeJsonExclusive(root, "only-once.json", { n: 2 }),
+    ).rejects.toMatchObject({ code: "EEXIST" });
+    expect(await readJson(root, "only-once.json")).toEqual({ n: 1 });
   });
 });

--- a/tests/unit/backend/vault/repositories/traversal.test.ts
+++ b/tests/unit/backend/vault/repositories/traversal.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { VaultAuditRepository } from "../../../../../src/backend/vault/repositories/audit-repository.js";
+import { VaultSessionRepository } from "../../../../../src/backend/vault/repositories/session-repository.js";
+import { VaultSessionTrackingRepository } from "../../../../../src/backend/vault/repositories/session-tracking-repository.js";
+
+const UNSAFE: readonly string[] = [
+  "",
+  ".",
+  "..",
+  "../x",
+  "a/b",
+  "a\\b",
+  "a\0b",
+];
+
+describe("traversal rejection for vault secondary repositories", () => {
+  let root: string;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "vault-traversal-"));
+  });
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  describe("VaultAuditRepository.create rejects unsafe memory_id", () => {
+    it.each(UNSAFE)("memory_id=%j throws", async (memoryId) => {
+      const repo = new VaultAuditRepository({ root });
+      await expect(
+        repo.create({
+          id: "a1",
+          project_id: "p1",
+          memory_id: memoryId,
+          action: "created",
+          actor: "chris",
+          reason: null,
+          diff: null,
+          created_at: new Date("2026-04-21T00:00:00.000Z"),
+        }),
+      ).rejects.toThrow(/invalid memory_id/);
+    });
+
+    it.each(UNSAFE)("findByMemoryId(%j) throws", async (memoryId) => {
+      const repo = new VaultAuditRepository({ root });
+      await expect(repo.findByMemoryId(memoryId)).rejects.toThrow(
+        /invalid memory_id/,
+      );
+    });
+  });
+
+  describe("VaultSessionRepository rejects unsafe session id", () => {
+    it.each(UNSAFE)("createSession(%j) throws", async (id) => {
+      const repo = new VaultSessionRepository({ root });
+      await expect(repo.createSession(id, "u1", "p1", "ws1")).rejects.toThrow(
+        /invalid session id/,
+      );
+    });
+
+    it.each(UNSAFE)("incrementBudgetUsed(%j) throws", async (id) => {
+      const repo = new VaultSessionRepository({ root });
+      await expect(repo.incrementBudgetUsed(id, 10)).rejects.toThrow(
+        /invalid session id/,
+      );
+    });
+
+    it.each(UNSAFE)("findById(%j) throws", async (id) => {
+      const repo = new VaultSessionRepository({ root });
+      await expect(repo.findById(id)).rejects.toThrow(/invalid session id/);
+    });
+
+    it.each(UNSAFE)("getBudget(%j) throws", async (id) => {
+      const repo = new VaultSessionRepository({ root });
+      await expect(repo.getBudget(id)).rejects.toThrow(/invalid session id/);
+    });
+  });
+
+  describe("VaultSessionTrackingRepository rejects unsafe segments", () => {
+    it.each(UNSAFE)("upsert userId=%j throws", async (value) => {
+      const repo = new VaultSessionTrackingRepository({ root });
+      await expect(repo.upsert(value, "p1", "ws1")).rejects.toThrow(
+        /invalid userId/,
+      );
+    });
+
+    it.each(UNSAFE)("upsert projectId=%j throws", async (value) => {
+      const repo = new VaultSessionTrackingRepository({ root });
+      await expect(repo.upsert("u1", value, "ws1")).rejects.toThrow(
+        /invalid projectId/,
+      );
+    });
+
+    it.each(UNSAFE)("upsert workspaceId=%j throws", async (value) => {
+      const repo = new VaultSessionTrackingRepository({ root });
+      await expect(repo.upsert("u1", "p1", value)).rejects.toThrow(
+        /invalid workspaceId/,
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2b.1 of the vault backend rollout. Lands the four non-embedded secondary repositories on the vault backend plus the shared JSON-IO helper they all build on. pg side gets two small parity patches.

### What's in

- **Plan doc** `docs/superpowers/plans/2026-04-21-vault-backend-phase-2b-secondary-repos.md` splits Phase 2b into 2b.1 (this PR), 2b.2 (embedded Comment/Flag/Relationship), and 2b.3 (VaultBackend wiring).
- **`io/json-fs.ts`**: `readJson` (ENOENT + empty → null), `writeJsonAtomic` (tmp+rename), `appendJsonLine` (for JSONL), `readJsonLines`.
- **`io/vault-fs.ts`**: `ensureParentDir` + `ensureFileExists` helpers.
- **`VaultAuditRepository`**: append-only JSONL per memory at `_audit/<memory_id>.jsonl`; `findByMemoryId` sorts created_at desc.
- **`VaultSchedulerStateRepository`**: singleton `_scheduler-state.json` under lock; `recordRun` monotonic.
- **`VaultSessionTrackingRepository`**: `_session-tracking/<user>/<ws>/<project>.json` per composite key; returns previous `last_session_at` from upsert.
- **`VaultSessionRepository`**: `_sessions/<id>.json` per session; `createSession` rejects existing ids, `incrementBudgetUsed` is CAS-under-lock.
- **Contract tests** for all four repos, parameterized over pg + vault.
- **Unit tests** for `io/json-fs.ts` (missing / empty / malformed).
- **pg parity patch**: `DrizzleAuditRepository.create` now honors caller-supplied `created_at`.

### Not in (follow-ups)

- `CommentRepository` · `FlagRepository` · `RelationshipRepository` (embedded in memory markdown) → 2b.2.
- `VaultBackend` class · factory arm · integration contract tests → 2b.3.

### Storage layout

All standalone repos use `_`-prefixed paths so they never collide with the three memory layouts consumed by `inferScopeFromPath`:

```
<vault-root>/
├── _audit/<memory_id>.jsonl
├── _scheduler-state.json
├── _sessions/<session_id>.json
└── _session-tracking/<user>/<workspace>/<project>.json
```

### Stats

- 2 commits · 15 files changed (+896 / -1) · 621/621 tests pass (58 files)
- typecheck / lint / prettier clean
- 20 new contract tests across both backends

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npx prettier --check` clean
- [x] `npm test -- --run` 621/621 pass
- [x] Contract suite pins: monotonic scheduler, CAS budget, composite-key session tracking, audit ordering + reason/diff roundtrip, caller-supplied audit timestamps (pg parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)