### PR TITLE
feat(vault): Phase 3 — LanceDB vector index

### DIFF
--- a/docs/superpowers/plans/2026-04-22-vault-backend-phase-3-vector-index.md
+++ b/docs/superpowers/plans/2026-04-22-vault-backend-phase-3-vector-index.md
@@ -1,0 +1,1978 @@
+# Vault Backend Phase 3 — LanceDB Vector Index Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the four vector-search `MemoryRepository` methods on the vault backend by integrating a LanceDB file-based index, replacing the Phase 2 `NotImplementedError` stubs. After this phase, `VaultBackend` is behaviorally at-parity with `PostgresBackend` for every `MemoryRepository` interface method.
+
+**Architecture:** A new `VaultVectorIndex` primitive (under `src/backend/vault/vector/`) wraps `@lancedb/lancedb` with cosine-distance + filter predicates and is the single point of contact with LanceDB. `VaultMemoryRepository` takes the index via constructor, writes through to it on `create`/`update`/`archive`, and delegates the four vector methods to it. Failure modes mirror the spec: lance is a derived cache, the markdown vault is the source of truth. Contract tests parameterize existing vector-method suites across pg + vault and a new parity test asserts top-K overlap on a ~500-memory corpus.
+
+**Tech Stack:** `@lancedb/lancedb` (file-based, cosine), Node.js, TypeScript, vitest, fast-check.
+
+---
+
+## Scope
+
+**In scope:**
+
+- New `src/backend/vault/vector/lance-index.ts` — typed wrapper: `upsert / delete / search / searchPairwise / listEmbeddings`.
+- Wire `VaultMemoryRepository` to the index on `create`, `update` (re-embed on content change), `archive` (delete row).
+- Implement `search`, `findDuplicates`, `findPairwiseSimilar`, `listWithEmbeddings` on `VaultMemoryRepository`.
+- Contract tests parameterized over pg + vault for the four methods.
+- Parity test: 500 synthetic memories → top-K overlap ≥ 95% between pg + vault on 20 queries.
+- `VaultBackend` takes an index root (defaults to `<vaultRoot>/.agent-brain/index.lance`); `close()` closes the lance connection.
+- A lance-side `content_hash` column so `update` skips re-embed when body unchanged (hash stored on index row only, never in markdown).
+
+**Out of scope (deferred):**
+
+- Git commit/push of lance writes — lance dir is runtime-only (`.agent-brain/`, gitignored).
+- Reindex-on-boot from vault scan — added in Phase 5 with the chokidar watcher; Phase 3 assumes writes flow through the repo.
+- HNSW/IVF-PQ index tuning — Phase 3 uses a plain (non-indexed) scan; create a vector index once the corpus demands it. The plain scan meets the Phase 3 parity bar and keeps the first-write path simple.
+- Embedding provider changes — the `embedding: number[]` parameter on `create`/`update` stays exactly as today.
+
+## Architecture
+
+```
+VaultMemoryRepository
+  ├─ markdown IO (Phase 2a) — unchanged
+  └─ VaultVectorIndex (Phase 3)
+       └─ @lancedb/lancedb
+            └─ <root>/.agent-brain/index.lance/
+```
+
+Every write op in `VaultMemoryRepository` takes the file lock, writes the markdown, then writes through to the lance index inside the same critical section. Lance failures after a successful markdown write log a warning and do **not** fail the caller (spec: vault = source of truth; repair path is Phase 5 watcher-driven reindex). Lance failures on the read path (search/findDuplicates/…) bubble up — a bad index means a bad search result, not a bad memory.
+
+### Table schema
+
+One table: `memories`. Columns:
+
+| Column          | Type                        | Meaning                                     |
+| --------------- | --------------------------- | ------------------------------------------- |
+| `id`            | Utf8 (primary key for merge) | memory id                                   |
+| `project_id`    | Utf8                        | deployment isolation filter                 |
+| `workspace_id`  | Utf8 nullable               | workspace scope filter                      |
+| `scope`         | Utf8                        | `workspace` / `user` / `project`            |
+| `author`        | Utf8                        | user-scope filter                           |
+| `title`         | Utf8                        | returned by findDuplicates                  |
+| `archived`      | Bool                        | mirrors `archived_at IS NOT NULL`           |
+| `content_hash`  | Utf8                        | sha256(content) — skip re-embed on no-op    |
+| `vector`        | FixedSizeList<Float32, D>   | embedding; D derived from first insert      |
+
+`D` is locked on first write (embedding_dimensions from the first create). Subsequent writes with mismatched dimension throw `ValidationError` at the wrapper.
+
+### Write path
+
+```
+memoryRepo.create({...memory, embedding})
+  ├─ lock + serialize + writeAtomic (existing Phase 2a)
+  ├─ index.upsert({ id, project_id, workspace_id, scope, author, title,
+  │                 archived: false, content_hash: sha256(content), vector: embedding })
+  └─ return memory
+```
+
+```
+memoryRepo.update(id, expectedVersion, updates)
+  ├─ existing Phase 2a read-modify-write under lock
+  ├─ if updates.embedding provided:
+  │     index.upsert({ id, ...meta, content_hash, vector: updates.embedding })
+  │  else if meta changed (archived_at is handled by archive, but scope/author/title/ws can drift):
+  │     index.upsertMetaOnly({ id, ...meta })   // preserves existing vector
+  └─ return next
+```
+
+```
+memoryRepo.archive(ids)
+  ├─ existing Phase 2a loop
+  └─ for each id that was archived: index.markArchived(id)
+     (soft-delete via column flip, not row delete — avoids re-embed churn
+     if a future operation were to un-archive)
+```
+
+### Read path
+
+All four read methods go through `VaultVectorIndex`:
+
+- `search(SearchOptions)` → `table.search(embedding).where(<filter>).distanceType("cosine").limit(limit+overshoot).toArray()`, map rows to `MemoryWithRelevance` by reading markdown files for full `Memory` shape. Filter `archived = false` always.
+- `findDuplicates(options)` → same shape, `limit(1)`, scope-aware `where` clause matching `DrizzleMemoryRepository.findDuplicates` semantics (D-16), threshold applied post-query.
+- `findPairwiseSimilar(options)` → for each row in the scope slice, run a `search(row.vector).where(id > row.id AND same_scope).limit(topN)`; union filter to `>= threshold`. O(N·K) not O(N²) — matches pg's CROSS JOIN bound since pg filters by threshold.
+- `listWithEmbeddings(options)` → scan + filter + return Memory + raw embedding. The vector is pulled from lance (not the markdown).
+
+### Failure semantics
+
+| Failure                                 | Phase 3 behavior                                                   |
+| --------------------------------------- | ------------------------------------------------------------------ |
+| Lance upsert fails after markdown write | Log warning, caller sees success. Index is now stale for this id. Repair in Phase 5. |
+| Lance delete fails during archive       | Same — log + succeed. Next search may surface the archived memory with a stale row; `archived=false` filter on the read path keys on the lance row, so this is a visible bug. Add an explicit unit test that exercises this branch. |
+| Dimension mismatch on write             | `ValidationError` — hard fail, markdown has already been written under Phase 2a. Caller sees success on markdown but the vector is not indexed. Acceptable for Phase 3 — a dimension change is operator-driven and rare. |
+| Index corruption / missing              | `VaultVectorIndex.create` throws on startup. `VaultBackend.create` propagates. |
+| Search on empty index                   | Return `[]`. |
+
+## File Structure
+
+**New files:**
+
+- `src/backend/vault/vector/lance-index.ts` — `VaultVectorIndex` class: `create()`, `close()`, `upsert()`, `upsertMetaOnly()`, `markArchived()`, `search()`, `findDuplicates()`, `findPairwiseSimilar()`, `listEmbeddings()`.
+- `src/backend/vault/vector/schema.ts` — Arrow schema builder `memorySchema(dims: number)`.
+- `src/backend/vault/vector/hash.ts` — `contentHash(content: string): string` (sha256 hex).
+- `tests/unit/backend/vault/vector/lance-index.test.ts` — CRUD + search + empty-index cases.
+- `tests/contract/repositories/memory-repository-vector.test.ts` — parameterized over pg + vault for the four vector methods.
+- `tests/integration/vector-parity.test.ts` — 500-memory parity.
+
+**Modified files:**
+
+- `src/backend/vault/repositories/memory-repository.ts` — constructor takes `VaultVectorIndex`; remove the four `NotImplementedError` stubs; hook write-through on `create` / `update` / `archive`.
+- `src/backend/vault/index.ts` — `VaultBackend.create()` instantiates + holds the index; `close()` closes it.
+- `tests/contract/repositories/_factories.ts` — `vaultFactory` instantiates a temp lance-backed index (gets `mkdtemp`-allocated root like today); close disposes both dirs.
+- `package.json` / `package-lock.json` — add `@lancedb/lancedb` (runtime dep), `apache-arrow` (peer), and `@lancedb/lancedb` types if needed.
+
+## Open decisions (locked)
+
+- **Index location:** `<vaultRoot>/.agent-brain/index.lance/`. Gitignored (Phase 4 adds the `.gitignore` write; Phase 3 just creates the dir).
+- **Distance metric:** cosine. Matches pg `cosineDistance` and the driver default we use for pgvector.
+- **`embedding_dimensions` source of truth:** first write pins D on the lance table schema. The repo passes through whatever the caller sends; dim drift is a `ValidationError`.
+- **Dedup of `create` ↔ `upsert`:** `VaultVectorIndex.upsert` is idempotent (mergeInsert on `id`). `create` uses upsert; `update` uses upsert. No separate `insert` method.
+- **Pairwise implementation:** N iterative searches, not a cross join. Bounded by `topN = 32` results per row, filtered by `threshold`. This keeps per-row work independent of N at the cost of missing pairs above rank 32 — acceptable because `findPairwiseSimilar`'s caller (consolidation) is already bounded to `<500` active memories in practice.
+- **Plain scan vs indexed:** Phase 3 ships with a plain scan (no `createIndex` call). Top-K correctness is exact; latency scales linearly. Phase 8 (perf) adds `Index.ivfPq` or HNSW once the corpus and the budget targets justify it.
+
+---
+
+## File Structure Summary
+
+| File                                                   | Responsibility                                                  |
+| ------------------------------------------------------ | --------------------------------------------------------------- |
+| `vector/schema.ts`                                     | Arrow schema builder                                            |
+| `vector/hash.ts`                                       | Pure content hash                                               |
+| `vector/lance-index.ts`                                | Stateful wrapper: connect, upsert, markArchived, search, etc.   |
+| `repositories/memory-repository.ts` (modified)         | Wire write-through + implement 4 vector methods via index       |
+| `index.ts` (modified)                                  | Compose index into VaultBackend lifecycle                       |
+| `tests/unit/backend/vault/vector/lance-index.test.ts`  | Wrapper unit coverage                                           |
+| `tests/contract/repositories/memory-repository-vector.test.ts` | Parity across pg + vault for the four methods           |
+| `tests/integration/vector-parity.test.ts`              | 500-memory overlap                                              |
+
+---
+
+## Task breakdown
+
+Tasks target 5–15 minutes each. Commit after each. Subagent-driven execution is the default.
+
+### Task 1: Add `@lancedb/lancedb` dependency and smoke-import
+
+**Files:**
+- Modify: `package.json`
+- Modify: `package-lock.json`
+- Create: `tests/unit/backend/vault/vector/smoke.test.ts`
+
+- [ ] **Step 1: Install**
+
+```bash
+npm i @lancedb/lancedb@^0.23 apache-arrow
+```
+
+- [ ] **Step 2: Add a smoke test that connects + creates + drops a temp table**
+
+```ts
+// tests/unit/backend/vault/vector/smoke.test.ts
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as lancedb from "@lancedb/lancedb";
+
+describe("@lancedb/lancedb smoke", () => {
+  let root: string | null = null;
+  afterEach(async () => {
+    if (root) await rm(root, { recursive: true, force: true });
+    root = null;
+  });
+
+  it("connects, creates a table, queries it, drops it", async () => {
+    root = await mkdtemp(join(tmpdir(), "lance-smoke-"));
+    const db = await lancedb.connect(root);
+    const table = await db.createTable("t", [
+      { id: "a", vector: [0.1, 0.2, 0.3] },
+      { id: "b", vector: [0.9, 0.8, 0.7] },
+    ]);
+    const got = await table
+      .search([0.1, 0.2, 0.3])
+      .distanceType("cosine")
+      .limit(2)
+      .toArray();
+    expect(got.map((r) => r.id)).toEqual(["a", "b"]);
+  });
+});
+```
+
+- [ ] **Step 3: Run smoke test**
+
+```bash
+npx vitest run tests/unit/backend/vault/vector/smoke.test.ts
+```
+
+Expected: PASS, 1 test.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json package-lock.json tests/unit/backend/vault/vector/smoke.test.ts
+git commit -m "chore(deps): add @lancedb/lancedb + apache-arrow for vault vector index"
+```
+
+---
+
+### Task 2: `vector/hash.ts` + unit test
+
+**Files:**
+- Create: `src/backend/vault/vector/hash.ts`
+- Create: `tests/unit/backend/vault/vector/hash.test.ts`
+
+- [ ] **Step 1: Write test**
+
+```ts
+// tests/unit/backend/vault/vector/hash.test.ts
+import { describe, it, expect } from "vitest";
+import { contentHash } from "../../../../../src/backend/vault/vector/hash.js";
+
+describe("contentHash", () => {
+  it("is deterministic for equal content", () => {
+    expect(contentHash("hello")).toBe(contentHash("hello"));
+  });
+
+  it("differs for different content", () => {
+    expect(contentHash("hello")).not.toBe(contentHash("world"));
+  });
+
+  it("is a 64-char hex string (sha256)", () => {
+    expect(contentHash("x")).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+```bash
+npx vitest run tests/unit/backend/vault/vector/hash.test.ts
+```
+
+Expected: FAIL — cannot find `hash.js`.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// src/backend/vault/vector/hash.ts
+import { createHash } from "node:crypto";
+
+export function contentHash(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+```bash
+npx vitest run tests/unit/backend/vault/vector/hash.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/vault/vector/hash.ts tests/unit/backend/vault/vector/hash.test.ts
+git commit -m "feat(vault-vector): add sha256 contentHash helper"
+```
+
+---
+
+### Task 3: `vector/schema.ts` + unit test
+
+**Files:**
+- Create: `src/backend/vault/vector/schema.ts`
+- Create: `tests/unit/backend/vault/vector/schema.test.ts`
+
+- [ ] **Step 1: Write test**
+
+```ts
+// tests/unit/backend/vault/vector/schema.test.ts
+import { describe, it, expect } from "vitest";
+import * as arrow from "apache-arrow";
+import { memorySchema } from "../../../../../src/backend/vault/vector/schema.js";
+
+describe("memorySchema", () => {
+  it("has the expected fields", () => {
+    const s = memorySchema(768);
+    const names = s.fields.map((f) => f.name).sort();
+    expect(names).toEqual([
+      "archived",
+      "author",
+      "content_hash",
+      "id",
+      "project_id",
+      "scope",
+      "title",
+      "vector",
+      "workspace_id",
+    ]);
+  });
+
+  it("pins the vector dimension", () => {
+    const s = memorySchema(4);
+    const f = s.fields.find((x) => x.name === "vector")!;
+    expect(f.type).toBeInstanceOf(arrow.FixedSizeList);
+    expect((f.type as arrow.FixedSizeList).listSize).toBe(4);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+```bash
+npx vitest run tests/unit/backend/vault/vector/schema.test.ts
+```
+
+Expected: FAIL — cannot find `schema.js`.
+
+- [ ] **Step 3: Implement**
+
+```ts
+// src/backend/vault/vector/schema.ts
+import * as arrow from "apache-arrow";
+
+export function memorySchema(dims: number): arrow.Schema {
+  return new arrow.Schema([
+    new arrow.Field("id", new arrow.Utf8(), false),
+    new arrow.Field("project_id", new arrow.Utf8(), false),
+    new arrow.Field("workspace_id", new arrow.Utf8(), true),
+    new arrow.Field("scope", new arrow.Utf8(), false),
+    new arrow.Field("author", new arrow.Utf8(), false),
+    new arrow.Field("title", new arrow.Utf8(), false),
+    new arrow.Field("archived", new arrow.Bool(), false),
+    new arrow.Field("content_hash", new arrow.Utf8(), false),
+    new arrow.Field(
+      "vector",
+      new arrow.FixedSizeList(
+        dims,
+        new arrow.Field("item", new arrow.Float32(), true),
+      ),
+      false,
+    ),
+  ]);
+}
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+```bash
+npx vitest run tests/unit/backend/vault/vector/schema.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/vault/vector/schema.ts tests/unit/backend/vault/vector/schema.test.ts
+git commit -m "feat(vault-vector): add Arrow memorySchema builder"
+```
+
+---
+
+### Task 4: `VaultVectorIndex` skeleton — create, close, upsert, countRows
+
+**Files:**
+- Create: `src/backend/vault/vector/lance-index.ts`
+- Create: `tests/unit/backend/vault/vector/lance-index.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+// tests/unit/backend/vault/vector/lance-index.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { VaultVectorIndex } from "../../../../../src/backend/vault/vector/lance-index.js";
+
+describe("VaultVectorIndex — upsert + countRows", () => {
+  let root: string;
+  let idx: VaultVectorIndex;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "lance-test-"));
+    idx = await VaultVectorIndex.create({ root, dims: 4 });
+  });
+  afterEach(async () => {
+    await idx.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("upserts rows and counts them", async () => {
+    await idx.upsert([
+      {
+        id: "a",
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: "workspace",
+        author: "u",
+        title: "t",
+        archived: false,
+        content_hash: "h1",
+        vector: [0.1, 0.2, 0.3, 0.4],
+      },
+    ]);
+    expect(await idx.countRows()).toBe(1);
+  });
+
+  it("upsert on the same id replaces the previous row", async () => {
+    const base = {
+      project_id: "p1",
+      workspace_id: "ws1",
+      scope: "workspace" as const,
+      author: "u",
+      title: "t",
+      archived: false,
+      content_hash: "h",
+      vector: [0, 0, 0, 0],
+    };
+    await idx.upsert([{ id: "a", ...base, content_hash: "h1" }]);
+    await idx.upsert([{ id: "a", ...base, content_hash: "h2" }]);
+    expect(await idx.countRows()).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify it fails**
+
+```bash
+npx vitest run tests/unit/backend/vault/vector/lance-index.test.ts
+```
+
+Expected: FAIL — cannot find module.
+
+- [ ] **Step 3: Implement skeleton**
+
+```ts
+// src/backend/vault/vector/lance-index.ts
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import * as lancedb from "@lancedb/lancedb";
+import { memorySchema } from "./schema.js";
+
+export interface IndexRow {
+  id: string;
+  project_id: string;
+  workspace_id: string | null;
+  scope: "workspace" | "user" | "project";
+  author: string;
+  title: string;
+  archived: boolean;
+  content_hash: string;
+  vector: number[];
+}
+
+export interface VaultVectorIndexConfig {
+  root: string;           // absolute path; wrapper appends /.agent-brain/index.lance
+  dims: number;           // embedding dimension, pins the table schema on first create
+}
+
+export class VaultVectorIndex {
+  private constructor(
+    private readonly db: lancedb.Connection,
+    private readonly table: lancedb.Table,
+    readonly dims: number,
+  ) {}
+
+  static async create(cfg: VaultVectorIndexConfig): Promise<VaultVectorIndex> {
+    const dir = join(cfg.root, ".agent-brain", "index.lance");
+    await mkdir(dir, { recursive: true });
+    const db = await lancedb.connect(dir);
+    const existing = await db.tableNames();
+    const table = existing.includes("memories")
+      ? await db.openTable("memories")
+      : await db.createEmptyTable("memories", memorySchema(cfg.dims));
+    return new VaultVectorIndex(db, table, cfg.dims);
+  }
+
+  async close(): Promise<void> {
+    // @lancedb/lancedb manages connection lifetime internally.
+    // close is a no-op hook today; kept for future resource cleanup.
+  }
+
+  async countRows(): Promise<number> {
+    return await this.table.countRows();
+  }
+
+  async upsert(rows: IndexRow[]): Promise<void> {
+    if (rows.length === 0) return;
+    for (const r of rows) {
+      if (r.vector.length !== this.dims) {
+        throw new Error(
+          `vector dimension mismatch: expected ${this.dims}, got ${r.vector.length} for id ${r.id}`,
+        );
+      }
+    }
+    await this.table
+      .mergeInsert("id")
+      .whenMatchedUpdateAll()
+      .whenNotMatchedInsertAll()
+      .execute(rows);
+  }
+}
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+```bash
+npx vitest run tests/unit/backend/vault/vector/lance-index.test.ts
+```
+
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/vault/vector/lance-index.ts tests/unit/backend/vault/vector/lance-index.test.ts
+git commit -m "feat(vault-vector): VaultVectorIndex skeleton — create/close/upsert/countRows"
+```
+
+---
+
+### Task 5: `VaultVectorIndex.search` + cosine filter predicate
+
+**Files:**
+- Modify: `src/backend/vault/vector/lance-index.ts`
+- Modify: `tests/unit/backend/vault/vector/lance-index.test.ts`
+
+- [ ] **Step 1: Append failing test block**
+
+```ts
+// append to tests/unit/backend/vault/vector/lance-index.test.ts
+describe("VaultVectorIndex — search", () => {
+  let root: string;
+  let idx: VaultVectorIndex;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "lance-test-"));
+    idx = await VaultVectorIndex.create({ root, dims: 3 });
+    await idx.upsert([
+      {
+        id: "a",
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: "workspace",
+        author: "u",
+        title: "A",
+        archived: false,
+        content_hash: "h",
+        vector: [1, 0, 0],
+      },
+      {
+        id: "b",
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: "workspace",
+        author: "u",
+        title: "B",
+        archived: false,
+        content_hash: "h",
+        vector: [0, 1, 0],
+      },
+      {
+        id: "c",
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: "workspace",
+        author: "u",
+        title: "C",
+        archived: true,          // must be filtered out
+        content_hash: "h",
+        vector: [1, 0, 0],
+      },
+    ]);
+  });
+  afterEach(async () => {
+    await idx.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("returns rows ordered by cosine similarity, excluding archived", async () => {
+    const hits = await idx.search({
+      embedding: [1, 0, 0],
+      projectId: "p1",
+      workspaceId: "ws1",
+      scope: ["workspace"],
+      userId: null,
+      limit: 10,
+      minSimilarity: 0,
+    });
+    expect(hits.map((h) => h.id)).toEqual(["a", "b"]);
+    expect(hits[0].relevance).toBeCloseTo(1, 5);
+    expect(hits[1].relevance).toBeCloseTo(0, 5);
+  });
+
+  it("respects minSimilarity threshold", async () => {
+    const hits = await idx.search({
+      embedding: [1, 0, 0],
+      projectId: "p1",
+      workspaceId: "ws1",
+      scope: ["workspace"],
+      userId: null,
+      limit: 10,
+      minSimilarity: 0.5,
+    });
+    expect(hits.map((h) => h.id)).toEqual(["a"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify fail**
+
+```bash
+npx vitest run tests/unit/backend/vault/vector/lance-index.test.ts
+```
+
+Expected: FAIL — `idx.search is not a function`.
+
+- [ ] **Step 3: Implement**
+
+Add to `VaultVectorIndex`:
+
+```ts
+export interface SearchParams {
+  embedding: number[];
+  projectId: string;
+  workspaceId: string | null;
+  scope: Array<"workspace" | "user" | "project">;
+  userId: string | null;
+  limit: number;
+  minSimilarity: number;
+}
+
+export interface SearchHit {
+  id: string;
+  relevance: number;
+}
+
+async search(params: SearchParams): Promise<SearchHit[]> {
+  if (params.embedding.length !== this.dims) {
+    throw new Error(
+      `vector dimension mismatch: expected ${this.dims}, got ${params.embedding.length}`,
+    );
+  }
+  const clauses: string[] = [
+    `archived = false`,
+    `project_id = ${sqlStr(params.projectId)}`,
+  ];
+  const scopeClauses: string[] = [];
+  for (const s of params.scope) {
+    if (s === "workspace") {
+      if (params.workspaceId === null) continue;
+      scopeClauses.push(
+        `(scope = 'workspace' AND workspace_id = ${sqlStr(params.workspaceId)})`,
+      );
+    } else if (s === "user") {
+      if (params.userId === null) continue;
+      scopeClauses.push(
+        `(scope = 'user' AND author = ${sqlStr(params.userId)})`,
+      );
+    } else {
+      scopeClauses.push(`scope = 'project'`);
+    }
+  }
+  if (scopeClauses.length === 0) return [];
+  clauses.push(`(${scopeClauses.join(" OR ")})`);
+  const rows = await this.table
+    .search(params.embedding)
+    .distanceType("cosine")
+    .where(clauses.join(" AND "))
+    .limit(params.limit)
+    .toArray();
+  return rows
+    .map((r: Record<string, unknown>) => ({
+      id: r.id as string,
+      relevance: 1 - Number(r._distance),
+    }))
+    .filter((h) => h.relevance >= params.minSimilarity);
+}
+```
+
+Add helper at module scope:
+
+```ts
+function sqlStr(v: string): string {
+  return `'${v.replace(/'/g, "''")}'`;
+}
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+```bash
+npx vitest run tests/unit/backend/vault/vector/lance-index.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(vault-vector): VaultVectorIndex.search with cosine + scope filter"
+```
+
+---
+
+### Task 6: `VaultVectorIndex.findDuplicates` (scope-aware, D-16 parity)
+
+**Files:**
+- Modify: `src/backend/vault/vector/lance-index.ts`
+- Modify: `tests/unit/backend/vault/vector/lance-index.test.ts`
+
+- [ ] **Step 1: Add failing test**
+
+```ts
+// append to lance-index.test.ts
+describe("VaultVectorIndex — findDuplicates", () => {
+  let root: string;
+  let idx: VaultVectorIndex;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "lance-test-"));
+    idx = await VaultVectorIndex.create({ root, dims: 3 });
+    await idx.upsert([
+      {
+        id: "a",
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: "workspace",
+        author: "u1",
+        title: "A",
+        archived: false,
+        content_hash: "h",
+        vector: [1, 0, 0],
+      },
+      {
+        id: "u",
+        project_id: "p1",
+        workspace_id: null,
+        scope: "user",
+        author: "u1",
+        title: "U",
+        archived: false,
+        content_hash: "h",
+        vector: [1, 0, 0],
+      },
+    ]);
+  });
+  afterEach(async () => {
+    await idx.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("workspace-scope dedup only checks workspace memories", async () => {
+    const hits = await idx.findDuplicates({
+      embedding: [1, 0, 0],
+      projectId: "p1",
+      workspaceId: "ws1",
+      scope: "workspace",
+      userId: "u1",
+      threshold: 0.5,
+    });
+    expect(hits.map((h) => h.id)).toEqual(["a"]);
+  });
+
+  it("user-scope dedup checks user AND workspace memories (D-16)", async () => {
+    const hits = await idx.findDuplicates({
+      embedding: [1, 0, 0],
+      projectId: "p1",
+      workspaceId: "ws1",
+      scope: "user",
+      userId: "u1",
+      threshold: 0.5,
+    });
+    // user-scope sees the "a" workspace match as well per D-16
+    expect(hits.map((h) => h.id).sort()).toEqual(["a"]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify fail**
+
+- [ ] **Step 3: Implement**
+
+```ts
+export interface DuplicateParams {
+  embedding: number[];
+  projectId: string;
+  workspaceId: string | null;
+  scope: "workspace" | "user" | "project";
+  userId: string;
+  threshold: number;
+}
+
+export interface DuplicateHit {
+  id: string;
+  title: string;
+  relevance: number;
+  scope: "workspace" | "user" | "project";
+}
+
+async findDuplicates(params: DuplicateParams): Promise<DuplicateHit[]> {
+  if (params.embedding.length !== this.dims) {
+    throw new Error(
+      `vector dimension mismatch: expected ${this.dims}, got ${params.embedding.length}`,
+    );
+  }
+  const clauses: string[] = [
+    `archived = false`,
+    `project_id = ${sqlStr(params.projectId)}`,
+  ];
+  if (params.scope === "workspace") {
+    if (params.workspaceId === null) {
+      throw new Error("workspaceId is required for workspace-scoped dedup");
+    }
+    clauses.push(
+      `scope = 'workspace'`,
+      `workspace_id = ${sqlStr(params.workspaceId)}`,
+    );
+  } else if (params.scope === "project") {
+    clauses.push(`scope = 'project'`);
+  } else {
+    if (params.workspaceId === null) {
+      throw new Error("workspaceId is required for user-scoped dedup");
+    }
+    clauses.push(
+      `(workspace_id = ${sqlStr(params.workspaceId)}` +
+        ` OR (scope = 'user' AND author = ${sqlStr(params.userId)}))`,
+    );
+  }
+  const rows = await this.table
+    .search(params.embedding)
+    .distanceType("cosine")
+    .where(clauses.join(" AND "))
+    .limit(1)
+    .toArray();
+  return rows
+    .map((r: Record<string, unknown>) => ({
+      id: r.id as string,
+      title: r.title as string,
+      relevance: 1 - Number(r._distance),
+      scope: r.scope as "workspace" | "user" | "project",
+    }))
+    .filter((h) => h.relevance >= params.threshold);
+}
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(vault-vector): VaultVectorIndex.findDuplicates (D-16 parity)"
+```
+
+---
+
+### Task 7: `VaultVectorIndex.findPairwiseSimilar` — per-row search approach
+
+**Files:**
+- Modify: `src/backend/vault/vector/lance-index.ts`
+- Modify: `tests/unit/backend/vault/vector/lance-index.test.ts`
+
+- [ ] **Step 1: Add failing test**
+
+```ts
+describe("VaultVectorIndex — findPairwiseSimilar", () => {
+  let root: string;
+  let idx: VaultVectorIndex;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "lance-test-"));
+    idx = await VaultVectorIndex.create({ root, dims: 3 });
+    await idx.upsert([
+      { id: "a", project_id: "p1", workspace_id: "ws1", scope: "workspace", author: "u", title: "A", archived: false, content_hash: "h", vector: [1, 0, 0] },
+      { id: "b", project_id: "p1", workspace_id: "ws1", scope: "workspace", author: "u", title: "B", archived: false, content_hash: "h", vector: [0.99, 0.01, 0] },
+      { id: "c", project_id: "p1", workspace_id: "ws1", scope: "workspace", author: "u", title: "C", archived: false, content_hash: "h", vector: [0, 1, 0] },
+    ]);
+  });
+  afterEach(async () => {
+    await idx.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("returns one entry per near-duplicate pair with a < b", async () => {
+    const pairs = await idx.findPairwiseSimilar({
+      projectId: "p1",
+      workspaceId: "ws1",
+      scope: "workspace",
+      threshold: 0.9,
+    });
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].memory_a_id).toBe("a");
+    expect(pairs[0].memory_b_id).toBe("b");
+    expect(pairs[0].similarity).toBeGreaterThan(0.9);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify fail**
+
+- [ ] **Step 3: Implement**
+
+```ts
+export interface PairwiseParams {
+  projectId: string;
+  workspaceId: string | null;
+  scope: "workspace" | "project";
+  threshold: number;
+}
+
+export interface PairwiseHit {
+  memory_a_id: string;
+  memory_b_id: string;
+  similarity: number;
+}
+
+async findPairwiseSimilar(params: PairwiseParams): Promise<PairwiseHit[]> {
+  const clauses: string[] = [
+    `archived = false`,
+    `project_id = ${sqlStr(params.projectId)}`,
+  ];
+  if (params.scope === "project") {
+    clauses.push(`scope = 'project'`);
+  } else {
+    if (params.workspaceId === null) {
+      throw new Error("workspaceId is required for workspace-scoped pairwise");
+    }
+    clauses.push(`scope = 'workspace'`);
+    clauses.push(`workspace_id = ${sqlStr(params.workspaceId)}`);
+  }
+  const where = clauses.join(" AND ");
+  // Pull the scope slice including vectors.
+  const rows = (await this.table
+    .query()
+    .where(where)
+    .select(["id", "vector"])
+    .toArray()) as Array<{ id: string; vector: number[] }>;
+  const pairs: PairwiseHit[] = [];
+  for (const r of rows) {
+    const hits = (await this.table
+      .search(Array.from(r.vector))
+      .distanceType("cosine")
+      .where(`${where} AND id > ${sqlStr(r.id)}`)
+      .limit(32)
+      .toArray()) as Array<{ id: string; _distance: number }>;
+    for (const h of hits) {
+      const sim = 1 - Number(h._distance);
+      if (sim >= params.threshold) {
+        pairs.push({
+          memory_a_id: r.id,
+          memory_b_id: h.id as string,
+          similarity: sim,
+        });
+      }
+    }
+  }
+  pairs.sort((a, b) => b.similarity - a.similarity);
+  return pairs;
+}
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(vault-vector): VaultVectorIndex.findPairwiseSimilar"
+```
+
+---
+
+### Task 8: `VaultVectorIndex.listEmbeddings` + `markArchived` + `upsertMetaOnly`
+
+**Files:**
+- Modify: `src/backend/vault/vector/lance-index.ts`
+- Modify: `tests/unit/backend/vault/vector/lance-index.test.ts`
+
+- [ ] **Step 1: Add failing tests**
+
+```ts
+describe("VaultVectorIndex — listEmbeddings + markArchived + upsertMetaOnly", () => {
+  let root: string;
+  let idx: VaultVectorIndex;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "lance-test-"));
+    idx = await VaultVectorIndex.create({ root, dims: 3 });
+    await idx.upsert([
+      { id: "a", project_id: "p1", workspace_id: "ws1", scope: "workspace", author: "u", title: "A", archived: false, content_hash: "h", vector: [1, 0, 0] },
+      { id: "b", project_id: "p1", workspace_id: "ws1", scope: "workspace", author: "u", title: "B", archived: false, content_hash: "h", vector: [0, 1, 0] },
+    ]);
+  });
+  afterEach(async () => {
+    await idx.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("listEmbeddings returns ids with vectors, excludes archived", async () => {
+    await idx.markArchived("b");
+    const list = await idx.listEmbeddings({
+      projectId: "p1",
+      workspaceId: "ws1",
+      scope: "workspace",
+      userId: null,
+      limit: 10,
+    });
+    expect(list.map((r) => r.id)).toEqual(["a"]);
+    expect(list[0].vector).toHaveLength(3);
+  });
+
+  it("upsertMetaOnly preserves the existing vector", async () => {
+    await idx.upsertMetaOnly({
+      id: "a",
+      project_id: "p1",
+      workspace_id: "ws1",
+      scope: "workspace",
+      author: "u",
+      title: "A-renamed",
+      archived: false,
+    });
+    const list = await idx.listEmbeddings({
+      projectId: "p1",
+      workspaceId: "ws1",
+      scope: "workspace",
+      userId: null,
+      limit: 10,
+    });
+    const a = list.find((r) => r.id === "a")!;
+    expect(a.vector).toEqual([1, 0, 0]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test, verify fail**
+
+- [ ] **Step 3: Implement**
+
+```ts
+async markArchived(id: string): Promise<void> {
+  await this.table.update({
+    where: `id = ${sqlStr(id)}`,
+    values: { archived: true },
+  });
+}
+
+export interface ListEmbeddingsParams {
+  projectId: string;
+  workspaceId: string | null;
+  scope: "workspace" | "user" | "project";
+  userId: string | null;
+  limit: number;
+}
+
+async listEmbeddings(params: ListEmbeddingsParams): Promise<
+  Array<{ id: string; vector: number[] }>
+> {
+  const clauses: string[] = [
+    `archived = false`,
+    `project_id = ${sqlStr(params.projectId)}`,
+  ];
+  if (params.scope === "workspace") {
+    if (params.workspaceId === null) {
+      throw new Error("workspaceId is required for workspace listEmbeddings");
+    }
+    clauses.push(
+      `scope = 'workspace'`,
+      `workspace_id = ${sqlStr(params.workspaceId)}`,
+    );
+  } else if (params.scope === "user") {
+    clauses.push(`scope = 'user'`);
+    if (params.userId !== null) {
+      clauses.push(`author = ${sqlStr(params.userId)}`);
+    }
+    if (params.workspaceId !== null) {
+      clauses.push(`workspace_id = ${sqlStr(params.workspaceId)}`);
+    }
+  } else {
+    clauses.push(`scope = 'project'`);
+  }
+  const rows = (await this.table
+    .query()
+    .where(clauses.join(" AND "))
+    .select(["id", "vector"])
+    .limit(params.limit)
+    .toArray()) as Array<{ id: string; vector: number[] }>;
+  return rows.map((r) => ({
+    id: r.id,
+    vector: Array.from(r.vector),
+  }));
+}
+
+async upsertMetaOnly(
+  meta: Omit<IndexRow, "content_hash" | "vector">,
+): Promise<void> {
+  const set: Record<string, string> = {
+    project_id: sqlStr(meta.project_id),
+    scope: sqlStr(meta.scope),
+    author: sqlStr(meta.author),
+    title: sqlStr(meta.title),
+    archived: String(meta.archived),
+  };
+  if (meta.workspace_id !== null) {
+    set.workspace_id = sqlStr(meta.workspace_id);
+  } else {
+    set.workspace_id = "NULL";
+  }
+  await this.table.update({
+    where: `id = ${sqlStr(meta.id)}`,
+    values: set,
+  });
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(vault-vector): markArchived + upsertMetaOnly + listEmbeddings"
+```
+
+---
+
+### Task 9: Wire index into `VaultMemoryRepository` — constructor + create path
+
+**Files:**
+- Modify: `src/backend/vault/repositories/memory-repository.ts`
+
+- [ ] **Step 1: Update `VaultMemoryConfig` and constructor**
+
+```ts
+// in memory-repository.ts
+
+import { VaultVectorIndex } from "../vector/lance-index.js";
+import { contentHash } from "../vector/hash.js";
+
+export interface VaultMemoryConfig {
+  root: string;
+  index: VaultVectorIndex;
+}
+
+// constructor stays private; static create() takes the VaultVectorIndex
+static async create(cfg: VaultMemoryConfig): Promise<VaultMemoryRepository> {
+  const index = new Map<string, IndexEntry>();
+  const files = await safeListMd(cfg.root);
+  for (const rel of files) {
+    const loc = inferScopeFromPath(rel);
+    if (loc === null) continue;
+    index.set(loc.id, {
+      path: rel,
+      scope: loc.scope,
+      workspaceId: loc.workspaceId,
+      userId: loc.userId,
+    });
+  }
+  return new VaultMemoryRepository(cfg, index);
+}
+```
+
+- [ ] **Step 2: Hook write-through inside `create`**
+
+Replace the existing `create` body end with:
+
+```ts
+async create(memory: Memory & { embedding: number[] }): Promise<Memory> {
+  if (this.index.has(memory.id)) {
+    throw new ConflictError(`memory already exists: ${memory.id}`);
+  }
+  const loc = locationFor(memory);
+  const rel = memoryPath(loc);
+  const md = serializeMemoryFile({
+    memory,
+    comments: [],
+    relationships: [],
+    flags: [],
+  });
+  const abs = join(this.cfg.root, rel);
+  await ensurePlaceholder(abs);
+  await withFileLock(abs, async () => {
+    const existing = await readMarkdown(this.cfg.root, rel);
+    if (existing.length > 0) {
+      throw new ConflictError(`memory already exists: ${memory.id}`);
+    }
+    await writeMarkdownAtomic(this.cfg.root, rel, md);
+  });
+  this.index.set(memory.id, {
+    path: rel,
+    scope: loc.scope,
+    workspaceId: loc.workspaceId,
+    userId: loc.userId,
+  });
+  await this.cfg.index.upsert([
+    {
+      id: memory.id,
+      project_id: memory.project_id,
+      workspace_id: memory.workspace_id,
+      scope: memory.scope,
+      author: memory.author,
+      title: memory.title,
+      archived: false,
+      content_hash: contentHash(memory.content),
+      vector: memory.embedding,
+    },
+  ]);
+  const saved = await this.#read(memory.id);
+  return saved.memory;
+}
+```
+
+- [ ] **Step 3: Update callers (factories + VaultBackend) to construct the index**
+
+In `src/backend/vault/index.ts`:
+
+```ts
+import { VaultVectorIndex } from "./vector/lance-index.js";
+
+export interface VaultBackendConfig {
+  root: string;
+  embeddingDimensions: number;    // NEW — required to pin the lance schema
+}
+
+private constructor(
+  memoryRepo: MemoryRepository,
+  private readonly index: VaultVectorIndex,
+  root: string,
+) {
+  this.memoryRepo = memoryRepo;
+  this.workspaceRepo = new VaultWorkspaceRepository({ root });
+  this.commentRepo = new VaultCommentRepository({ root });
+  this.sessionRepo = new VaultSessionTrackingRepository({ root });
+  this.sessionLifecycleRepo = new VaultSessionRepository({ root });
+  this.auditRepo = new VaultAuditRepository({ root });
+  this.flagRepo = new VaultFlagRepository({ root });
+  this.relationshipRepo = new VaultRelationshipRepository({ root });
+  this.schedulerStateRepo = new VaultSchedulerStateRepository({ root });
+}
+
+static async create(cfg: VaultBackendConfig): Promise<VaultBackend> {
+  await mkdir(cfg.root, { recursive: true });
+  const index = await VaultVectorIndex.create({
+    root: cfg.root,
+    dims: cfg.embeddingDimensions,
+  });
+  const memoryRepo = await VaultMemoryRepository.create({
+    root: cfg.root,
+    index,
+  });
+  return new VaultBackend(memoryRepo, index, cfg.root);
+}
+
+async close(): Promise<void> {
+  await this.index.close();
+}
+```
+
+In `src/backend/factory.ts` — forward `embeddingDimensions` from config (already present in `src/config.ts` for pg; reuse). Locate the existing `vault` branch, extend:
+
+```ts
+case "vault":
+  return VaultBackend.create({
+    root: cfg.vaultRoot,
+    embeddingDimensions: cfg.embeddingDimensions,
+  });
+```
+
+In `tests/contract/repositories/_factories.ts` `vaultFactory`:
+
+```ts
+const root = await mkdtemp(join(tmpdir(), "contract-vault-"));
+const { VaultVectorIndex } = await import(
+  "../../../src/backend/vault/vector/lance-index.js"
+);
+const index = await VaultVectorIndex.create({ root, dims: 768 });
+const memoryRepo = await VaultMemoryRepository.create({ root, index });
+// ...
+close: async () => {
+  await index.close();
+  await rm(root, { recursive: true, force: true });
+},
+```
+
+- [ ] **Step 4: Typecheck**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Run existing contract tests — should still pass**
+
+```bash
+npx vitest run tests/contract/repositories
+```
+
+Expected: all green. None of the four vector methods are touched yet — they still throw `NotImplementedError`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A
+git commit -m "feat(vault-vector): wire VaultVectorIndex into VaultMemoryRepository create path"
+```
+
+---
+
+### Task 10: Hook update + archive write-through
+
+**Files:**
+- Modify: `src/backend/vault/repositories/memory-repository.ts`
+
+- [ ] **Step 1: Add a unit test asserting the index stays in sync on update**
+
+Append to a new file `tests/unit/backend/vault/repositories/memory-repository-index-sync.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { VaultMemoryRepository } from "../../../../../src/backend/vault/repositories/memory-repository.js";
+import { VaultWorkspaceRepository } from "../../../../../src/backend/vault/repositories/workspace-repository.js";
+import { VaultVectorIndex } from "../../../../../src/backend/vault/vector/lance-index.js";
+import type { Memory } from "../../../../../src/types/memory.js";
+
+const DIMS = 3;
+const now = new Date("2026-04-22T00:00:00.000Z");
+
+function makeMemory(overrides: Partial<Memory> = {}): Memory {
+  return {
+    id: "m1", project_id: "p1", workspace_id: "ws1",
+    content: "body", title: "Title", type: "fact", scope: "workspace",
+    tags: null, author: "a", source: null, session_id: null, metadata: null,
+    embedding_model: null, embedding_dimensions: DIMS, version: 1,
+    created_at: now, updated_at: now, verified_at: null, archived_at: null,
+    comment_count: 0, flag_count: 0, relationship_count: 0, last_comment_at: null,
+    verified_by: null, ...overrides,
+  };
+}
+
+describe("VaultMemoryRepository — lance index sync", () => {
+  let root: string;
+  let idx: VaultVectorIndex;
+  let repo: VaultMemoryRepository;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "repo-sync-"));
+    idx = await VaultVectorIndex.create({ root, dims: DIMS });
+    repo = await VaultMemoryRepository.create({ root, index: idx });
+    await new VaultWorkspaceRepository({ root }).findOrCreate("ws1");
+  });
+  afterEach(async () => {
+    await idx.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("archive flips the lance row's archived flag", async () => {
+    await repo.create({ ...makeMemory(), embedding: [1, 0, 0] });
+    expect(await idx.countRows()).toBe(1);
+    await repo.archive(["m1"]);
+    const hits = await idx.search({
+      embedding: [1, 0, 0],
+      projectId: "p1",
+      workspaceId: "ws1",
+      scope: ["workspace"],
+      userId: null,
+      limit: 10,
+      minSimilarity: 0,
+    });
+    expect(hits).toEqual([]);
+  });
+
+  it("update with new embedding replaces the vector", async () => {
+    await repo.create({ ...makeMemory(), embedding: [1, 0, 0] });
+    await repo.update("m1", 1, { content: "new", embedding: [0, 1, 0] });
+    const hits = await idx.search({
+      embedding: [0, 1, 0],
+      projectId: "p1",
+      workspaceId: "ws1",
+      scope: ["workspace"],
+      userId: null,
+      limit: 10,
+      minSimilarity: 0.9,
+    });
+    expect(hits.map((h) => h.id)).toEqual(["m1"]);
+  });
+
+  it("update with no embedding updates meta only", async () => {
+    await repo.create({
+      ...makeMemory({ title: "Old" }),
+      embedding: [1, 0, 0],
+    });
+    await repo.update("m1", 1, { title: "New" });
+    const hits = await idx.search({
+      embedding: [1, 0, 0],
+      projectId: "p1",
+      workspaceId: "ws1",
+      scope: ["workspace"],
+      userId: null,
+      limit: 1,
+      minSimilarity: 0,
+    });
+    expect(hits).toHaveLength(1);
+    // meta-only upsert keeps vector intact
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail**
+
+- [ ] **Step 3: Modify `update` in `memory-repository.ts`**
+
+Inside the `withFileLock` block, after `await writeMarkdownAtomic(...)`, before the `reread`:
+
+```ts
+if (updates.embedding !== undefined && updates.embedding !== null) {
+  await this.cfg.index.upsert([
+    {
+      id: next.id,
+      project_id: next.project_id,
+      workspace_id: next.workspace_id,
+      scope: next.scope,
+      author: next.author,
+      title: next.title,
+      archived: false,
+      content_hash: contentHash(next.content),
+      vector: updates.embedding,
+    },
+  ]);
+} else {
+  await this.cfg.index.upsertMetaOnly({
+    id: next.id,
+    project_id: next.project_id,
+    workspace_id: next.workspace_id,
+    scope: next.scope,
+    author: next.author,
+    title: next.title,
+    archived: false,
+  });
+}
+```
+
+- [ ] **Step 4: Modify `archive` in `memory-repository.ts`**
+
+Inside the per-id loop, after `count += 1`:
+
+```ts
+await this.cfg.index.markArchived(id);
+```
+
+- [ ] **Step 5: Run unit tests, verify pass**
+
+```bash
+npx vitest run tests/unit/backend/vault/repositories/memory-repository-index-sync.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Full test suite smoke**
+
+```bash
+npm test --run
+```
+
+Expected: all green; no regressions.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A
+git commit -m "feat(vault-vector): write-through on update + archive"
+```
+
+---
+
+### Task 11: Implement `search` on VaultMemoryRepository
+
+**Files:**
+- Modify: `src/backend/vault/repositories/memory-repository.ts`
+
+- [ ] **Step 1: Write failing contract test**
+
+Create `tests/contract/repositories/memory-repository-vector.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { factories, type TestBackend } from "./_factories.js";
+import type { Memory } from "../../../src/types/memory.js";
+
+const DIMS = 768;
+const now = new Date("2026-04-22T00:00:00.000Z");
+
+function embVec(seed: number): number[] {
+  const v = new Array(DIMS).fill(0);
+  v[seed % DIMS] = 1;
+  return v;
+}
+
+function makeMemory(id: string, overrides: Partial<Memory> = {}): Memory {
+  return {
+    id, project_id: "p1", workspace_id: "ws1",
+    content: `body-${id}`, title: `T-${id}`, type: "fact",
+    scope: "workspace", tags: null, author: "a", source: null,
+    session_id: null, metadata: null, embedding_model: null,
+    embedding_dimensions: DIMS, version: 1,
+    created_at: now, updated_at: now, verified_at: null, archived_at: null,
+    comment_count: 0, flag_count: 0, relationship_count: 0,
+    last_comment_at: null, verified_by: null, ...overrides,
+  };
+}
+
+describe.each(factories)(
+  "MemoryRepository vector contract — $name",
+  (factory) => {
+    let backend: TestBackend;
+    beforeEach(async () => {
+      backend = await factory.create();
+      await backend.workspaceRepo.findOrCreate("ws1");
+    });
+    afterEach(async () => {
+      await backend.close();
+    });
+
+    it("search returns exact match at rank 1", async () => {
+      await backend.memoryRepo.create({ ...makeMemory("a"), embedding: embVec(5) });
+      await backend.memoryRepo.create({ ...makeMemory("b"), embedding: embVec(200) });
+      const hits = await backend.memoryRepo.search({
+        embedding: embVec(5),
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: ["workspace"],
+        limit: 2,
+        min_similarity: 0,
+      });
+      expect(hits[0].id).toBe("a");
+      expect(hits[0].relevance).toBeCloseTo(1, 3);
+    });
+
+    it("search excludes archived", async () => {
+      await backend.memoryRepo.create({ ...makeMemory("a"), embedding: embVec(5) });
+      await backend.memoryRepo.archive(["a"]);
+      const hits = await backend.memoryRepo.search({
+        embedding: embVec(5),
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: ["workspace"],
+        limit: 10,
+        min_similarity: 0,
+      });
+      expect(hits).toEqual([]);
+    });
+
+    it("findDuplicates returns top workspace-scope match above threshold", async () => {
+      await backend.memoryRepo.create({ ...makeMemory("a"), embedding: embVec(5) });
+      const hits = await backend.memoryRepo.findDuplicates({
+        embedding: embVec(5),
+        projectId: "p1",
+        workspaceId: "ws1",
+        scope: "workspace",
+        userId: "ignored",
+        threshold: 0.9,
+      });
+      expect(hits.map((h) => h.id)).toEqual(["a"]);
+    });
+
+    it("findPairwiseSimilar surfaces near-dupes", async () => {
+      const v = embVec(10);
+      const w = [...v];
+      w[11] = 0.01;  // small perturbation
+      await backend.memoryRepo.create({ ...makeMemory("a"), embedding: v });
+      await backend.memoryRepo.create({ ...makeMemory("b"), embedding: w });
+      const pairs = await backend.memoryRepo.findPairwiseSimilar({
+        projectId: "p1",
+        workspaceId: "ws1",
+        scope: "workspace",
+        threshold: 0.9,
+      });
+      const ids = pairs.map((p) => [p.memory_a_id, p.memory_b_id].sort());
+      expect(ids).toContainEqual(["a", "b"]);
+    });
+
+    it("listWithEmbeddings returns stored embeddings", async () => {
+      await backend.memoryRepo.create({ ...makeMemory("a"), embedding: embVec(5) });
+      const rows = await backend.memoryRepo.listWithEmbeddings({
+        projectId: "p1",
+        workspaceId: "ws1",
+        scope: "workspace",
+        limit: 10,
+      });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].embedding).toHaveLength(DIMS);
+      expect(rows[0].embedding[5]).toBe(1);
+    });
+  },
+);
+```
+
+- [ ] **Step 2: Run test, verify fail** (all `search`-related cases fail for vault: `NotImplementedError`)
+
+- [ ] **Step 3: Implement `search` on the repo**
+
+Replace the stub in `memory-repository.ts`:
+
+```ts
+async search(options: SearchOptions): Promise<MemoryWithRelevance[]> {
+  if (options.scope.length === 0) {
+    throw new ValidationError("scope must contain at least one value");
+  }
+  for (const s of options.scope) {
+    if (s === "user" && !options.user_id) {
+      throw new ValidationError("user_id is required for user-scoped search");
+    }
+  }
+  const hits = await this.cfg.index.search({
+    embedding: options.embedding,
+    projectId: options.project_id,
+    workspaceId: options.workspace_id,
+    scope: options.scope,
+    userId: options.user_id ?? null,
+    limit: options.limit ?? 10,
+    minSimilarity: options.min_similarity ?? 0.3,
+  });
+  const out: MemoryWithRelevance[] = [];
+  for (const h of hits) {
+    const m = await this.findById(h.id);
+    if (m !== null) out.push({ ...m, relevance: h.relevance });
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run contract tests, `search`-cases pass**
+
+```bash
+npx vitest run tests/contract/repositories/memory-repository-vector.test.ts -t "search"
+```
+
+Expected: both `search` cases PASS; the other three still fail.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(vault): implement MemoryRepository.search via VaultVectorIndex"
+```
+
+---
+
+### Task 12: Implement `findDuplicates`, `findPairwiseSimilar`, `listWithEmbeddings`
+
+**Files:**
+- Modify: `src/backend/vault/repositories/memory-repository.ts`
+
+- [ ] **Step 1: Replace the three remaining stubs**
+
+```ts
+async findDuplicates(
+  options: Parameters<MemoryRepository["findDuplicates"]>[0],
+): ReturnType<MemoryRepository["findDuplicates"]> {
+  if (options.scope === "workspace" && !options.workspaceId) {
+    throw new ValidationError("workspaceId is required for workspace-scoped dedup");
+  }
+  if (options.scope === "user" && !options.workspaceId) {
+    throw new ValidationError("workspaceId is required for user-scoped dedup");
+  }
+  return await this.cfg.index.findDuplicates({
+    embedding: options.embedding,
+    projectId: options.projectId,
+    workspaceId: options.workspaceId,
+    scope: options.scope,
+    userId: options.userId,
+    threshold: options.threshold,
+  });
+}
+
+async findPairwiseSimilar(
+  options: Parameters<MemoryRepository["findPairwiseSimilar"]>[0],
+): ReturnType<MemoryRepository["findPairwiseSimilar"]> {
+  return await this.cfg.index.findPairwiseSimilar({
+    projectId: options.projectId,
+    workspaceId: options.workspaceId,
+    scope: options.scope,
+    threshold: options.threshold,
+  });
+}
+
+async listWithEmbeddings(
+  options: Parameters<MemoryRepository["listWithEmbeddings"]>[0],
+): ReturnType<MemoryRepository["listWithEmbeddings"]> {
+  const rows = await this.cfg.index.listEmbeddings({
+    projectId: options.projectId,
+    workspaceId: options.workspaceId,
+    scope: options.scope,
+    userId: options.userId ?? null,
+    limit: options.limit,
+  });
+  const out: Array<Memory & { embedding: number[] }> = [];
+  for (const r of rows) {
+    const m = await this.findById(r.id);
+    if (m !== null) out.push({ ...m, embedding: r.vector });
+  }
+  return out;
+}
+```
+
+- [ ] **Step 2: Run full contract test file**
+
+```bash
+npx vitest run tests/contract/repositories/memory-repository-vector.test.ts
+```
+
+Expected: all cases PASS.
+
+- [ ] **Step 3: Full test suite smoke**
+
+```bash
+npm test --run
+```
+
+Expected: all green; no regressions.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "feat(vault): implement findDuplicates + findPairwiseSimilar + listWithEmbeddings"
+```
+
+---
+
+### Task 13: Vector parity test (pg vs vault, 500 memories)
+
+**Files:**
+- Create: `tests/integration/vector-parity.test.ts`
+
+- [ ] **Step 1: Write the parity test**
+
+```ts
+// tests/integration/vector-parity.test.ts
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import seedrandom from "seedrandom";
+import { DrizzleMemoryRepository } from "../../src/repositories/memory-repository.js";
+import { DrizzleWorkspaceRepository } from "../../src/repositories/workspace-repository.js";
+import { VaultMemoryRepository } from "../../src/backend/vault/repositories/memory-repository.js";
+import { VaultWorkspaceRepository } from "../../src/backend/vault/repositories/workspace-repository.js";
+import { VaultVectorIndex } from "../../src/backend/vault/vector/lance-index.js";
+import { getTestDb, truncateAll } from "../helpers.js";
+import type { Memory } from "../../src/types/memory.js";
+
+const DIMS = 64;
+const N = 500;
+
+function randomVec(rng: () => number): number[] {
+  const v: number[] = [];
+  let norm = 0;
+  for (let i = 0; i < DIMS; i++) {
+    const x = rng() - 0.5;
+    v.push(x);
+    norm += x * x;
+  }
+  const s = 1 / Math.sqrt(norm);
+  return v.map((x) => x * s);
+}
+
+describe("vector parity — pg vs vault", () => {
+  let root: string;
+  let idx: VaultVectorIndex;
+  let vault: VaultMemoryRepository;
+  let pg: DrizzleMemoryRepository;
+
+  beforeAll(async () => {
+    const db = getTestDb();
+    await truncateAll();
+    root = await mkdtemp(join(tmpdir(), "parity-"));
+    idx = await VaultVectorIndex.create({ root, dims: DIMS });
+    vault = await VaultMemoryRepository.create({ root, index: idx });
+    pg = new DrizzleMemoryRepository(db);
+    await new DrizzleWorkspaceRepository(db).findOrCreate("ws1");
+    await new VaultWorkspaceRepository({ root }).findOrCreate("ws1");
+
+    const rng = seedrandom("parity-seed");
+    const now = new Date();
+    for (let i = 0; i < N; i++) {
+      const m: Memory = {
+        id: `m${i}`, project_id: "p1", workspace_id: "ws1",
+        content: `body ${i}`, title: `T${i}`, type: "fact",
+        scope: "workspace", tags: null, author: "a", source: null,
+        session_id: null, metadata: null, embedding_model: null,
+        embedding_dimensions: DIMS, version: 1,
+        created_at: now, updated_at: now, verified_at: null, archived_at: null,
+        comment_count: 0, flag_count: 0, relationship_count: 0,
+        last_comment_at: null, verified_by: null,
+      };
+      const v = randomVec(rng);
+      await pg.create({ ...m, embedding: v });
+      await vault.create({ ...m, embedding: v });
+    }
+  }, 60_000);
+
+  afterAll(async () => {
+    await idx.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("top-10 overlap ≥ 95% across 20 queries", async () => {
+    const rng = seedrandom("parity-query");
+    let totalOverlap = 0;
+    const QUERIES = 20;
+    const K = 10;
+    for (let q = 0; q < QUERIES; q++) {
+      const v = randomVec(rng);
+      const pgIds = (
+        await pg.search({
+          embedding: v,
+          project_id: "p1",
+          workspace_id: "ws1",
+          scope: ["workspace"],
+          limit: K,
+          min_similarity: 0,
+        })
+      ).map((h) => h.id);
+      const vaultIds = (
+        await vault.search({
+          embedding: v,
+          project_id: "p1",
+          workspace_id: "ws1",
+          scope: ["workspace"],
+          limit: K,
+          min_similarity: 0,
+        })
+      ).map((h) => h.id);
+      const overlap = pgIds.filter((id) => vaultIds.includes(id)).length;
+      totalOverlap += overlap;
+    }
+    const overlapRatio = totalOverlap / (QUERIES * K);
+    expect(overlapRatio).toBeGreaterThanOrEqual(0.95);
+  }, 30_000);
+});
+```
+
+- [ ] **Step 2: Add seedrandom if not present**
+
+```bash
+npm i -D seedrandom @types/seedrandom
+```
+
+- [ ] **Step 3: Run parity test**
+
+```bash
+npx vitest run tests/integration/vector-parity.test.ts
+```
+
+Expected: PASS. If overlap drops below 0.95, first check cosine-vs-L2 mismatch, archived filter, or dimension pinning; do not lower the threshold.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "test(vault-vector): pg vs vault top-K overlap parity (500 memories, 20 queries)"
+```
+
+---
+
+### Task 14: CI + lint + typecheck sweep
+
+**Files:** none
+
+- [ ] **Step 1: Typecheck**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 2: Lint**
+
+```bash
+npm run lint
+```
+
+Expected: no errors; fix lint complaints in modified files if any.
+
+- [ ] **Step 3: Prettier**
+
+```bash
+npx prettier --check 'src/backend/vault/vector/**/*.ts' 'tests/**/vector*/**/*.ts' 'tests/integration/vector-parity.test.ts'
+```
+
+If fails:
+
+```bash
+npx prettier --write 'src/backend/vault/vector/**/*.ts' 'tests/**/vector*/**/*.ts' 'tests/integration/vector-parity.test.ts'
+```
+
+- [ ] **Step 4: Full test suite**
+
+```bash
+npm test --run
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit any lint/format cleanups**
+
+```bash
+git add -A && git diff --cached --quiet || git commit -m "style(vault-vector): lint + prettier cleanup"
+```
+
+---
+
+### Task 15: Open PR
+
+**Files:** none
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin feat/vault-backend-phase-3-vector
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --title "feat(vault): Phase 3 — LanceDB vector index" --body "$(cat <<'EOF'
+## Summary
+
+- Add `VaultVectorIndex` (`src/backend/vault/vector/`) wrapping `@lancedb/lancedb`.
+- Wire index into `VaultMemoryRepository` on `create` / `update` / `archive`.
+- Replace the four `NotImplementedError` stubs with real `search` / `findDuplicates` / `findPairwiseSimilar` / `listWithEmbeddings` implementations.
+- Parameterized contract tests cover the four methods across pg + vault.
+- Parity test: top-10 overlap ≥ 95% across 20 queries over 500 memories.
+
+Ref: `docs/superpowers/plans/2026-04-22-vault-backend-phase-3-vector-index.md`.
+
+## Test plan
+
+- [x] `npx vitest run tests/unit/backend/vault/vector` — unit coverage
+- [x] `npx vitest run tests/contract/repositories/memory-repository-vector.test.ts` — contract parity
+- [x] `npx vitest run tests/integration/vector-parity.test.ts` — top-K overlap ≥ 95%
+- [x] `npm test --run` — no regressions
+- [x] `npx tsc --noEmit` — typecheck clean
+- [x] `npm run lint` — lint clean
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review checklist (before opening PR)
+
+**1. Spec coverage:** Every vector-side `MemoryRepository` method has both an index-level unit test and a cross-backend contract test. Parity bar is the spec's `≥ 95%` top-K overlap.
+
+**2. Placeholder scan:** None. Every step has actual code or an exact command.
+
+**3. Type consistency:** `VaultMemoryConfig` adds `index: VaultVectorIndex`; every `create()` call site updated. `VaultBackendConfig` adds `embeddingDimensions`.
+
+**4. Out-of-scope residue:** No `.gitignore` writes, no watcher, no commit/push. Lance dir lives under `.agent-brain/` so Phase 4's gitignore rule covers it automatically when it ships.
+
+**5. Failure semantics:** Lance-write-after-markdown failures are logged and allowed to succeed on the write path, documented in "Failure semantics" table. Read-path failures bubble.

--- a/docs/superpowers/plans/2026-04-22-vault-backend-phase-3-vector-index.md
+++ b/docs/superpowers/plans/2026-04-22-vault-backend-phase-3-vector-index.md
@@ -45,17 +45,17 @@ Every write op in `VaultMemoryRepository` takes the file lock, writes the markdo
 
 One table: `memories`. Columns:
 
-| Column          | Type                        | Meaning                                     |
-| --------------- | --------------------------- | ------------------------------------------- |
-| `id`            | Utf8 (primary key for merge) | memory id                                   |
-| `project_id`    | Utf8                        | deployment isolation filter                 |
-| `workspace_id`  | Utf8 nullable               | workspace scope filter                      |
-| `scope`         | Utf8                        | `workspace` / `user` / `project`            |
-| `author`        | Utf8                        | user-scope filter                           |
-| `title`         | Utf8                        | returned by findDuplicates                  |
-| `archived`      | Bool                        | mirrors `archived_at IS NOT NULL`           |
-| `content_hash`  | Utf8                        | sha256(content) — skip re-embed on no-op    |
-| `vector`        | FixedSizeList<Float32, D>   | embedding; D derived from first insert      |
+| Column         | Type                         | Meaning                                  |
+| -------------- | ---------------------------- | ---------------------------------------- |
+| `id`           | Utf8 (primary key for merge) | memory id                                |
+| `project_id`   | Utf8                         | deployment isolation filter              |
+| `workspace_id` | Utf8 nullable                | workspace scope filter                   |
+| `scope`        | Utf8                         | `workspace` / `user` / `project`         |
+| `author`       | Utf8                         | user-scope filter                        |
+| `title`        | Utf8                         | returned by findDuplicates               |
+| `archived`     | Bool                         | mirrors `archived_at IS NOT NULL`        |
+| `content_hash` | Utf8                         | sha256(content) — skip re-embed on no-op |
+| `vector`       | FixedSizeList<Float32, D>    | embedding; D derived from first insert   |
 
 `D` is locked on first write (embedding_dimensions from the first create). Subsequent writes with mismatched dimension throw `ValidationError` at the wrapper.
 
@@ -98,13 +98,13 @@ All four read methods go through `VaultVectorIndex`:
 
 ### Failure semantics
 
-| Failure                                 | Phase 3 behavior                                                   |
-| --------------------------------------- | ------------------------------------------------------------------ |
-| Lance upsert fails after markdown write | Log warning, caller sees success. Index is now stale for this id. Repair in Phase 5. |
+| Failure                                 | Phase 3 behavior                                                                                                                                                                                                                    |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Lance upsert fails after markdown write | Log warning, caller sees success. Index is now stale for this id. Repair in Phase 5.                                                                                                                                                |
 | Lance delete fails during archive       | Same — log + succeed. Next search may surface the archived memory with a stale row; `archived=false` filter on the read path keys on the lance row, so this is a visible bug. Add an explicit unit test that exercises this branch. |
-| Dimension mismatch on write             | `ValidationError` — hard fail, markdown has already been written under Phase 2a. Caller sees success on markdown but the vector is not indexed. Acceptable for Phase 3 — a dimension change is operator-driven and rare. |
-| Index corruption / missing              | `VaultVectorIndex.create` throws on startup. `VaultBackend.create` propagates. |
-| Search on empty index                   | Return `[]`. |
+| Dimension mismatch on write             | `ValidationError` — hard fail, markdown has already been written under Phase 2a. Caller sees success on markdown but the vector is not indexed. Acceptable for Phase 3 — a dimension change is operator-driven and rare.            |
+| Index corruption / missing              | `VaultVectorIndex.create` throws on startup. `VaultBackend.create` propagates.                                                                                                                                                      |
+| Search on empty index                   | Return `[]`.                                                                                                                                                                                                                        |
 
 ## File Structure
 
@@ -137,16 +137,16 @@ All four read methods go through `VaultVectorIndex`:
 
 ## File Structure Summary
 
-| File                                                   | Responsibility                                                  |
-| ------------------------------------------------------ | --------------------------------------------------------------- |
-| `vector/schema.ts`                                     | Arrow schema builder                                            |
-| `vector/hash.ts`                                       | Pure content hash                                               |
-| `vector/lance-index.ts`                                | Stateful wrapper: connect, upsert, markArchived, search, etc.   |
-| `repositories/memory-repository.ts` (modified)         | Wire write-through + implement 4 vector methods via index       |
-| `index.ts` (modified)                                  | Compose index into VaultBackend lifecycle                       |
-| `tests/unit/backend/vault/vector/lance-index.test.ts`  | Wrapper unit coverage                                           |
-| `tests/contract/repositories/memory-repository-vector.test.ts` | Parity across pg + vault for the four methods           |
-| `tests/integration/vector-parity.test.ts`              | 500-memory overlap                                              |
+| File                                                           | Responsibility                                                |
+| -------------------------------------------------------------- | ------------------------------------------------------------- |
+| `vector/schema.ts`                                             | Arrow schema builder                                          |
+| `vector/hash.ts`                                               | Pure content hash                                             |
+| `vector/lance-index.ts`                                        | Stateful wrapper: connect, upsert, markArchived, search, etc. |
+| `repositories/memory-repository.ts` (modified)                 | Wire write-through + implement 4 vector methods via index     |
+| `index.ts` (modified)                                          | Compose index into VaultBackend lifecycle                     |
+| `tests/unit/backend/vault/vector/lance-index.test.ts`          | Wrapper unit coverage                                         |
+| `tests/contract/repositories/memory-repository-vector.test.ts` | Parity across pg + vault for the four methods                 |
+| `tests/integration/vector-parity.test.ts`                      | 500-memory overlap                                            |
 
 ---
 
@@ -157,6 +157,7 @@ Tasks target 5–15 minutes each. Commit after each. Subagent-driven execution i
 ### Task 1: Add `@lancedb/lancedb` dependency and smoke-import
 
 **Files:**
+
 - Modify: `package.json`
 - Modify: `package-lock.json`
 - Create: `tests/unit/backend/vault/vector/smoke.test.ts`
@@ -221,6 +222,7 @@ git commit -m "chore(deps): add @lancedb/lancedb + apache-arrow for vault vector
 ### Task 2: `vector/hash.ts` + unit test
 
 **Files:**
+
 - Create: `src/backend/vault/vector/hash.ts`
 - Create: `tests/unit/backend/vault/vector/hash.test.ts`
 
@@ -285,6 +287,7 @@ git commit -m "feat(vault-vector): add sha256 contentHash helper"
 ### Task 3: `vector/schema.ts` + unit test
 
 **Files:**
+
 - Create: `src/backend/vault/vector/schema.ts`
 - Create: `tests/unit/backend/vault/vector/schema.test.ts`
 
@@ -378,6 +381,7 @@ git commit -m "feat(vault-vector): add Arrow memorySchema builder"
 ### Task 4: `VaultVectorIndex` skeleton — create, close, upsert, countRows
 
 **Files:**
+
 - Create: `src/backend/vault/vector/lance-index.ts`
 - Create: `tests/unit/backend/vault/vector/lance-index.test.ts`
 
@@ -468,8 +472,8 @@ export interface IndexRow {
 }
 
 export interface VaultVectorIndexConfig {
-  root: string;           // absolute path; wrapper appends /.agent-brain/index.lance
-  dims: number;           // embedding dimension, pins the table schema on first create
+  root: string; // absolute path; wrapper appends /.agent-brain/index.lance
+  dims: number; // embedding dimension, pins the table schema on first create
 }
 
 export class VaultVectorIndex {
@@ -537,6 +541,7 @@ git commit -m "feat(vault-vector): VaultVectorIndex skeleton — create/close/up
 ### Task 5: `VaultVectorIndex.search` + cosine filter predicate
 
 **Files:**
+
 - Modify: `src/backend/vault/vector/lance-index.ts`
 - Modify: `tests/unit/backend/vault/vector/lance-index.test.ts`
 
@@ -580,7 +585,7 @@ describe("VaultVectorIndex — search", () => {
         scope: "workspace",
         author: "u",
         title: "C",
-        archived: true,          // must be filtered out
+        archived: true, // must be filtered out
         content_hash: "h",
         vector: [1, 0, 0],
       },
@@ -720,6 +725,7 @@ git commit -m "feat(vault-vector): VaultVectorIndex.search with cosine + scope f
 ### Task 6: `VaultVectorIndex.findDuplicates` (scope-aware, D-16 parity)
 
 **Files:**
+
 - Modify: `src/backend/vault/vector/lance-index.ts`
 - Modify: `tests/unit/backend/vault/vector/lance-index.test.ts`
 
@@ -871,6 +877,7 @@ git commit -m "feat(vault-vector): VaultVectorIndex.findDuplicates (D-16 parity)
 ### Task 7: `VaultVectorIndex.findPairwiseSimilar` — per-row search approach
 
 **Files:**
+
 - Modify: `src/backend/vault/vector/lance-index.ts`
 - Modify: `tests/unit/backend/vault/vector/lance-index.test.ts`
 
@@ -884,9 +891,39 @@ describe("VaultVectorIndex — findPairwiseSimilar", () => {
     root = await mkdtemp(join(tmpdir(), "lance-test-"));
     idx = await VaultVectorIndex.create({ root, dims: 3 });
     await idx.upsert([
-      { id: "a", project_id: "p1", workspace_id: "ws1", scope: "workspace", author: "u", title: "A", archived: false, content_hash: "h", vector: [1, 0, 0] },
-      { id: "b", project_id: "p1", workspace_id: "ws1", scope: "workspace", author: "u", title: "B", archived: false, content_hash: "h", vector: [0.99, 0.01, 0] },
-      { id: "c", project_id: "p1", workspace_id: "ws1", scope: "workspace", author: "u", title: "C", archived: false, content_hash: "h", vector: [0, 1, 0] },
+      {
+        id: "a",
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: "workspace",
+        author: "u",
+        title: "A",
+        archived: false,
+        content_hash: "h",
+        vector: [1, 0, 0],
+      },
+      {
+        id: "b",
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: "workspace",
+        author: "u",
+        title: "B",
+        archived: false,
+        content_hash: "h",
+        vector: [0.99, 0.01, 0],
+      },
+      {
+        id: "c",
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: "workspace",
+        author: "u",
+        title: "C",
+        archived: false,
+        content_hash: "h",
+        vector: [0, 1, 0],
+      },
     ]);
   });
   afterEach(async () => {
@@ -986,6 +1023,7 @@ git commit -m "feat(vault-vector): VaultVectorIndex.findPairwiseSimilar"
 ### Task 8: `VaultVectorIndex.listEmbeddings` + `markArchived` + `upsertMetaOnly`
 
 **Files:**
+
 - Modify: `src/backend/vault/vector/lance-index.ts`
 - Modify: `tests/unit/backend/vault/vector/lance-index.test.ts`
 
@@ -999,8 +1037,28 @@ describe("VaultVectorIndex — listEmbeddings + markArchived + upsertMetaOnly", 
     root = await mkdtemp(join(tmpdir(), "lance-test-"));
     idx = await VaultVectorIndex.create({ root, dims: 3 });
     await idx.upsert([
-      { id: "a", project_id: "p1", workspace_id: "ws1", scope: "workspace", author: "u", title: "A", archived: false, content_hash: "h", vector: [1, 0, 0] },
-      { id: "b", project_id: "p1", workspace_id: "ws1", scope: "workspace", author: "u", title: "B", archived: false, content_hash: "h", vector: [0, 1, 0] },
+      {
+        id: "a",
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: "workspace",
+        author: "u",
+        title: "A",
+        archived: false,
+        content_hash: "h",
+        vector: [1, 0, 0],
+      },
+      {
+        id: "b",
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: "workspace",
+        author: "u",
+        title: "B",
+        archived: false,
+        content_hash: "h",
+        vector: [0, 1, 0],
+      },
     ]);
   });
   afterEach(async () => {
@@ -1138,6 +1196,7 @@ git commit -m "feat(vault-vector): markArchived + upsertMetaOnly + listEmbedding
 ### Task 9: Wire index into `VaultMemoryRepository` — constructor + create path
 
 **Files:**
+
 - Modify: `src/backend/vault/repositories/memory-repository.ts`
 
 - [ ] **Step 1: Update `VaultMemoryConfig` and constructor**
@@ -1321,6 +1380,7 @@ git commit -m "feat(vault-vector): wire VaultVectorIndex into VaultMemoryReposit
 ### Task 10: Hook update + archive write-through
 
 **Files:**
+
 - Modify: `src/backend/vault/repositories/memory-repository.ts`
 
 - [ ] **Step 1: Add a unit test asserting the index stays in sync on update**
@@ -1342,13 +1402,31 @@ const now = new Date("2026-04-22T00:00:00.000Z");
 
 function makeMemory(overrides: Partial<Memory> = {}): Memory {
   return {
-    id: "m1", project_id: "p1", workspace_id: "ws1",
-    content: "body", title: "Title", type: "fact", scope: "workspace",
-    tags: null, author: "a", source: null, session_id: null, metadata: null,
-    embedding_model: null, embedding_dimensions: DIMS, version: 1,
-    created_at: now, updated_at: now, verified_at: null, archived_at: null,
-    comment_count: 0, flag_count: 0, relationship_count: 0, last_comment_at: null,
-    verified_by: null, ...overrides,
+    id: "m1",
+    project_id: "p1",
+    workspace_id: "ws1",
+    content: "body",
+    title: "Title",
+    type: "fact",
+    scope: "workspace",
+    tags: null,
+    author: "a",
+    source: null,
+    session_id: null,
+    metadata: null,
+    embedding_model: null,
+    embedding_dimensions: DIMS,
+    version: 1,
+    created_at: now,
+    updated_at: now,
+    verified_at: null,
+    archived_at: null,
+    comment_count: 0,
+    flag_count: 0,
+    relationship_count: 0,
+    last_comment_at: null,
+    verified_by: null,
+    ...overrides,
   };
 }
 
@@ -1489,6 +1567,7 @@ git commit -m "feat(vault-vector): write-through on update + archive"
 ### Task 11: Implement `search` on VaultMemoryRepository
 
 **Files:**
+
 - Modify: `src/backend/vault/repositories/memory-repository.ts`
 
 - [ ] **Step 1: Write failing contract test**
@@ -1511,14 +1590,31 @@ function embVec(seed: number): number[] {
 
 function makeMemory(id: string, overrides: Partial<Memory> = {}): Memory {
   return {
-    id, project_id: "p1", workspace_id: "ws1",
-    content: `body-${id}`, title: `T-${id}`, type: "fact",
-    scope: "workspace", tags: null, author: "a", source: null,
-    session_id: null, metadata: null, embedding_model: null,
-    embedding_dimensions: DIMS, version: 1,
-    created_at: now, updated_at: now, verified_at: null, archived_at: null,
-    comment_count: 0, flag_count: 0, relationship_count: 0,
-    last_comment_at: null, verified_by: null, ...overrides,
+    id,
+    project_id: "p1",
+    workspace_id: "ws1",
+    content: `body-${id}`,
+    title: `T-${id}`,
+    type: "fact",
+    scope: "workspace",
+    tags: null,
+    author: "a",
+    source: null,
+    session_id: null,
+    metadata: null,
+    embedding_model: null,
+    embedding_dimensions: DIMS,
+    version: 1,
+    created_at: now,
+    updated_at: now,
+    verified_at: null,
+    archived_at: null,
+    comment_count: 0,
+    flag_count: 0,
+    relationship_count: 0,
+    last_comment_at: null,
+    verified_by: null,
+    ...overrides,
   };
 }
 
@@ -1535,8 +1631,14 @@ describe.each(factories)(
     });
 
     it("search returns exact match at rank 1", async () => {
-      await backend.memoryRepo.create({ ...makeMemory("a"), embedding: embVec(5) });
-      await backend.memoryRepo.create({ ...makeMemory("b"), embedding: embVec(200) });
+      await backend.memoryRepo.create({
+        ...makeMemory("a"),
+        embedding: embVec(5),
+      });
+      await backend.memoryRepo.create({
+        ...makeMemory("b"),
+        embedding: embVec(200),
+      });
       const hits = await backend.memoryRepo.search({
         embedding: embVec(5),
         project_id: "p1",
@@ -1550,7 +1652,10 @@ describe.each(factories)(
     });
 
     it("search excludes archived", async () => {
-      await backend.memoryRepo.create({ ...makeMemory("a"), embedding: embVec(5) });
+      await backend.memoryRepo.create({
+        ...makeMemory("a"),
+        embedding: embVec(5),
+      });
       await backend.memoryRepo.archive(["a"]);
       const hits = await backend.memoryRepo.search({
         embedding: embVec(5),
@@ -1564,7 +1669,10 @@ describe.each(factories)(
     });
 
     it("findDuplicates returns top workspace-scope match above threshold", async () => {
-      await backend.memoryRepo.create({ ...makeMemory("a"), embedding: embVec(5) });
+      await backend.memoryRepo.create({
+        ...makeMemory("a"),
+        embedding: embVec(5),
+      });
       const hits = await backend.memoryRepo.findDuplicates({
         embedding: embVec(5),
         projectId: "p1",
@@ -1579,7 +1687,7 @@ describe.each(factories)(
     it("findPairwiseSimilar surfaces near-dupes", async () => {
       const v = embVec(10);
       const w = [...v];
-      w[11] = 0.01;  // small perturbation
+      w[11] = 0.01; // small perturbation
       await backend.memoryRepo.create({ ...makeMemory("a"), embedding: v });
       await backend.memoryRepo.create({ ...makeMemory("b"), embedding: w });
       const pairs = await backend.memoryRepo.findPairwiseSimilar({
@@ -1593,7 +1701,10 @@ describe.each(factories)(
     });
 
     it("listWithEmbeddings returns stored embeddings", async () => {
-      await backend.memoryRepo.create({ ...makeMemory("a"), embedding: embVec(5) });
+      await backend.memoryRepo.create({
+        ...makeMemory("a"),
+        embedding: embVec(5),
+      });
       const rows = await backend.memoryRepo.listWithEmbeddings({
         projectId: "p1",
         workspaceId: "ws1",
@@ -1662,6 +1773,7 @@ git commit -m "feat(vault): implement MemoryRepository.search via VaultVectorInd
 ### Task 12: Implement `findDuplicates`, `findPairwiseSimilar`, `listWithEmbeddings`
 
 **Files:**
+
 - Modify: `src/backend/vault/repositories/memory-repository.ts`
 
 - [ ] **Step 1: Replace the three remaining stubs**
@@ -1744,6 +1856,7 @@ git commit -m "feat(vault): implement findDuplicates + findPairwiseSimilar + lis
 ### Task 13: Vector parity test (pg vs vault, 500 memories)
 
 **Files:**
+
 - Create: `tests/integration/vector-parity.test.ts`
 
 - [ ] **Step 1: Write the parity test**
@@ -1798,14 +1911,30 @@ describe("vector parity — pg vs vault", () => {
     const now = new Date();
     for (let i = 0; i < N; i++) {
       const m: Memory = {
-        id: `m${i}`, project_id: "p1", workspace_id: "ws1",
-        content: `body ${i}`, title: `T${i}`, type: "fact",
-        scope: "workspace", tags: null, author: "a", source: null,
-        session_id: null, metadata: null, embedding_model: null,
-        embedding_dimensions: DIMS, version: 1,
-        created_at: now, updated_at: now, verified_at: null, archived_at: null,
-        comment_count: 0, flag_count: 0, relationship_count: 0,
-        last_comment_at: null, verified_by: null,
+        id: `m${i}`,
+        project_id: "p1",
+        workspace_id: "ws1",
+        content: `body ${i}`,
+        title: `T${i}`,
+        type: "fact",
+        scope: "workspace",
+        tags: null,
+        author: "a",
+        source: null,
+        session_id: null,
+        metadata: null,
+        embedding_model: null,
+        embedding_dimensions: DIMS,
+        version: 1,
+        created_at: now,
+        updated_at: now,
+        verified_at: null,
+        archived_at: null,
+        comment_count: 0,
+        flag_count: 0,
+        relationship_count: 0,
+        last_comment_at: null,
+        verified_by: null,
       };
       const v = randomVec(rng);
       await pg.create({ ...m, embedding: v });

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,11 +33,13 @@
         "@types/node": "^22.0.0",
         "@types/node-cron": "^3.0.11",
         "@types/proper-lockfile": "^4.1.4",
+        "@types/seedrandom": "^3.0.8",
         "eslint": "^10.1.0",
         "eslint-config-prettier": "^10.1.8",
         "fast-check": "^4.7.0",
         "husky": "^9.1.7",
         "prettier": "^3.8.1",
+        "seedrandom": "^3.0.5",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.57.2",
         "vitest": "^4.1.0"
@@ -4474,6 +4476,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/seedrandom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-3.0.8.tgz",
+      "integrity": "sha512-TY1eezMU2zH2ozQoAFAQFOPpvP15g+ZgSfTZt31AUUH/Rxtnz3H+A/Sv1Snw2/amp//omibc+AEkTaA8KUeOLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
@@ -8222,6 +8231,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.1014.0",
+        "@lancedb/lancedb": "^0.27.2",
         "@modelcontextprotocol/sdk": "^1.27.1",
+        "apache-arrow": "^18.1.0",
         "cron-parser": "^4.9.0",
         "dotenv": "^16.0.0",
         "drizzle-kit": "^0.31.10",
@@ -1897,6 +1899,163 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@lancedb/lancedb": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb/-/lancedb-0.27.2.tgz",
+      "integrity": "sha512-JQpZHV5KzUzDI3flYCjtZcfHlEbL8lM54E0NT+jrRYe29aKYegfavvPsAsuZp0VdcMwFMZcpMkaBhjQMo/fwvg==",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "dependencies": {
+        "reflect-metadata": "^0.2.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "optionalDependencies": {
+        "@lancedb/lancedb-darwin-arm64": "0.27.2",
+        "@lancedb/lancedb-linux-arm64-gnu": "0.27.2",
+        "@lancedb/lancedb-linux-arm64-musl": "0.27.2",
+        "@lancedb/lancedb-linux-x64-gnu": "0.27.2",
+        "@lancedb/lancedb-linux-x64-musl": "0.27.2",
+        "@lancedb/lancedb-win32-arm64-msvc": "0.27.2",
+        "@lancedb/lancedb-win32-x64-msvc": "0.27.2"
+      },
+      "peerDependencies": {
+        "apache-arrow": ">=15.0.0 <=18.1.0"
+      }
+    },
+    "node_modules/@lancedb/lancedb-darwin-arm64": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-darwin-arm64/-/lancedb-darwin-arm64-0.27.2.tgz",
+      "integrity": "sha512-+XM68V/Rou8kKWDnUeKvg9ChKS0zGeQC2sKAop+06Ty4LwIjEGkeYBYrK0vMhZkBN5EFaOjTOp8E8hGQxdFwXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@lancedb/lancedb-linux-arm64-gnu": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-gnu/-/lancedb-linux-arm64-gnu-0.27.2.tgz",
+      "integrity": "sha512-laiTTDeMUTzm7t+t6ME5nNQMDoERjmkeuWAFWekbXiFdmp62Dqu34Lvf2BvpWnKwxLMZ5JcBJFIw32WS8/8Jnw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@lancedb/lancedb-linux-arm64-musl": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-arm64-musl/-/lancedb-linux-arm64-musl-0.27.2.tgz",
+      "integrity": "sha512-bK5Mc50EvwGZaaiym5CoPu8Y4GNSyEEvTQ0dTC2AUIm83qdQu1rGw6kkYtc/rTH/hbvAvPQot4agHDZfMVxfYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@lancedb/lancedb-linux-x64-gnu": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-x64-gnu/-/lancedb-linux-x64-gnu-0.27.2.tgz",
+      "integrity": "sha512-qe+ML0YmPru0o84f33RBHqoNk6zsHBjiXTLKsEBDiiFYKks/XMsrkKy9NQYcTxShBrg/nx/MLzCzd7dihqgNYw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@lancedb/lancedb-linux-x64-musl": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-linux-x64-musl/-/lancedb-linux-x64-musl-0.27.2.tgz",
+      "integrity": "sha512-ZpX6Oxn06qvzAdm+D/gNb3SRp/A9lgRAPvPg6nnMmSQk5XamC/hbGO07uK1wwop7nlqXUH/thk4is2y2ieWdTw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@lancedb/lancedb-win32-arm64-msvc": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-win32-arm64-msvc/-/lancedb-win32-arm64-msvc-0.27.2.tgz",
+      "integrity": "sha512-4ffpFvh49MiUtkdFJOmBytXEbgUPXORphTOuExnJAgT1VAKwQcu4ZzdsgNoK6mumKBaU+pYQU/MedNkgTzx/Lw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@lancedb/lancedb-win32-x64-msvc": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/@lancedb/lancedb-win32-x64-msvc/-/lancedb-win32-x64-msvc-0.27.2.tgz",
+      "integrity": "sha512-XlwiI6CK2Gkqq+FFVAStHojao/XjIJpDPTm7Tb9SpLL64IlwGw3yaT2hnWKTm90W4KlSrpfSldPly+s+y4U7JQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@mcp-ui/client": {
@@ -4115,6 +4274,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
@@ -4175,6 +4343,18 @@
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
       }
+    },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
+      "license": "MIT"
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
@@ -4750,7 +4930,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4760,6 +4939,35 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/apache-arrow": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-18.1.0.tgz",
+      "integrity": "sha512-v/ShMp57iBnBp4lDgV8Jx3d3Q5/Hac25FWmQ98eMahUiHPXcvwIMKJD0hBIgclm/FCG+LwPkAKtkRO1O/W0YGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^20.13.0",
+        "command-line-args": "^5.2.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^24.3.25",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.js"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/arg": {
@@ -4789,6 +4997,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/array-back": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
+      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/assertion-error": {
@@ -4928,7 +5145,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4941,11 +5157,25 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
     "node_modules/chalk/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -5013,7 +5243,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5026,8 +5255,55 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/command-line-args": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
+      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.1.0",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
+      "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.1",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/command-line-usage/node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
     },
     "node_modules/commander": {
       "version": "13.1.0",
@@ -6050,6 +6326,18 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/find-replace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
+      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -6080,6 +6368,12 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/flatbuffers": {
+      "version": "24.12.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.12.23.tgz",
+      "integrity": "sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==",
+      "license": "Apache-2.0"
     },
     "node_modules/flatted": {
       "version": "3.4.2",
@@ -6321,7 +6615,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6626,6 +6919,14 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/json-buffer": {
@@ -6976,6 +7277,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -7750,6 +8057,12 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -8380,6 +8693,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/table-layout/node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/tailwind-merge": {
@@ -9060,11 +9395,19 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/typical": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
+      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -9384,6 +9727,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   },
   "dependencies": {
     "@aws-sdk/client-bedrock-runtime": "^3.1014.0",
+    "@lancedb/lancedb": "^0.27.2",
     "@modelcontextprotocol/sdk": "^1.27.1",
+    "apache-arrow": "^18.1.0",
     "cron-parser": "^4.9.0",
     "dotenv": "^16.0.0",
     "drizzle-kit": "^0.31.10",

--- a/package.json
+++ b/package.json
@@ -49,11 +49,13 @@
     "@types/node": "^22.0.0",
     "@types/node-cron": "^3.0.11",
     "@types/proper-lockfile": "^4.1.4",
+    "@types/seedrandom": "^3.0.8",
     "eslint": "^10.1.0",
     "eslint-config-prettier": "^10.1.8",
     "fast-check": "^4.7.0",
     "husky": "^9.1.7",
     "prettier": "^3.8.1",
+    "seedrandom": "^3.0.5",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.57.2",
     "vitest": "^4.1.0"

--- a/src/backend/factory.ts
+++ b/src/backend/factory.ts
@@ -7,6 +7,7 @@ export interface BackendConfig {
   backend: BackendName;
   databaseUrl: string;
   vaultRoot: string;
+  embeddingDimensions: number;
 }
 
 export async function createBackend(
@@ -21,7 +22,10 @@ export async function createBackend(
           "vault backend requires AGENT_BRAIN_VAULT_ROOT to be set",
         );
       }
-      return VaultBackend.create({ root: config.vaultRoot });
+      return VaultBackend.create({
+        root: config.vaultRoot,
+        embeddingDimensions: config.embeddingDimensions,
+      });
     default: {
       // Exhaustiveness + runtime guard for an env-var typo that slipped past zod.
       const _exhaustive: never = config.backend;

--- a/src/backend/vault/index.ts
+++ b/src/backend/vault/index.ts
@@ -8,6 +8,7 @@ import { VaultSchedulerStateRepository } from "./repositories/scheduler-state-re
 import { VaultSessionRepository } from "./repositories/session-repository.js";
 import { VaultSessionTrackingRepository } from "./repositories/session-tracking-repository.js";
 import { VaultWorkspaceRepository } from "./repositories/workspace-repository.js";
+import { VaultVectorIndex } from "./vector/lance-index.js";
 import type { BackendName, StorageBackend } from "../types.js";
 import type {
   AuditRepository,
@@ -23,11 +24,13 @@ import type {
 
 export interface VaultBackendConfig {
   root: string;
+  embeddingDimensions: number;
 }
 
 // Markdown-vault backend. Composes the nine Vault* repositories backed
-// by files under a single root directory. All IO is per-op, so close()
-// is a no-op — there's no connection pool to drain.
+// by files under a single root directory, plus a LanceDB-backed vector
+// index under <root>/.agent-brain/index.lance. close() disposes the
+// vector index; markdown IO is per-op and needs no teardown.
 export class VaultBackend implements StorageBackend {
   readonly name: BackendName = "vault";
   readonly memoryRepo: MemoryRepository;
@@ -40,7 +43,11 @@ export class VaultBackend implements StorageBackend {
   readonly relationshipRepo: RelationshipRepository;
   readonly schedulerStateRepo: SchedulerStateRepository;
 
-  private constructor(memoryRepo: MemoryRepository, root: string) {
+  private constructor(
+    memoryRepo: MemoryRepository,
+    private readonly vectorIndex: VaultVectorIndex,
+    root: string,
+  ) {
     this.memoryRepo = memoryRepo;
     this.workspaceRepo = new VaultWorkspaceRepository({ root });
     this.commentRepo = new VaultCommentRepository({ root });
@@ -54,9 +61,18 @@ export class VaultBackend implements StorageBackend {
 
   static async create(cfg: VaultBackendConfig): Promise<VaultBackend> {
     await mkdir(cfg.root, { recursive: true });
-    const memoryRepo = await VaultMemoryRepository.create({ root: cfg.root });
-    return new VaultBackend(memoryRepo, cfg.root);
+    const vectorIndex = await VaultVectorIndex.create({
+      root: cfg.root,
+      dims: cfg.embeddingDimensions,
+    });
+    const memoryRepo = await VaultMemoryRepository.create({
+      root: cfg.root,
+      index: vectorIndex,
+    });
+    return new VaultBackend(memoryRepo, vectorIndex, cfg.root);
   }
 
-  async close(): Promise<void> {}
+  async close(): Promise<void> {
+    await this.vectorIndex.close();
+  }
 }

--- a/src/backend/vault/repositories/memory-repository.ts
+++ b/src/backend/vault/repositories/memory-repository.ts
@@ -38,6 +38,7 @@ import {
 import { withFileLock } from "../io/lock.js";
 import { VaultVectorIndex } from "../vector/lance-index.js";
 import { contentHash } from "../vector/hash.js";
+import { logger } from "../../../utils/logger.js";
 
 export interface VaultMemoryConfig {
   root: string;
@@ -83,6 +84,16 @@ export class VaultMemoryRepository implements MemoryRepository {
     if (this.index.has(memory.id)) {
       throw new ConflictError(`memory already exists: ${memory.id}`);
     }
+    // Dimension check before touching the filesystem: after markdown
+    // is durably written, lance failures are swallowed (markdown is
+    // source of truth), so a programmer-error wrong-dim embedding
+    // here would leave the vault permanently out of sync with the
+    // index. Fail fast before any write lands on disk.
+    if (memory.embedding.length !== this.cfg.index.dims) {
+      throw new ValidationError(
+        `vector dimension mismatch: expected ${this.cfg.index.dims}, got ${memory.embedding.length} for id ${memory.id}`,
+      );
+    }
     const loc = locationFor(memory);
     const rel = memoryPath(loc);
     const md = serializeMemoryFile({
@@ -111,19 +122,30 @@ export class VaultMemoryRepository implements MemoryRepository {
       workspaceId: loc.workspaceId,
       userId: loc.userId,
     });
-    await this.cfg.index.upsert([
-      {
+    // Markdown is source of truth; lance is a derived cache. A lance
+    // failure here leaves the new memory un-indexed until Phase 5's
+    // watcher-driven reindex picks it up. Log and return success.
+    try {
+      await this.cfg.index.upsert([
+        {
+          id: memory.id,
+          project_id: memory.project_id,
+          workspace_id: memory.workspace_id,
+          scope: memory.scope,
+          author: memory.author,
+          title: memory.title,
+          archived: false,
+          content_hash: contentHash(memory.content),
+          vector: memory.embedding,
+        },
+      ]);
+    } catch (err) {
+      logger.warn("lance upsert failed on create; index stale", {
         id: memory.id,
-        project_id: memory.project_id,
-        workspace_id: memory.workspace_id,
-        scope: memory.scope,
-        author: memory.author,
-        title: memory.title,
-        archived: false,
-        content_hash: contentHash(memory.content),
-        vector: memory.embedding,
-      },
-    ]);
+        op: "create",
+        err,
+      });
+    }
     const saved = await this.#read(memory.id);
     return saved.memory;
   }
@@ -162,6 +184,20 @@ export class VaultMemoryRepository implements MemoryRepository {
         `Memory ${id} update failed: not found or archived`,
       );
 
+    // Pre-check embedding dim before acquiring the lock; same reason
+    // as create() — markdown write succeeds then the lance call is
+    // swallowed on failure, so dim-mismatch must fail before any on-
+    // disk mutation.
+    if (
+      updates.embedding !== undefined &&
+      updates.embedding !== null &&
+      updates.embedding.length !== this.cfg.index.dims
+    ) {
+      throw new ValidationError(
+        `vector dimension mismatch: expected ${this.cfg.index.dims}, got ${updates.embedding.length} for id ${id}`,
+      );
+    }
+
     const abs = join(this.cfg.root, entry.path);
     return await withFileLock(abs, async () => {
       const raw = await readMarkdown(this.cfg.root, entry.path);
@@ -192,9 +228,23 @@ export class VaultMemoryRepository implements MemoryRepository {
         flags: parsed.flags,
       });
       await writeMarkdownAtomic(this.cfg.root, entry.path, md);
-      if (embedding !== undefined && embedding !== null) {
-        await this.cfg.index.upsert([
-          {
+      try {
+        if (embedding !== undefined && embedding !== null) {
+          await this.cfg.index.upsert([
+            {
+              id: next.id,
+              project_id: next.project_id,
+              workspace_id: next.workspace_id,
+              scope: next.scope,
+              author: next.author,
+              title: next.title,
+              archived: false,
+              content_hash: contentHash(next.content),
+              vector: embedding,
+            },
+          ]);
+        } else {
+          const rowsUpdated = await this.cfg.index.upsertMetaOnly({
             id: next.id,
             project_id: next.project_id,
             workspace_id: next.workspace_id,
@@ -202,19 +252,23 @@ export class VaultMemoryRepository implements MemoryRepository {
             author: next.author,
             title: next.title,
             archived: false,
-            content_hash: contentHash(next.content),
-            vector: embedding,
-          },
-        ]);
-      } else {
-        await this.cfg.index.upsertMetaOnly({
+          });
+          // lancedb's update() is a no-op on zero matches. A missing
+          // row means the lance index and markdown vault have drifted
+          // — e.g. a previous create() swallowed an upsert failure.
+          // Markdown still wins; surface the drift for Phase 5 repair.
+          if (rowsUpdated === 0) {
+            logger.warn("lance meta-only update matched no rows; index drift", {
+              id: next.id,
+              op: "update",
+            });
+          }
+        }
+      } catch (err) {
+        logger.warn("lance upsert failed on update; index stale", {
           id: next.id,
-          project_id: next.project_id,
-          workspace_id: next.workspace_id,
-          scope: next.scope,
-          author: next.author,
-          title: next.title,
-          archived: false,
+          op: "update",
+          err,
         });
       }
       const reread = await this.#read(id);
@@ -245,8 +299,26 @@ export class VaultMemoryRepository implements MemoryRepository {
         archived.push(id);
       });
     }
+    // One lance failure (or missing row) must not abort archive
+    // propagation for the remaining ids. Markdown is already flipped
+    // for each id in `archived`, so the caller's return count is
+    // accurate regardless of lance outcome.
     for (const id of archived) {
-      await this.cfg.index.markArchived(id);
+      try {
+        const rowsUpdated = await this.cfg.index.markArchived(id);
+        if (rowsUpdated === 0) {
+          logger.warn("lance markArchived matched no rows; index drift", {
+            id,
+            op: "archive",
+          });
+        }
+      } catch (err) {
+        logger.warn("lance markArchived failed; index stale", {
+          id,
+          op: "archive",
+          err,
+        });
+      }
     }
     return count;
   }

--- a/src/backend/vault/repositories/memory-repository.ts
+++ b/src/backend/vault/repositories/memory-repository.ts
@@ -431,9 +431,7 @@ export class VaultMemoryRepository implements MemoryRepository {
     }
     for (const s of options.scope) {
       if (s === "user" && !options.user_id) {
-        throw new ValidationError(
-          "user_id is required for user-scoped search",
-        );
+        throw new ValidationError("user_id is required for user-scoped search");
       }
     }
     const hits = await this.cfg.index.search({

--- a/src/backend/vault/repositories/memory-repository.ts
+++ b/src/backend/vault/repositories/memory-repository.ts
@@ -20,7 +20,6 @@ import {
   NotFoundError,
   ValidationError,
 } from "../../../utils/errors.js";
-import { NotImplementedError } from "../errors.js";
 import {
   parseMemoryFile,
   serializeMemoryFile,
@@ -426,26 +425,85 @@ export class VaultMemoryRepository implements MemoryRepository {
     return Array.from(set);
   }
 
-  /* eslint-disable @typescript-eslint/no-unused-vars */
-  async search(_options: SearchOptions): Promise<MemoryWithRelevance[]> {
-    throw new NotImplementedError("search");
+  async search(options: SearchOptions): Promise<MemoryWithRelevance[]> {
+    if (options.scope.length === 0) {
+      throw new ValidationError("scope must contain at least one value");
+    }
+    for (const s of options.scope) {
+      if (s === "user" && !options.user_id) {
+        throw new ValidationError(
+          "user_id is required for user-scoped search",
+        );
+      }
+    }
+    const hits = await this.cfg.index.search({
+      embedding: options.embedding,
+      projectId: options.project_id,
+      workspaceId: options.workspace_id,
+      scope: options.scope,
+      userId: options.user_id ?? null,
+      limit: options.limit ?? 10,
+      minSimilarity: options.min_similarity ?? 0.3,
+    });
+    const out: MemoryWithRelevance[] = [];
+    for (const h of hits) {
+      const m = await this.findById(h.id);
+      if (m !== null) out.push({ ...m, relevance: h.relevance });
+    }
+    return out;
   }
+
   async findDuplicates(
-    _options: Parameters<MemoryRepository["findDuplicates"]>[0],
+    options: Parameters<MemoryRepository["findDuplicates"]>[0],
   ): ReturnType<MemoryRepository["findDuplicates"]> {
-    throw new NotImplementedError("findDuplicates");
+    if (options.scope === "workspace" && !options.workspaceId) {
+      throw new ValidationError(
+        "workspaceId is required for workspace-scoped dedup",
+      );
+    }
+    if (options.scope === "user" && !options.workspaceId) {
+      throw new ValidationError(
+        "workspaceId is required for user-scoped dedup",
+      );
+    }
+    return await this.cfg.index.findDuplicates({
+      embedding: options.embedding,
+      projectId: options.projectId,
+      workspaceId: options.workspaceId,
+      scope: options.scope,
+      userId: options.userId,
+      threshold: options.threshold,
+    });
   }
+
   async findPairwiseSimilar(
-    _options: Parameters<MemoryRepository["findPairwiseSimilar"]>[0],
+    options: Parameters<MemoryRepository["findPairwiseSimilar"]>[0],
   ): ReturnType<MemoryRepository["findPairwiseSimilar"]> {
-    throw new NotImplementedError("findPairwiseSimilar");
+    return await this.cfg.index.findPairwiseSimilar({
+      projectId: options.projectId,
+      workspaceId: options.workspaceId,
+      scope: options.scope,
+      threshold: options.threshold,
+    });
   }
+
   async listWithEmbeddings(
-    _options: Parameters<MemoryRepository["listWithEmbeddings"]>[0],
+    options: Parameters<MemoryRepository["listWithEmbeddings"]>[0],
   ): ReturnType<MemoryRepository["listWithEmbeddings"]> {
-    throw new NotImplementedError("listWithEmbeddings");
+    const rows = await this.cfg.index.listEmbeddings({
+      projectId: options.projectId,
+      workspaceId: options.workspaceId,
+      scope: options.scope,
+      userId: options.userId ?? null,
+      limit: options.limit,
+    });
+    const out: Array<Memory & { embedding: number[] }> = [];
+    for (const r of rows) {
+      const m = await this.findById(r.id);
+      if (m !== null) out.push({ ...m, embedding: r.vector });
+    }
+    return out;
   }
-  /* eslint-enable @typescript-eslint/no-unused-vars */
 
   async #loadAll(): Promise<Memory[]> {
     const out: Memory[] = [];

--- a/src/backend/vault/repositories/memory-repository.ts
+++ b/src/backend/vault/repositories/memory-repository.ts
@@ -37,9 +37,12 @@ import {
   writeMarkdownAtomic,
 } from "../io/vault-fs.js";
 import { withFileLock } from "../io/lock.js";
+import { VaultVectorIndex } from "../vector/lance-index.js";
+import { contentHash } from "../vector/hash.js";
 
 export interface VaultMemoryConfig {
   root: string;
+  index: VaultVectorIndex;
 }
 
 interface IndexEntry {
@@ -109,6 +112,19 @@ export class VaultMemoryRepository implements MemoryRepository {
       workspaceId: loc.workspaceId,
       userId: loc.userId,
     });
+    await this.cfg.index.upsert([
+      {
+        id: memory.id,
+        project_id: memory.project_id,
+        workspace_id: memory.workspace_id,
+        scope: memory.scope,
+        author: memory.author,
+        title: memory.title,
+        archived: false,
+        content_hash: contentHash(memory.content),
+        vector: memory.embedding,
+      },
+    ]);
     const saved = await this.#read(memory.id);
     return saved.memory;
   }

--- a/src/backend/vault/repositories/memory-repository.ts
+++ b/src/backend/vault/repositories/memory-repository.ts
@@ -176,10 +176,9 @@ export class VaultMemoryRepository implements MemoryRepository {
           `Memory ${id} update failed: version mismatch (expected ${expectedVersion}, found ${parsed.memory.version})`,
         );
 
-      // Embedding is stored outside the markdown file; callers may
-      // pass one through but the vault persists only scalar fields.
-      const { embedding: _emb, ...rest } = updates;
-      void _emb;
+      // The markdown file persists only scalar fields; the embedding
+      // (if provided) is written to the vector index below instead.
+      const { embedding, ...rest } = updates;
 
       const next: Memory = {
         ...parsed.memory,
@@ -194,6 +193,31 @@ export class VaultMemoryRepository implements MemoryRepository {
         flags: parsed.flags,
       });
       await writeMarkdownAtomic(this.cfg.root, entry.path, md);
+      if (embedding !== undefined && embedding !== null) {
+        await this.cfg.index.upsert([
+          {
+            id: next.id,
+            project_id: next.project_id,
+            workspace_id: next.workspace_id,
+            scope: next.scope,
+            author: next.author,
+            title: next.title,
+            archived: false,
+            content_hash: contentHash(next.content),
+            vector: embedding,
+          },
+        ]);
+      } else {
+        await this.cfg.index.upsertMetaOnly({
+          id: next.id,
+          project_id: next.project_id,
+          workspace_id: next.workspace_id,
+          scope: next.scope,
+          author: next.author,
+          title: next.title,
+          archived: false,
+        });
+      }
       const reread = await this.#read(id);
       return reread.memory;
     });
@@ -202,6 +226,7 @@ export class VaultMemoryRepository implements MemoryRepository {
   async archive(ids: string[]): Promise<number> {
     let count = 0;
     const now = new Date();
+    const archived: string[] = [];
     for (const id of ids) {
       const entry = this.index.get(id);
       if (!entry) continue;
@@ -218,7 +243,11 @@ export class VaultMemoryRepository implements MemoryRepository {
         });
         await writeMarkdownAtomic(this.cfg.root, entry.path, md);
         count += 1;
+        archived.push(id);
       });
+    }
+    for (const id of archived) {
+      await this.cfg.index.markArchived(id);
     }
     return count;
   }

--- a/src/backend/vault/vector/hash.ts
+++ b/src/backend/vault/vector/hash.ts
@@ -1,0 +1,5 @@
+import { createHash } from "node:crypto";
+
+export function contentHash(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}

--- a/src/backend/vault/vector/lance-index.ts
+++ b/src/backend/vault/vector/lance-index.ts
@@ -159,7 +159,9 @@ export class VaultVectorIndex {
       clauses.push(`scope = 'project'`);
     } else {
       if (params.workspaceId === null) {
-        throw new Error("workspaceId is required for workspace-scoped pairwise");
+        throw new Error(
+          "workspaceId is required for workspace-scoped pairwise",
+        );
       }
       clauses.push(
         `scope = 'workspace'`,

--- a/src/backend/vault/vector/lance-index.ts
+++ b/src/backend/vault/vector/lance-index.ts
@@ -196,6 +196,75 @@ export class VaultVectorIndex {
     pairs.sort((a, b) => b.similarity - a.similarity);
     return pairs;
   }
+
+  async markArchived(id: string): Promise<void> {
+    await this.table.update({
+      where: `id = ${sqlStr(id)}`,
+      values: { archived: true },
+    });
+  }
+
+  async upsertMetaOnly(
+    meta: Omit<IndexRow, "content_hash" | "vector">,
+  ): Promise<void> {
+    await this.table.update({
+      where: `id = ${sqlStr(meta.id)}`,
+      values: {
+        project_id: meta.project_id,
+        scope: meta.scope,
+        author: meta.author,
+        title: meta.title,
+        archived: meta.archived,
+        workspace_id: meta.workspace_id,
+      },
+    });
+  }
+
+  async listEmbeddings(
+    params: ListEmbeddingsParams,
+  ): Promise<Array<{ id: string; vector: number[] }>> {
+    const clauses: string[] = [
+      `archived = false`,
+      `project_id = ${sqlStr(params.projectId)}`,
+    ];
+    if (params.scope === "workspace") {
+      if (params.workspaceId === null) {
+        throw new Error("workspaceId is required for workspace listEmbeddings");
+      }
+      clauses.push(
+        `scope = 'workspace'`,
+        `workspace_id = ${sqlStr(params.workspaceId)}`,
+      );
+    } else if (params.scope === "user") {
+      clauses.push(`scope = 'user'`);
+      if (params.userId !== null) {
+        clauses.push(`author = ${sqlStr(params.userId)}`);
+      }
+      if (params.workspaceId !== null) {
+        clauses.push(`workspace_id = ${sqlStr(params.workspaceId)}`);
+      }
+    } else {
+      clauses.push(`scope = 'project'`);
+    }
+    const rows = (await this.table
+      .query()
+      .where(clauses.join(" AND "))
+      .select(["id", "vector"])
+      .limit(params.limit)
+      .toArray()) as Array<{ id: string; vector: number[] | Float32Array }>;
+    return rows.map((r) => ({
+      id: r.id,
+      vector: Array.from(r.vector as ArrayLike<number>),
+    }));
+  }
+}
+
+export interface ListEmbeddingsParams {
+  projectId: string;
+  workspaceId: string | null;
+  scope: "workspace" | "user" | "project";
+  userId: string | null;
+  limit: number;
 }
 
 export interface PairwiseParams {

--- a/src/backend/vault/vector/lance-index.ts
+++ b/src/backend/vault/vector/lance-index.ts
@@ -2,6 +2,7 @@ import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import * as lancedb from "@lancedb/lancedb";
 import type { VectorQuery } from "@lancedb/lancedb";
+import { ValidationError } from "../../../utils/errors.js";
 import { memorySchema } from "./schema.js";
 
 export interface IndexRow {
@@ -51,13 +52,7 @@ export class VaultVectorIndex {
 
   async upsert(rows: IndexRow[]): Promise<void> {
     if (rows.length === 0) return;
-    for (const r of rows) {
-      if (r.vector.length !== this.dims) {
-        throw new Error(
-          `vector dimension mismatch: expected ${this.dims}, got ${r.vector.length} for id ${r.id}`,
-        );
-      }
-    }
+    for (const r of rows) this.#assertDim(r.vector, r.id);
     await this.table
       .mergeInsert("id")
       .whenMatchedUpdateAll()
@@ -66,11 +61,7 @@ export class VaultVectorIndex {
   }
 
   async search(params: SearchParams): Promise<SearchHit[]> {
-    if (params.embedding.length !== this.dims) {
-      throw new Error(
-        `vector dimension mismatch: expected ${this.dims}, got ${params.embedding.length}`,
-      );
-    }
+    this.#assertDim(params.embedding);
     const clauses: string[] = [
       `archived = false`,
       `project_id = ${sqlStr(params.projectId)}`,
@@ -107,11 +98,7 @@ export class VaultVectorIndex {
   }
 
   async findDuplicates(params: DuplicateParams): Promise<DuplicateHit[]> {
-    if (params.embedding.length !== this.dims) {
-      throw new Error(
-        `vector dimension mismatch: expected ${this.dims}, got ${params.embedding.length}`,
-      );
-    }
+    this.#assertDim(params.embedding);
     const clauses: string[] = [
       `archived = false`,
       `project_id = ${sqlStr(params.projectId)}`,
@@ -197,17 +184,21 @@ export class VaultVectorIndex {
     return pairs;
   }
 
-  async markArchived(id: string): Promise<void> {
-    await this.table.update({
+  // Returns rowsUpdated so callers can detect index drift (id missing).
+  // lancedb's update() on zero matches succeeds silently — caller must
+  // treat rowsUpdated === 0 as a warning condition, not as success.
+  async markArchived(id: string): Promise<number> {
+    const res = await this.table.update({
       where: `id = ${sqlStr(id)}`,
       values: { archived: true },
     });
+    return res.rowsUpdated;
   }
 
   async upsertMetaOnly(
     meta: Omit<IndexRow, "content_hash" | "vector">,
-  ): Promise<void> {
-    await this.table.update({
+  ): Promise<number> {
+    const res = await this.table.update({
       where: `id = ${sqlStr(meta.id)}`,
       values: {
         project_id: meta.project_id,
@@ -218,6 +209,7 @@ export class VaultVectorIndex {
         workspace_id: meta.workspace_id,
       },
     });
+    return res.rowsUpdated;
   }
 
   async listEmbeddings(
@@ -256,6 +248,14 @@ export class VaultVectorIndex {
       id: r.id,
       vector: Array.from(r.vector as ArrayLike<number>),
     }));
+  }
+
+  #assertDim(vec: number[], id?: string): void {
+    if (vec.length === this.dims) return;
+    const suffix = id === undefined ? "" : ` for id ${id}`;
+    throw new ValidationError(
+      `vector dimension mismatch: expected ${this.dims}, got ${vec.length}${suffix}`,
+    );
   }
 }
 

--- a/src/backend/vault/vector/lance-index.ts
+++ b/src/backend/vault/vector/lance-index.ts
@@ -1,0 +1,66 @@
+import { mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import * as lancedb from "@lancedb/lancedb";
+import { memorySchema } from "./schema.js";
+
+export interface IndexRow {
+  id: string;
+  project_id: string;
+  workspace_id: string | null;
+  scope: "workspace" | "user" | "project";
+  author: string;
+  title: string;
+  archived: boolean;
+  content_hash: string;
+  vector: number[];
+}
+
+export interface VaultVectorIndexConfig {
+  root: string;
+  dims: number;
+}
+
+export class VaultVectorIndex {
+  private constructor(
+    private readonly db: lancedb.Connection,
+    private readonly table: lancedb.Table,
+    readonly dims: number,
+  ) {}
+
+  static async create(cfg: VaultVectorIndexConfig): Promise<VaultVectorIndex> {
+    const dir = join(cfg.root, ".agent-brain", "index.lance");
+    await mkdir(dir, { recursive: true });
+    const db = await lancedb.connect(dir);
+    const existing = await db.tableNames();
+    const table = existing.includes("memories")
+      ? await db.openTable("memories")
+      : await db.createEmptyTable("memories", memorySchema(cfg.dims));
+    return new VaultVectorIndex(db, table, cfg.dims);
+  }
+
+  async close(): Promise<void> {
+    // @lancedb/lancedb manages connection lifetime internally; no
+    // explicit close hook is required today. Kept for forward-compat
+    // with future resource ownership changes.
+  }
+
+  async countRows(): Promise<number> {
+    return await this.table.countRows();
+  }
+
+  async upsert(rows: IndexRow[]): Promise<void> {
+    if (rows.length === 0) return;
+    for (const r of rows) {
+      if (r.vector.length !== this.dims) {
+        throw new Error(
+          `vector dimension mismatch: expected ${this.dims}, got ${r.vector.length} for id ${r.id}`,
+        );
+      }
+    }
+    await this.table
+      .mergeInsert("id")
+      .whenMatchedUpdateAll()
+      .whenNotMatchedInsertAll()
+      .execute(rows);
+  }
+}

--- a/src/backend/vault/vector/lance-index.ts
+++ b/src/backend/vault/vector/lance-index.ts
@@ -1,6 +1,7 @@
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import * as lancedb from "@lancedb/lancedb";
+import type { VectorQuery } from "@lancedb/lancedb";
 import { memorySchema } from "./schema.js";
 
 export interface IndexRow {
@@ -61,7 +62,7 @@ export class VaultVectorIndex {
       .mergeInsert("id")
       .whenMatchedUpdateAll()
       .whenNotMatchedInsertAll()
-      .execute(rows);
+      .execute(rows as unknown as Record<string, unknown>[]);
   }
 
   async search(params: SearchParams): Promise<SearchHit[]> {
@@ -92,8 +93,7 @@ export class VaultVectorIndex {
     }
     if (scopeClauses.length === 0) return [];
     clauses.push(`(${scopeClauses.join(" OR ")})`);
-    const rows = (await this.table
-      .search(params.embedding)
+    const rows = (await (this.table.search(params.embedding) as VectorQuery)
       .distanceType("cosine")
       .where(clauses.join(" AND "))
       .limit(params.limit)
@@ -135,8 +135,7 @@ export class VaultVectorIndex {
           ` OR (scope = 'user' AND author = ${sqlStr(params.userId)}))`,
       );
     }
-    const rows = (await this.table
-      .search(params.embedding)
+    const rows = (await (this.table.search(params.embedding) as VectorQuery)
       .distanceType("cosine")
       .where(clauses.join(" AND "))
       .limit(1)
@@ -176,8 +175,7 @@ export class VaultVectorIndex {
     const pairs: PairwiseHit[] = [];
     for (const r of rows) {
       const vec = Array.from(r.vector as ArrayLike<number>);
-      const hits = (await this.table
-        .search(vec)
+      const hits = (await (this.table.search(vec) as VectorQuery)
         .distanceType("cosine")
         .where(`${where} AND id > ${sqlStr(r.id)}`)
         .limit(32)

--- a/src/backend/vault/vector/lance-index.ts
+++ b/src/backend/vault/vector/lance-index.ts
@@ -150,6 +150,65 @@ export class VaultVectorIndex {
       }))
       .filter((h) => h.relevance >= params.threshold);
   }
+
+  async findPairwiseSimilar(params: PairwiseParams): Promise<PairwiseHit[]> {
+    const clauses: string[] = [
+      `archived = false`,
+      `project_id = ${sqlStr(params.projectId)}`,
+    ];
+    if (params.scope === "project") {
+      clauses.push(`scope = 'project'`);
+    } else {
+      if (params.workspaceId === null) {
+        throw new Error("workspaceId is required for workspace-scoped pairwise");
+      }
+      clauses.push(
+        `scope = 'workspace'`,
+        `workspace_id = ${sqlStr(params.workspaceId)}`,
+      );
+    }
+    const where = clauses.join(" AND ");
+    const rows = (await this.table
+      .query()
+      .where(where)
+      .select(["id", "vector"])
+      .toArray()) as Array<{ id: string; vector: number[] | Float32Array }>;
+    const pairs: PairwiseHit[] = [];
+    for (const r of rows) {
+      const vec = Array.from(r.vector as ArrayLike<number>);
+      const hits = (await this.table
+        .search(vec)
+        .distanceType("cosine")
+        .where(`${where} AND id > ${sqlStr(r.id)}`)
+        .limit(32)
+        .toArray()) as Array<Record<string, unknown>>;
+      for (const h of hits) {
+        const sim = 1 - Number(h._distance);
+        if (sim >= params.threshold) {
+          pairs.push({
+            memory_a_id: r.id,
+            memory_b_id: h.id as string,
+            similarity: sim,
+          });
+        }
+      }
+    }
+    pairs.sort((a, b) => b.similarity - a.similarity);
+    return pairs;
+  }
+}
+
+export interface PairwiseParams {
+  projectId: string;
+  workspaceId: string | null;
+  scope: "workspace" | "project";
+  threshold: number;
+}
+
+export interface PairwiseHit {
+  memory_a_id: string;
+  memory_b_id: string;
+  similarity: number;
 }
 
 export interface DuplicateParams {

--- a/src/backend/vault/vector/lance-index.ts
+++ b/src/backend/vault/vector/lance-index.ts
@@ -63,4 +63,65 @@ export class VaultVectorIndex {
       .whenNotMatchedInsertAll()
       .execute(rows);
   }
+
+  async search(params: SearchParams): Promise<SearchHit[]> {
+    if (params.embedding.length !== this.dims) {
+      throw new Error(
+        `vector dimension mismatch: expected ${this.dims}, got ${params.embedding.length}`,
+      );
+    }
+    const clauses: string[] = [
+      `archived = false`,
+      `project_id = ${sqlStr(params.projectId)}`,
+    ];
+    const scopeClauses: string[] = [];
+    for (const s of params.scope) {
+      if (s === "workspace") {
+        if (params.workspaceId === null) continue;
+        scopeClauses.push(
+          `(scope = 'workspace' AND workspace_id = ${sqlStr(params.workspaceId)})`,
+        );
+      } else if (s === "user") {
+        if (params.userId === null) continue;
+        scopeClauses.push(
+          `(scope = 'user' AND author = ${sqlStr(params.userId)})`,
+        );
+      } else {
+        scopeClauses.push(`scope = 'project'`);
+      }
+    }
+    if (scopeClauses.length === 0) return [];
+    clauses.push(`(${scopeClauses.join(" OR ")})`);
+    const rows = (await this.table
+      .search(params.embedding)
+      .distanceType("cosine")
+      .where(clauses.join(" AND "))
+      .limit(params.limit)
+      .toArray()) as Array<Record<string, unknown>>;
+    return rows
+      .map((r) => ({
+        id: r.id as string,
+        relevance: 1 - Number(r._distance),
+      }))
+      .filter((h) => h.relevance >= params.minSimilarity);
+  }
+}
+
+export interface SearchParams {
+  embedding: number[];
+  projectId: string;
+  workspaceId: string | null;
+  scope: Array<"workspace" | "user" | "project">;
+  userId: string | null;
+  limit: number;
+  minSimilarity: number;
+}
+
+export interface SearchHit {
+  id: string;
+  relevance: number;
+}
+
+function sqlStr(v: string): string {
+  return `'${v.replace(/'/g, "''")}'`;
 }

--- a/src/backend/vault/vector/lance-index.ts
+++ b/src/backend/vault/vector/lance-index.ts
@@ -105,6 +105,67 @@ export class VaultVectorIndex {
       }))
       .filter((h) => h.relevance >= params.minSimilarity);
   }
+
+  async findDuplicates(params: DuplicateParams): Promise<DuplicateHit[]> {
+    if (params.embedding.length !== this.dims) {
+      throw new Error(
+        `vector dimension mismatch: expected ${this.dims}, got ${params.embedding.length}`,
+      );
+    }
+    const clauses: string[] = [
+      `archived = false`,
+      `project_id = ${sqlStr(params.projectId)}`,
+    ];
+    if (params.scope === "workspace") {
+      if (params.workspaceId === null) {
+        throw new Error("workspaceId is required for workspace-scoped dedup");
+      }
+      clauses.push(
+        `scope = 'workspace'`,
+        `workspace_id = ${sqlStr(params.workspaceId)}`,
+      );
+    } else if (params.scope === "project") {
+      clauses.push(`scope = 'project'`);
+    } else {
+      if (params.workspaceId === null) {
+        throw new Error("workspaceId is required for user-scoped dedup");
+      }
+      clauses.push(
+        `(workspace_id = ${sqlStr(params.workspaceId)}` +
+          ` OR (scope = 'user' AND author = ${sqlStr(params.userId)}))`,
+      );
+    }
+    const rows = (await this.table
+      .search(params.embedding)
+      .distanceType("cosine")
+      .where(clauses.join(" AND "))
+      .limit(1)
+      .toArray()) as Array<Record<string, unknown>>;
+    return rows
+      .map((r) => ({
+        id: r.id as string,
+        title: r.title as string,
+        relevance: 1 - Number(r._distance),
+        scope: r.scope as "workspace" | "user" | "project",
+      }))
+      .filter((h) => h.relevance >= params.threshold);
+  }
+}
+
+export interface DuplicateParams {
+  embedding: number[];
+  projectId: string;
+  workspaceId: string | null;
+  scope: "workspace" | "user" | "project";
+  userId: string;
+  threshold: number;
+}
+
+export interface DuplicateHit {
+  id: string;
+  title: string;
+  relevance: number;
+  scope: "workspace" | "user" | "project";
 }
 
 export interface SearchParams {

--- a/src/backend/vault/vector/schema.ts
+++ b/src/backend/vault/vector/schema.ts
@@ -1,0 +1,22 @@
+import * as arrow from "apache-arrow";
+
+export function memorySchema(dims: number): arrow.Schema {
+  return new arrow.Schema([
+    new arrow.Field("id", new arrow.Utf8(), false),
+    new arrow.Field("project_id", new arrow.Utf8(), false),
+    new arrow.Field("workspace_id", new arrow.Utf8(), true),
+    new arrow.Field("scope", new arrow.Utf8(), false),
+    new arrow.Field("author", new arrow.Utf8(), false),
+    new arrow.Field("title", new arrow.Utf8(), false),
+    new arrow.Field("archived", new arrow.Bool(), false),
+    new arrow.Field("content_hash", new arrow.Utf8(), false),
+    new arrow.Field(
+      "vector",
+      new arrow.FixedSizeList(
+        dims,
+        new arrow.Field("item", new arrow.Float32(), true),
+      ),
+      false,
+    ),
+  ]);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -39,6 +39,7 @@ async function main() {
       backend: config.backend,
       databaseUrl: config.databaseUrl,
       vaultRoot: config.vaultRoot,
+      embeddingDimensions: config.embeddingDimensions,
     });
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/tests/contract/backend.test.ts
+++ b/tests/contract/backend.test.ts
@@ -91,6 +91,7 @@ const cases: BackendCase[] = [
         backend: "postgres",
         databaseUrl: TEST_DB_URL,
         vaultRoot: "",
+        embeddingDimensions: 768,
       });
       return {
         backend,
@@ -108,6 +109,7 @@ const cases: BackendCase[] = [
         backend: "vault",
         databaseUrl: "",
         vaultRoot: root,
+        embeddingDimensions: 768,
       });
       return {
         backend,

--- a/tests/contract/repositories/_factories.ts
+++ b/tests/contract/repositories/_factories.ts
@@ -86,9 +86,8 @@ export const vaultFactory: Factory = {
   name: "vault",
   async create() {
     const root = await mkdtemp(join(tmpdir(), "contract-vault-"));
-    const { VaultVectorIndex } = await import(
-      "../../../src/backend/vault/vector/lance-index.js"
-    );
+    const { VaultVectorIndex } =
+      await import("../../../src/backend/vault/vector/lance-index.js");
     const index = await VaultVectorIndex.create({ root, dims: 768 });
     const memoryRepo = await VaultMemoryRepository.create({ root, index });
     const workspaceRepo = new VaultWorkspaceRepository({ root });

--- a/tests/contract/repositories/_factories.ts
+++ b/tests/contract/repositories/_factories.ts
@@ -86,7 +86,11 @@ export const vaultFactory: Factory = {
   name: "vault",
   async create() {
     const root = await mkdtemp(join(tmpdir(), "contract-vault-"));
-    const memoryRepo = await VaultMemoryRepository.create({ root });
+    const { VaultVectorIndex } = await import(
+      "../../../src/backend/vault/vector/lance-index.js"
+    );
+    const index = await VaultVectorIndex.create({ root, dims: 768 });
+    const memoryRepo = await VaultMemoryRepository.create({ root, index });
     const workspaceRepo = new VaultWorkspaceRepository({ root });
     const auditRepo = new VaultAuditRepository({ root });
     const schedulerStateRepo = new VaultSchedulerStateRepository({ root });
@@ -107,6 +111,7 @@ export const vaultFactory: Factory = {
       flagRepo,
       relationshipRepo,
       close: async () => {
+        await index.close();
         await rm(root, { recursive: true, force: true });
       },
     };

--- a/tests/contract/repositories/memory-repository-vector.test.ts
+++ b/tests/contract/repositories/memory-repository-vector.test.ts
@@ -144,5 +144,78 @@ describe.each(factories)(
       expect(rows[0].embedding).toHaveLength(DIMS);
       expect(rows[0].embedding[5]).toBeCloseTo(1, 5);
     });
+
+    it("findDuplicates excludes archived rows", async () => {
+      await backend.memoryRepo.create({
+        ...makeMemory("a"),
+        embedding: embVec(5),
+      });
+      await backend.memoryRepo.archive(["a"]);
+      const hits = await backend.memoryRepo.findDuplicates({
+        embedding: embVec(5),
+        projectId: "p1",
+        workspaceId: "ws1",
+        scope: "workspace",
+        userId: "ignored",
+        threshold: 0.9,
+      });
+      expect(hits).toEqual([]);
+    });
+
+    it("findPairwiseSimilar excludes archived rows", async () => {
+      const v = embVec(10);
+      const w = [...v];
+      w[11] = 0.01;
+      await backend.memoryRepo.create({ ...makeMemory("a"), embedding: v });
+      await backend.memoryRepo.create({ ...makeMemory("b"), embedding: w });
+      await backend.memoryRepo.archive(["a"]);
+      const pairs = await backend.memoryRepo.findPairwiseSimilar({
+        projectId: "p1",
+        workspaceId: "ws1",
+        scope: "workspace",
+        threshold: 0.9,
+      });
+      const ids = pairs.flatMap((p) => [p.memory_a_id, p.memory_b_id]);
+      expect(ids).not.toContain("a");
+    });
+
+    it("listWithEmbeddings excludes archived rows", async () => {
+      await backend.memoryRepo.create({
+        ...makeMemory("a"),
+        embedding: embVec(5),
+      });
+      await backend.memoryRepo.create({
+        ...makeMemory("b"),
+        embedding: embVec(6),
+      });
+      await backend.memoryRepo.archive(["a"]);
+      const rows = await backend.memoryRepo.listWithEmbeddings({
+        projectId: "p1",
+        workspaceId: "ws1",
+        scope: "workspace",
+        limit: 10,
+      });
+      expect(rows.map((r) => r.id)).toEqual(["b"]);
+    });
+
+    it("findDuplicates honors project scope", async () => {
+      await backend.memoryRepo.create({
+        ...makeMemory("p-hit", { scope: "project", workspace_id: null }),
+        embedding: embVec(7),
+      });
+      await backend.memoryRepo.create({
+        ...makeMemory("ws-noise", { scope: "workspace" }),
+        embedding: embVec(7),
+      });
+      const hits = await backend.memoryRepo.findDuplicates({
+        embedding: embVec(7),
+        projectId: "p1",
+        workspaceId: null,
+        scope: "project",
+        userId: "ignored",
+        threshold: 0.9,
+      });
+      expect(hits.map((h) => h.id)).toEqual(["p-hit"]);
+    });
   },
 );

--- a/tests/contract/repositories/memory-repository-vector.test.ts
+++ b/tests/contract/repositories/memory-repository-vector.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { factories, type TestBackend } from "./_factories.js";
+import type { Memory } from "../../../src/types/memory.js";
+
+const DIMS = 768;
+const now = new Date("2026-04-22T00:00:00.000Z");
+
+function embVec(seed: number): number[] {
+  const v = new Array(DIMS).fill(0);
+  v[seed % DIMS] = 1;
+  return v;
+}
+
+function makeMemory(id: string, overrides: Partial<Memory> = {}): Memory {
+  return {
+    id,
+    project_id: "p1",
+    workspace_id: "ws1",
+    content: `body-${id}`,
+    title: `T-${id}`,
+    type: "fact",
+    scope: "workspace",
+    tags: null,
+    author: "a",
+    source: null,
+    session_id: null,
+    metadata: null,
+    embedding_model: null,
+    embedding_dimensions: DIMS,
+    version: 1,
+    created_at: now,
+    updated_at: now,
+    verified_at: null,
+    archived_at: null,
+    comment_count: 0,
+    flag_count: 0,
+    relationship_count: 0,
+    last_comment_at: null,
+    verified_by: null,
+    ...overrides,
+  };
+}
+
+describe.each(factories)(
+  "MemoryRepository vector contract — $name",
+  (factory) => {
+    let backend: TestBackend;
+    beforeEach(async () => {
+      backend = await factory.create();
+      await backend.workspaceRepo.findOrCreate("ws1");
+    });
+    afterEach(async () => {
+      await backend.close();
+    });
+
+    it("search returns exact match at rank 1", async () => {
+      await backend.memoryRepo.create({
+        ...makeMemory("a"),
+        embedding: embVec(5),
+      });
+      await backend.memoryRepo.create({
+        ...makeMemory("b"),
+        embedding: embVec(200),
+      });
+      const hits = await backend.memoryRepo.search({
+        embedding: embVec(5),
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: ["workspace"],
+        limit: 2,
+        min_similarity: 0,
+      });
+      expect(hits[0].id).toBe("a");
+      expect(hits[0].relevance).toBeCloseTo(1, 3);
+    });
+
+    it("search excludes archived", async () => {
+      await backend.memoryRepo.create({
+        ...makeMemory("a"),
+        embedding: embVec(5),
+      });
+      await backend.memoryRepo.archive(["a"]);
+      const hits = await backend.memoryRepo.search({
+        embedding: embVec(5),
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: ["workspace"],
+        limit: 10,
+        min_similarity: 0,
+      });
+      expect(hits).toEqual([]);
+    });
+
+    it("findDuplicates returns top workspace-scope match above threshold", async () => {
+      await backend.memoryRepo.create({
+        ...makeMemory("a"),
+        embedding: embVec(5),
+      });
+      const hits = await backend.memoryRepo.findDuplicates({
+        embedding: embVec(5),
+        projectId: "p1",
+        workspaceId: "ws1",
+        scope: "workspace",
+        userId: "ignored",
+        threshold: 0.9,
+      });
+      expect(hits.map((h) => h.id)).toEqual(["a"]);
+    });
+
+    it("findPairwiseSimilar surfaces near-dupes", async () => {
+      const v = embVec(10);
+      const w = [...v];
+      w[11] = 0.01;
+      await backend.memoryRepo.create({
+        ...makeMemory("a"),
+        embedding: v,
+      });
+      await backend.memoryRepo.create({
+        ...makeMemory("b"),
+        embedding: w,
+      });
+      const pairs = await backend.memoryRepo.findPairwiseSimilar({
+        projectId: "p1",
+        workspaceId: "ws1",
+        scope: "workspace",
+        threshold: 0.9,
+      });
+      const ids = pairs.map((p) => [p.memory_a_id, p.memory_b_id].sort());
+      expect(ids).toContainEqual(["a", "b"]);
+    });
+
+    it("listWithEmbeddings returns stored embeddings", async () => {
+      await backend.memoryRepo.create({
+        ...makeMemory("a"),
+        embedding: embVec(5),
+      });
+      const rows = await backend.memoryRepo.listWithEmbeddings({
+        projectId: "p1",
+        workspaceId: "ws1",
+        scope: "workspace",
+        limit: 10,
+      });
+      expect(rows).toHaveLength(1);
+      expect(rows[0].embedding).toHaveLength(DIMS);
+      expect(rows[0].embedding[5]).toBeCloseTo(1, 5);
+    });
+  },
+);

--- a/tests/integration/vector-parity.test.ts
+++ b/tests/integration/vector-parity.test.ts
@@ -13,6 +13,7 @@ import type { Memory } from "../../src/types/memory.js";
 
 const DIMS = 768;
 const N = 500;
+const N_PROJECT = 100;
 
 function randomUnitVec(rng: () => number): number[] {
   const v: number[] = [];
@@ -75,6 +76,39 @@ describe("vector parity — pg vs vault", () => {
       await pg.create({ ...m, embedding: v });
       await vault.create({ ...m, embedding: v });
     }
+    // Seed project-scope memories to parity-check the project-scope
+    // read path (workspace-scoped seed above only exercises workspace).
+    for (let i = 0; i < N_PROJECT; i++) {
+      const m: Memory = {
+        id: `pm${i}`,
+        project_id: "p1",
+        workspace_id: null,
+        content: `project body ${i}`,
+        title: `PT${i}`,
+        type: "fact",
+        scope: "project",
+        tags: null,
+        author: "a",
+        source: null,
+        session_id: null,
+        metadata: null,
+        embedding_model: null,
+        embedding_dimensions: DIMS,
+        version: 1,
+        created_at: now,
+        updated_at: now,
+        verified_at: null,
+        archived_at: null,
+        comment_count: 0,
+        flag_count: 0,
+        relationship_count: 0,
+        last_comment_at: null,
+        verified_by: null,
+      };
+      const v = randomUnitVec(rng);
+      await pg.create({ ...m, embedding: v });
+      await vault.create({ ...m, embedding: v });
+    }
   }, 120_000);
 
   afterAll(async () => {
@@ -105,6 +139,40 @@ describe("vector parity — pg vs vault", () => {
           project_id: "p1",
           workspace_id: "ws1",
           scope: ["workspace"],
+          limit: K,
+          min_similarity: 0,
+        })
+      ).map((h) => h.id);
+      const overlap = pgIds.filter((id) => vaultIds.includes(id)).length;
+      totalOverlap += overlap;
+    }
+    const overlapRatio = totalOverlap / (QUERIES * K);
+    expect(overlapRatio).toBeGreaterThanOrEqual(0.95);
+  }, 30_000);
+
+  it("project-scope top-10 overlap ≥ 95% across 10 queries", async () => {
+    const rng = seedrandom("parity-project-query");
+    let totalOverlap = 0;
+    const QUERIES = 10;
+    const K = 10;
+    for (let q = 0; q < QUERIES; q++) {
+      const v = randomUnitVec(rng);
+      const pgIds = (
+        await pg.search({
+          embedding: v,
+          project_id: "p1",
+          workspace_id: "ws1",
+          scope: ["project"],
+          limit: K,
+          min_similarity: 0,
+        })
+      ).map((h) => h.id);
+      const vaultIds = (
+        await vault.search({
+          embedding: v,
+          project_id: "p1",
+          workspace_id: "ws1",
+          scope: ["project"],
           limit: K,
           min_similarity: 0,
         })

--- a/tests/integration/vector-parity.test.ts
+++ b/tests/integration/vector-parity.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import seedrandom from "seedrandom";
+import { DrizzleMemoryRepository } from "../../src/repositories/memory-repository.js";
+import { DrizzleWorkspaceRepository } from "../../src/repositories/workspace-repository.js";
+import { VaultMemoryRepository } from "../../src/backend/vault/repositories/memory-repository.js";
+import { VaultWorkspaceRepository } from "../../src/backend/vault/repositories/workspace-repository.js";
+import { VaultVectorIndex } from "../../src/backend/vault/vector/lance-index.js";
+import { getTestDb, truncateAll } from "../helpers.js";
+import type { Memory } from "../../src/types/memory.js";
+
+const DIMS = 768;
+const N = 500;
+
+function randomUnitVec(rng: () => number): number[] {
+  const v: number[] = [];
+  let norm = 0;
+  for (let i = 0; i < DIMS; i++) {
+    const x = rng() - 0.5;
+    v.push(x);
+    norm += x * x;
+  }
+  const s = 1 / Math.sqrt(norm);
+  return v.map((x) => x * s);
+}
+
+describe("vector parity — pg vs vault", () => {
+  let root: string;
+  let idx: VaultVectorIndex;
+  let vault: VaultMemoryRepository;
+  let pg: DrizzleMemoryRepository;
+
+  beforeAll(async () => {
+    const db = getTestDb();
+    await truncateAll();
+    root = await mkdtemp(join(tmpdir(), "parity-"));
+    idx = await VaultVectorIndex.create({ root, dims: DIMS });
+    vault = await VaultMemoryRepository.create({ root, index: idx });
+    pg = new DrizzleMemoryRepository(db);
+    await new DrizzleWorkspaceRepository(db).findOrCreate("ws1");
+    await new VaultWorkspaceRepository({ root }).findOrCreate("ws1");
+
+    const rng = seedrandom("parity-seed");
+    const now = new Date();
+    for (let i = 0; i < N; i++) {
+      const m: Memory = {
+        id: `m${i}`,
+        project_id: "p1",
+        workspace_id: "ws1",
+        content: `body ${i}`,
+        title: `T${i}`,
+        type: "fact",
+        scope: "workspace",
+        tags: null,
+        author: "a",
+        source: null,
+        session_id: null,
+        metadata: null,
+        embedding_model: null,
+        embedding_dimensions: DIMS,
+        version: 1,
+        created_at: now,
+        updated_at: now,
+        verified_at: null,
+        archived_at: null,
+        comment_count: 0,
+        flag_count: 0,
+        relationship_count: 0,
+        last_comment_at: null,
+        verified_by: null,
+      };
+      const v = randomUnitVec(rng);
+      await pg.create({ ...m, embedding: v });
+      await vault.create({ ...m, embedding: v });
+    }
+  }, 120_000);
+
+  afterAll(async () => {
+    await idx.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("top-10 overlap ≥ 95% across 20 queries", async () => {
+    const rng = seedrandom("parity-query");
+    let totalOverlap = 0;
+    const QUERIES = 20;
+    const K = 10;
+    for (let q = 0; q < QUERIES; q++) {
+      const v = randomUnitVec(rng);
+      const pgIds = (
+        await pg.search({
+          embedding: v,
+          project_id: "p1",
+          workspace_id: "ws1",
+          scope: ["workspace"],
+          limit: K,
+          min_similarity: 0,
+        })
+      ).map((h) => h.id);
+      const vaultIds = (
+        await vault.search({
+          embedding: v,
+          project_id: "p1",
+          workspace_id: "ws1",
+          scope: ["workspace"],
+          limit: K,
+          min_similarity: 0,
+        })
+      ).map((h) => h.id);
+      const overlap = pgIds.filter((id) => vaultIds.includes(id)).length;
+      totalOverlap += overlap;
+    }
+    const overlapRatio = totalOverlap / (QUERIES * K);
+    expect(overlapRatio).toBeGreaterThanOrEqual(0.95);
+  }, 30_000);
+});

--- a/tests/unit/backend/factory.test.ts
+++ b/tests/unit/backend/factory.test.ts
@@ -12,6 +12,7 @@ describe("createBackend", () => {
         backend: "vault",
         databaseUrl: "postgresql://unused",
         vaultRoot: root,
+        embeddingDimensions: 768,
       });
       expect(backend.name).toBe("vault");
       await backend.close();
@@ -26,6 +27,7 @@ describe("createBackend", () => {
         backend: "vault",
         databaseUrl: "postgresql://unused",
         vaultRoot: "",
+        embeddingDimensions: 768,
       }),
     ).rejects.toThrow(/AGENT_BRAIN_VAULT_ROOT/);
   });
@@ -37,6 +39,7 @@ describe("createBackend", () => {
         backend: "nosuch",
         databaseUrl: "postgresql://unused",
         vaultRoot: "",
+        embeddingDimensions: 768,
       }),
     ).rejects.toThrow(/unknown backend/i);
   });

--- a/tests/unit/backend/vault/repositories/memory-repository-index-sync.test.ts
+++ b/tests/unit/backend/vault/repositories/memory-repository-index-sync.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, rm } from "node:fs/promises";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { VaultMemoryRepository } from "../../../../../src/backend/vault/repositories/memory-repository.js";
 import { VaultWorkspaceRepository } from "../../../../../src/backend/vault/repositories/workspace-repository.js";
 import { VaultVectorIndex } from "../../../../../src/backend/vault/vector/lance-index.js";
+import { ValidationError } from "../../../../../src/utils/errors.js";
 import type { Memory } from "../../../../../src/types/memory.js";
 
 const DIMS = 3;
@@ -105,5 +106,142 @@ describe("VaultMemoryRepository — lance index sync", () => {
     });
     expect(hits).toHaveLength(1);
     expect(hits[0].id).toBe("m1");
+  });
+
+  describe("lance write-failure swallow (markdown = source of truth)", () => {
+    it("create: lance upsert throw → markdown persists, caller sees success, warn logged", async () => {
+      const warnSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      vi.spyOn(idx, "upsert").mockRejectedValueOnce(new Error("lance boom"));
+
+      const saved = await repo.create({
+        ...makeMemory(),
+        embedding: [1, 0, 0],
+      });
+      expect(saved.id).toBe("m1");
+
+      const body = await readFile(
+        join(root, "workspaces/ws1/memories/m1.md"),
+        "utf8",
+      );
+      expect(body).toContain("m1");
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[agent-brain] WARN:",
+        "lance upsert failed on create; index stale",
+        expect.objectContaining({ id: "m1", op: "create" }),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it("update: lance upsert throw → markdown persists, caller sees success, warn logged", async () => {
+      await repo.create({ ...makeMemory(), embedding: [1, 0, 0] });
+      const warnSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      vi.spyOn(idx, "upsert").mockRejectedValueOnce(new Error("lance boom"));
+
+      const next = await repo.update("m1", 1, {
+        content: "updated",
+        embedding: [0, 1, 0],
+      });
+      expect(next.content).toBe("updated");
+      expect(next.version).toBe(2);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[agent-brain] WARN:",
+        "lance upsert failed on update; index stale",
+        expect.objectContaining({ id: "m1", op: "update" }),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it("update meta-only: missing lance row → drift warn logged, caller sees success", async () => {
+      await repo.create({ ...makeMemory(), embedding: [1, 0, 0] });
+      const warnSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      // Force meta-only upsert to report zero-row match (simulated drift)
+      vi.spyOn(idx, "upsertMetaOnly").mockResolvedValueOnce(0);
+
+      const next = await repo.update("m1", 1, { title: "Renamed" });
+      expect(next.title).toBe("Renamed");
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[agent-brain] WARN:",
+        "lance meta-only update matched no rows; index drift",
+        expect.objectContaining({ id: "m1", op: "update" }),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it("archive: lance failure on one id does not abort loop for others", async () => {
+      await repo.create({ ...makeMemory({ id: "a" }), embedding: [1, 0, 0] });
+      await repo.create({ ...makeMemory({ id: "b" }), embedding: [0, 1, 0] });
+      await repo.create({ ...makeMemory({ id: "c" }), embedding: [0, 0, 1] });
+      const warnSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      // First archive call throws, subsequent calls succeed.
+      const spy = vi
+        .spyOn(idx, "markArchived")
+        .mockImplementationOnce(async () => {
+          throw new Error("lance boom");
+        });
+
+      const count = await repo.archive(["a", "b", "c"]);
+      expect(count).toBe(3);
+      expect(spy).toHaveBeenCalledTimes(3);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[agent-brain] WARN:",
+        "lance markArchived failed; index stale",
+        expect.objectContaining({ id: "a", op: "archive" }),
+      );
+      // b and c should have been flipped in lance despite a's failure.
+      const bStillVisible = await idx.search({
+        embedding: [0, 1, 0],
+        projectId: "p1",
+        workspaceId: "ws1",
+        scope: ["workspace"],
+        userId: null,
+        limit: 10,
+        minSimilarity: 0,
+      });
+      expect(bStillVisible.map((h) => h.id)).not.toContain("b");
+      warnSpy.mockRestore();
+    });
+
+    it("archive: missing lance row → drift warn, caller count reflects markdown", async () => {
+      await repo.create({ ...makeMemory(), embedding: [1, 0, 0] });
+      const warnSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      vi.spyOn(idx, "markArchived").mockResolvedValueOnce(0);
+
+      const count = await repo.archive(["m1"]);
+      expect(count).toBe(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[agent-brain] WARN:",
+        "lance markArchived matched no rows; index drift",
+        expect.objectContaining({ id: "m1", op: "archive" }),
+      );
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe("pre-write dimension guard", () => {
+    it("create: wrong-dim embedding → ValidationError before any fs write", async () => {
+      await expect(
+        repo.create({ ...makeMemory(), embedding: [1, 0, 0, 0] }),
+      ).rejects.toBeInstanceOf(ValidationError);
+      // Markdown must NOT have been written.
+      await expect(
+        readFile(join(root, "workspaces/ws1/memories/m1.md"), "utf8"),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+      // Lance row count unchanged (still 0).
+      expect(await idx.countRows()).toBe(0);
+    });
+
+    it("update: wrong-dim embedding → ValidationError, markdown unchanged", async () => {
+      await repo.create({ ...makeMemory(), embedding: [1, 0, 0] });
+      await expect(
+        repo.update("m1", 1, { embedding: [1, 0] }),
+      ).rejects.toBeInstanceOf(ValidationError);
+      // Version should still be 1 (no write committed).
+      const current = await repo.findById("m1");
+      expect(current?.version).toBe(1);
+    });
   });
 });

--- a/tests/unit/backend/vault/repositories/memory-repository-index-sync.test.ts
+++ b/tests/unit/backend/vault/repositories/memory-repository-index-sync.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { VaultMemoryRepository } from "../../../../../src/backend/vault/repositories/memory-repository.js";
+import { VaultWorkspaceRepository } from "../../../../../src/backend/vault/repositories/workspace-repository.js";
+import { VaultVectorIndex } from "../../../../../src/backend/vault/vector/lance-index.js";
+import type { Memory } from "../../../../../src/types/memory.js";
+
+const DIMS = 3;
+const now = new Date("2026-04-22T00:00:00.000Z");
+
+function makeMemory(overrides: Partial<Memory> = {}): Memory {
+  return {
+    id: "m1",
+    project_id: "p1",
+    workspace_id: "ws1",
+    content: "body",
+    title: "Title",
+    type: "fact",
+    scope: "workspace",
+    tags: null,
+    author: "a",
+    source: null,
+    session_id: null,
+    metadata: null,
+    embedding_model: null,
+    embedding_dimensions: DIMS,
+    version: 1,
+    created_at: now,
+    updated_at: now,
+    verified_at: null,
+    archived_at: null,
+    comment_count: 0,
+    flag_count: 0,
+    relationship_count: 0,
+    last_comment_at: null,
+    verified_by: null,
+    ...overrides,
+  };
+}
+
+describe("VaultMemoryRepository — lance index sync", () => {
+  let root: string;
+  let idx: VaultVectorIndex;
+  let repo: VaultMemoryRepository;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "repo-sync-"));
+    idx = await VaultVectorIndex.create({ root, dims: DIMS });
+    repo = await VaultMemoryRepository.create({ root, index: idx });
+    await new VaultWorkspaceRepository({ root }).findOrCreate("ws1");
+  });
+
+  afterEach(async () => {
+    await idx.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("archive flips the lance row's archived flag", async () => {
+    await repo.create({ ...makeMemory(), embedding: [1, 0, 0] });
+    expect(await idx.countRows()).toBe(1);
+    await repo.archive(["m1"]);
+    const hits = await idx.search({
+      embedding: [1, 0, 0],
+      projectId: "p1",
+      workspaceId: "ws1",
+      scope: ["workspace"],
+      userId: null,
+      limit: 10,
+      minSimilarity: 0,
+    });
+    expect(hits).toEqual([]);
+  });
+
+  it("update with new embedding replaces the vector", async () => {
+    await repo.create({ ...makeMemory(), embedding: [1, 0, 0] });
+    await repo.update("m1", 1, { content: "new", embedding: [0, 1, 0] });
+    const hits = await idx.search({
+      embedding: [0, 1, 0],
+      projectId: "p1",
+      workspaceId: "ws1",
+      scope: ["workspace"],
+      userId: null,
+      limit: 10,
+      minSimilarity: 0.9,
+    });
+    expect(hits.map((h) => h.id)).toEqual(["m1"]);
+  });
+
+  it("update with no embedding preserves existing vector + updates meta", async () => {
+    await repo.create({
+      ...makeMemory({ title: "Old" }),
+      embedding: [1, 0, 0],
+    });
+    await repo.update("m1", 1, { title: "New" });
+    const hits = await idx.search({
+      embedding: [1, 0, 0],
+      projectId: "p1",
+      workspaceId: "ws1",
+      scope: ["workspace"],
+      userId: null,
+      limit: 1,
+      minSimilarity: 0,
+    });
+    expect(hits).toHaveLength(1);
+    expect(hits[0].id).toBe("m1");
+  });
+});

--- a/tests/unit/backend/vault/repositories/memory-repository.test.ts
+++ b/tests/unit/backend/vault/repositories/memory-repository.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { VaultMemoryRepository } from "../../../../../src/backend/vault/repositories/memory-repository.js";
-import { NotImplementedError } from "../../../../../src/backend/vault/errors.js";
+import { VaultVectorIndex } from "../../../../../src/backend/vault/vector/lance-index.js";
 import {
   ConflictError,
   ValidationError,
@@ -43,12 +43,15 @@ function makeMemory(overrides: Partial<Memory> = {}): Memory {
 
 describe("VaultMemoryRepository — CRUD", () => {
   let root: string;
+  let idx: VaultVectorIndex;
   let repo: VaultMemoryRepository;
   beforeEach(async () => {
     root = await mkdtemp(join(tmpdir(), "vault-memrepo-"));
-    repo = await VaultMemoryRepository.create({ root });
+    idx = await VaultVectorIndex.create({ root, dims: 1 });
+    repo = await VaultMemoryRepository.create({ root, index: idx });
   });
   afterEach(async () => {
+    await idx.close();
     await rm(root, { recursive: true, force: true });
   });
 
@@ -132,26 +135,29 @@ describe("VaultMemoryRepository — CRUD", () => {
   it("VaultMemoryRepository.create rebuilds index from existing vault", async () => {
     // Pre-seed a memory via the same repo API on a separate instance,
     // then construct a fresh repo against the same root.
-    const pre = await VaultMemoryRepository.create({ root });
+    const pre = await VaultMemoryRepository.create({ root, index: idx });
     await pre.create({
       ...makeMemory({ id: "preexist" }),
       embedding: [0],
     });
 
-    const repo2 = await VaultMemoryRepository.create({ root });
+    const repo2 = await VaultMemoryRepository.create({ root, index: idx });
     expect(await repo2.findById("preexist")).not.toBeNull();
   });
 });
 
 describe("VaultMemoryRepository — listings", () => {
   let root: string;
+  let idx: VaultVectorIndex;
   let repo: VaultMemoryRepository;
 
   beforeEach(async () => {
     root = await mkdtemp(join(tmpdir(), "vault-memrepo-list-"));
-    repo = await VaultMemoryRepository.create({ root });
+    idx = await VaultVectorIndex.create({ root, dims: 1 });
+    repo = await VaultMemoryRepository.create({ root, index: idx });
   });
   afterEach(async () => {
+    await idx.close();
     await rm(root, { recursive: true, force: true });
   });
 
@@ -406,78 +412,17 @@ describe("VaultMemoryRepository — listings", () => {
   });
 });
 
-describe("VaultMemoryRepository — vector stubs throw NotImplementedError", () => {
-  let root: string;
-  let repo: VaultMemoryRepository;
-  beforeEach(async () => {
-    root = await mkdtemp(join(tmpdir(), "vault-memrepo-stubs-"));
-    repo = await VaultMemoryRepository.create({ root });
-  });
-  afterEach(async () => {
-    await rm(root, { recursive: true, force: true });
-  });
-
-  it("search throws NotImplementedError with statusHint 501", async () => {
-    await expect(
-      repo.search({
-        embedding: [0],
-        project_id: "p",
-        workspace_id: "ws",
-        scope: ["workspace"],
-      }),
-    ).rejects.toSatisfy((err: unknown) => {
-      return (
-        err instanceof NotImplementedError &&
-        (err as NotImplementedError).statusHint === 501 &&
-        (err as Error).message.includes("search")
-      );
-    });
-  });
-
-  it("findDuplicates throws NotImplementedError", async () => {
-    await expect(
-      repo.findDuplicates({
-        embedding: [0],
-        projectId: "p",
-        workspaceId: "ws",
-        scope: "workspace",
-        userId: "u",
-        threshold: 0.9,
-      }),
-    ).rejects.toBeInstanceOf(NotImplementedError);
-  });
-
-  it("findPairwiseSimilar throws NotImplementedError", async () => {
-    await expect(
-      repo.findPairwiseSimilar({
-        projectId: "p",
-        workspaceId: "ws",
-        scope: "workspace",
-        threshold: 0.9,
-      }),
-    ).rejects.toBeInstanceOf(NotImplementedError);
-  });
-
-  it("listWithEmbeddings throws NotImplementedError", async () => {
-    await expect(
-      repo.listWithEmbeddings({
-        projectId: "p",
-        workspaceId: "ws",
-        scope: "workspace",
-        limit: 10,
-      }),
-    ).rejects.toBeInstanceOf(NotImplementedError);
-  });
-});
-
 describe("VaultMemoryRepository — list validation", () => {
   let root: string;
+  let idx: VaultVectorIndex;
   let repo: VaultMemoryRepository;
   beforeEach(async () => {
     root = await mkdtemp(join(tmpdir(), "vault-memrepo-validate-"));
-    repo = await VaultMemoryRepository.create({ root });
+    idx = await VaultVectorIndex.create({ root, dims: 1 });
+    repo = await VaultMemoryRepository.create({ root, index: idx });
   });
   afterEach(async () => {
+    await idx.close();
     await rm(root, { recursive: true, force: true });
   });
 

--- a/tests/unit/backend/vault/vector/hash.test.ts
+++ b/tests/unit/backend/vault/vector/hash.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { contentHash } from "../../../../../src/backend/vault/vector/hash.js";
+
+describe("contentHash", () => {
+  it("is deterministic for equal content", () => {
+    expect(contentHash("hello")).toBe(contentHash("hello"));
+  });
+
+  it("differs for different content", () => {
+    expect(contentHash("hello")).not.toBe(contentHash("world"));
+  });
+
+  it("is a 64-char hex string (sha256)", () => {
+    expect(contentHash("x")).toMatch(/^[0-9a-f]{64}$/);
+  });
+});

--- a/tests/unit/backend/vault/vector/lance-index.test.ts
+++ b/tests/unit/backend/vault/vector/lance-index.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { VaultVectorIndex } from "../../../../../src/backend/vault/vector/lance-index.js";
+
+describe("VaultVectorIndex — upsert + countRows", () => {
+  let root: string;
+  let idx: VaultVectorIndex;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "lance-test-"));
+    idx = await VaultVectorIndex.create({ root, dims: 4 });
+  });
+  afterEach(async () => {
+    await idx.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("upserts rows and counts them", async () => {
+    await idx.upsert([
+      {
+        id: "a",
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: "workspace",
+        author: "u",
+        title: "t",
+        archived: false,
+        content_hash: "h1",
+        vector: [0.1, 0.2, 0.3, 0.4],
+      },
+    ]);
+    expect(await idx.countRows()).toBe(1);
+  });
+
+  it("upsert on the same id replaces the previous row", async () => {
+    const base = {
+      project_id: "p1",
+      workspace_id: "ws1",
+      scope: "workspace" as const,
+      author: "u",
+      title: "t",
+      archived: false,
+      content_hash: "h",
+      vector: [0, 0, 0, 0],
+    };
+    await idx.upsert([{ id: "a", ...base, content_hash: "h1" }]);
+    await idx.upsert([{ id: "a", ...base, content_hash: "h2" }]);
+    expect(await idx.countRows()).toBe(1);
+  });
+
+  it("rejects a vector with the wrong dimension", async () => {
+    await expect(
+      idx.upsert([
+        {
+          id: "a",
+          project_id: "p1",
+          workspace_id: "ws1",
+          scope: "workspace",
+          author: "u",
+          title: "t",
+          archived: false,
+          content_hash: "h",
+          vector: [0, 0, 0],
+        },
+      ]),
+    ).rejects.toThrow(/dimension mismatch/);
+  });
+});

--- a/tests/unit/backend/vault/vector/lance-index.test.ts
+++ b/tests/unit/backend/vault/vector/lance-index.test.ts
@@ -156,3 +156,79 @@ describe("VaultVectorIndex — search", () => {
     expect(hits).toEqual([]);
   });
 });
+
+describe("VaultVectorIndex — findDuplicates", () => {
+  let root: string;
+  let idx: VaultVectorIndex;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "lance-test-"));
+    idx = await VaultVectorIndex.create({ root, dims: 3 });
+    await idx.upsert([
+      {
+        id: "a",
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: "workspace",
+        author: "u1",
+        title: "A",
+        archived: false,
+        content_hash: "h",
+        vector: [1, 0, 0],
+      },
+      {
+        id: "u",
+        project_id: "p1",
+        workspace_id: null,
+        scope: "user",
+        author: "u1",
+        title: "U",
+        archived: false,
+        content_hash: "h",
+        vector: [1, 0, 0],
+      },
+    ]);
+  });
+  afterEach(async () => {
+    await idx.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("workspace-scope dedup only checks workspace memories", async () => {
+    const hits = await idx.findDuplicates({
+      embedding: [1, 0, 0],
+      projectId: "p1",
+      workspaceId: "ws1",
+      scope: "workspace",
+      userId: "u1",
+      threshold: 0.5,
+    });
+    expect(hits.map((h) => h.id)).toEqual(["a"]);
+  });
+
+  it("user-scope dedup checks both the workspace and user slices (D-16)", async () => {
+    const hits = await idx.findDuplicates({
+      embedding: [1, 0, 0],
+      projectId: "p1",
+      workspaceId: "ws1",
+      scope: "user",
+      userId: "u1",
+      threshold: 0.5,
+    });
+    // limit(1) — takes whichever ranks first. Any surfaced row must be
+    // one of the two near-identical vectors; pg returns the same.
+    expect(hits).toHaveLength(1);
+    expect(["a", "u"]).toContain(hits[0].id);
+  });
+
+  it("below threshold returns empty", async () => {
+    const hits = await idx.findDuplicates({
+      embedding: [0, 0, 1],
+      projectId: "p1",
+      workspaceId: "ws1",
+      scope: "workspace",
+      userId: "u1",
+      threshold: 0.9,
+    });
+    expect(hits).toEqual([]);
+  });
+});

--- a/tests/unit/backend/vault/vector/lance-index.test.ts
+++ b/tests/unit/backend/vault/vector/lance-index.test.ts
@@ -303,3 +303,76 @@ describe("VaultVectorIndex — findPairwiseSimilar", () => {
     expect(pairs).toEqual([]);
   });
 });
+
+describe("VaultVectorIndex — listEmbeddings + markArchived + upsertMetaOnly", () => {
+  let root: string;
+  let idx: VaultVectorIndex;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "lance-test-"));
+    idx = await VaultVectorIndex.create({ root, dims: 3 });
+    await idx.upsert([
+      {
+        id: "a",
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: "workspace",
+        author: "u",
+        title: "A",
+        archived: false,
+        content_hash: "h",
+        vector: [1, 0, 0],
+      },
+      {
+        id: "b",
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: "workspace",
+        author: "u",
+        title: "B",
+        archived: false,
+        content_hash: "h",
+        vector: [0, 1, 0],
+      },
+    ]);
+  });
+  afterEach(async () => {
+    await idx.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("listEmbeddings returns ids with vectors, excludes archived", async () => {
+    await idx.markArchived("b");
+    const list = await idx.listEmbeddings({
+      projectId: "p1",
+      workspaceId: "ws1",
+      scope: "workspace",
+      userId: null,
+      limit: 10,
+    });
+    expect(list.map((r) => r.id)).toEqual(["a"]);
+    expect(list[0].vector).toHaveLength(3);
+    expect(list[0].vector[0]).toBeCloseTo(1, 5);
+  });
+
+  it("upsertMetaOnly preserves the existing vector", async () => {
+    await idx.upsertMetaOnly({
+      id: "a",
+      project_id: "p1",
+      workspace_id: "ws1",
+      scope: "workspace",
+      author: "u",
+      title: "A-renamed",
+      archived: false,
+    });
+    const list = await idx.listEmbeddings({
+      projectId: "p1",
+      workspaceId: "ws1",
+      scope: "workspace",
+      userId: null,
+      limit: 10,
+    });
+    const a = list.find((r) => r.id === "a")!;
+    expect(a.vector[0]).toBeCloseTo(1, 5);
+    expect(a.vector[1]).toBeCloseTo(0, 5);
+  });
+});

--- a/tests/unit/backend/vault/vector/lance-index.test.ts
+++ b/tests/unit/backend/vault/vector/lance-index.test.ts
@@ -67,3 +67,92 @@ describe("VaultVectorIndex — upsert + countRows", () => {
     ).rejects.toThrow(/dimension mismatch/);
   });
 });
+
+describe("VaultVectorIndex — search", () => {
+  let root: string;
+  let idx: VaultVectorIndex;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "lance-test-"));
+    idx = await VaultVectorIndex.create({ root, dims: 3 });
+    await idx.upsert([
+      {
+        id: "a",
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: "workspace",
+        author: "u",
+        title: "A",
+        archived: false,
+        content_hash: "h",
+        vector: [1, 0, 0],
+      },
+      {
+        id: "b",
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: "workspace",
+        author: "u",
+        title: "B",
+        archived: false,
+        content_hash: "h",
+        vector: [0, 1, 0],
+      },
+      {
+        id: "c",
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: "workspace",
+        author: "u",
+        title: "C",
+        archived: true,
+        content_hash: "h",
+        vector: [1, 0, 0],
+      },
+    ]);
+  });
+  afterEach(async () => {
+    await idx.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("returns rows ordered by cosine similarity, excluding archived", async () => {
+    const hits = await idx.search({
+      embedding: [1, 0, 0],
+      projectId: "p1",
+      workspaceId: "ws1",
+      scope: ["workspace"],
+      userId: null,
+      limit: 10,
+      minSimilarity: 0,
+    });
+    expect(hits.map((h) => h.id)).toEqual(["a", "b"]);
+    expect(hits[0].relevance).toBeCloseTo(1, 5);
+    expect(hits[1].relevance).toBeCloseTo(0, 5);
+  });
+
+  it("respects minSimilarity threshold", async () => {
+    const hits = await idx.search({
+      embedding: [1, 0, 0],
+      projectId: "p1",
+      workspaceId: "ws1",
+      scope: ["workspace"],
+      userId: null,
+      limit: 10,
+      minSimilarity: 0.5,
+    });
+    expect(hits.map((h) => h.id)).toEqual(["a"]);
+  });
+
+  it("returns empty when scope list resolves to no clauses", async () => {
+    const hits = await idx.search({
+      embedding: [1, 0, 0],
+      projectId: "p1",
+      workspaceId: null, // workspace scope requested with no ws → skipped
+      scope: ["workspace"],
+      userId: null,
+      limit: 10,
+      minSimilarity: 0,
+    });
+    expect(hits).toEqual([]);
+  });
+});

--- a/tests/unit/backend/vault/vector/lance-index.test.ts
+++ b/tests/unit/backend/vault/vector/lance-index.test.ts
@@ -232,3 +232,74 @@ describe("VaultVectorIndex — findDuplicates", () => {
     expect(hits).toEqual([]);
   });
 });
+
+describe("VaultVectorIndex — findPairwiseSimilar", () => {
+  let root: string;
+  let idx: VaultVectorIndex;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "lance-test-"));
+    idx = await VaultVectorIndex.create({ root, dims: 3 });
+    await idx.upsert([
+      {
+        id: "a",
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: "workspace",
+        author: "u",
+        title: "A",
+        archived: false,
+        content_hash: "h",
+        vector: [1, 0, 0],
+      },
+      {
+        id: "b",
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: "workspace",
+        author: "u",
+        title: "B",
+        archived: false,
+        content_hash: "h",
+        vector: [0.99, 0.01, 0],
+      },
+      {
+        id: "c",
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: "workspace",
+        author: "u",
+        title: "C",
+        archived: false,
+        content_hash: "h",
+        vector: [0, 1, 0],
+      },
+    ]);
+  });
+  afterEach(async () => {
+    await idx.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("returns one entry per near-duplicate pair with a < b", async () => {
+    const pairs = await idx.findPairwiseSimilar({
+      projectId: "p1",
+      workspaceId: "ws1",
+      scope: "workspace",
+      threshold: 0.9,
+    });
+    expect(pairs).toHaveLength(1);
+    expect(pairs[0].memory_a_id).toBe("a");
+    expect(pairs[0].memory_b_id).toBe("b");
+    expect(pairs[0].similarity).toBeGreaterThan(0.9);
+  });
+
+  it("returns empty when nothing is above threshold", async () => {
+    const pairs = await idx.findPairwiseSimilar({
+      projectId: "p1",
+      workspaceId: "ws1",
+      scope: "workspace",
+      threshold: 0.99999,
+    });
+    expect(pairs).toEqual([]);
+  });
+});

--- a/tests/unit/backend/vault/vector/schema.test.ts
+++ b/tests/unit/backend/vault/vector/schema.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import * as arrow from "apache-arrow";
+import { memorySchema } from "../../../../../src/backend/vault/vector/schema.js";
+
+describe("memorySchema", () => {
+  it("has the expected fields", () => {
+    const s = memorySchema(768);
+    const names = s.fields.map((f) => f.name).sort();
+    expect(names).toEqual([
+      "archived",
+      "author",
+      "content_hash",
+      "id",
+      "project_id",
+      "scope",
+      "title",
+      "vector",
+      "workspace_id",
+    ]);
+  });
+
+  it("pins the vector dimension", () => {
+    const s = memorySchema(4);
+    const f = s.fields.find((x) => x.name === "vector")!;
+    expect(f.type).toBeInstanceOf(arrow.FixedSizeList);
+    expect((f.type as arrow.FixedSizeList).listSize).toBe(4);
+  });
+});

--- a/tests/unit/backend/vault/vector/smoke.test.ts
+++ b/tests/unit/backend/vault/vector/smoke.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as lancedb from "@lancedb/lancedb";
+
+describe("@lancedb/lancedb smoke", () => {
+  let root: string | null = null;
+  afterEach(async () => {
+    if (root) await rm(root, { recursive: true, force: true });
+    root = null;
+  });
+
+  it("connects, creates a table, queries it", async () => {
+    root = await mkdtemp(join(tmpdir(), "lance-smoke-"));
+    const db = await lancedb.connect(root);
+    const table = await db.createTable("t", [
+      { id: "a", vector: [0.1, 0.2, 0.3] },
+      { id: "b", vector: [0.9, 0.8, 0.7] },
+    ]);
+    const got = await table
+      .search([0.1, 0.2, 0.3])
+      .distanceType("cosine")
+      .limit(2)
+      .toArray();
+    expect(got.map((r) => r.id)).toEqual(["a", "b"]);
+  });
+});

--- a/tests/unit/backend/vault/vector/smoke.test.ts
+++ b/tests/unit/backend/vault/vector/smoke.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import * as lancedb from "@lancedb/lancedb";
+import type { VectorQuery } from "@lancedb/lancedb";
 
 describe("@lancedb/lancedb smoke", () => {
   let root: string | null = null;
@@ -18,11 +19,10 @@ describe("@lancedb/lancedb smoke", () => {
       { id: "a", vector: [0.1, 0.2, 0.3] },
       { id: "b", vector: [0.9, 0.8, 0.7] },
     ]);
-    const got = await table
-      .search([0.1, 0.2, 0.3])
+    const got = await (table.search([0.1, 0.2, 0.3]) as VectorQuery)
       .distanceType("cosine")
       .limit(2)
       .toArray();
-    expect(got.map((r) => r.id)).toEqual(["a", "b"]);
+    expect(got.map((r: Record<string, unknown>) => r.id)).toEqual(["a", "b"]);
   });
 });


### PR DESCRIPTION
## Summary

- Add `VaultVectorIndex` (`src/backend/vault/vector/`) wrapping `@lancedb/lancedb` (file-based, cosine, plain scan).
- Wire the index into `VaultMemoryRepository` on `create` / `update` / `archive`. `update` with an embedding re-upserts the vector; without, it touches metadata only. `archive` flips the lance row's `archived` flag.
- Replace the four `NotImplementedError` stubs with real `search` / `findDuplicates` / `findPairwiseSimilar` / `listWithEmbeddings` implementations. Findings are assembled by querying lance for ids + reading the markdown vault for the full `Memory`.
- `VaultBackendConfig` now requires `embeddingDimensions`; the factory threads it through from `src/config.ts`. Lance table schema pins dimension on first write.
- Parameterized contract tests exercise the four vector methods against both pg + vault.
- Parity integration test: 500 random memories, 20 random queries, top-10 overlap ≥ 95% between pg and vault.

Ref: `docs/superpowers/plans/2026-04-22-vault-backend-phase-3-vector-index.md`

## Out of scope (deferred)

- Git commit/push of lance writes — lance lives under `.agent-brain/` (runtime only).
- Reindex-on-boot from vault scan — Phase 5 watcher.
- HNSW / IVF-PQ index tuning — plain scan meets the parity bar at Phase 3 scale.

## Test plan

- [x] \`npx vitest run tests/unit/backend/vault/vector\` — unit coverage (14 tests)
- [x] \`npx vitest run tests/contract/repositories/memory-repository-vector.test.ts\` — contract parity (10 tests)
- [x] \`npx vitest run tests/integration/vector-parity.test.ts\` — top-10 overlap ≥ 95%
- [x] \`npm test --run\` — 841 tests pass, no regressions
- [x] \`npx tsc --noEmit\` — typecheck clean
- [x] \`npm run lint\` — lint clean
- [x] \`npx prettier --check …\` — formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)