### PR TITLE
feat(vault): Phase 4a — git write-path integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,11 @@ DATABASE_URL=postgresql://agentic:agentic@localhost:5432/agent_brain
 # first boot if missing.
 AGENT_BRAIN_VAULT_ROOT=
 
+# Vault: commit user-scope memories to git alongside workspace/project
+# ones. Default false: users/ stays gitignored (privacy-first). Set
+# true only when the vault remote is private-per-user.
+AGENT_BRAIN_VAULT_TRACK_USERS=false
+
 # Embedding provider: titan | mock | ollama
 EMBEDDING_PROVIDER=ollama
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "pgvector": "^0.2.1",
         "postgres": "^3.4.8",
         "proper-lockfile": "^4.1.2",
+        "simple-git": "^3.36.0",
         "tsx": "^4.21.0",
         "zod": "^4.3.6"
       },
@@ -1903,6 +1904,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "license": "MIT"
+    },
     "node_modules/@lancedb/lancedb": {
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/@lancedb/lancedb/-/lancedb-0.27.2.tgz",
@@ -3617,6 +3633,21 @@
       "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@simple-git/args-pathspec": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@simple-git/args-pathspec/-/args-pathspec-1.0.3.tgz",
+      "integrity": "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==",
+      "license": "MIT"
+    },
+    "node_modules/@simple-git/argv-parser": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@simple-git/argv-parser/-/argv-parser-1.1.1.tgz",
+      "integrity": "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@simple-git/args-pathspec": "^1.0.3"
+      }
     },
     "node_modules/@smithy/abort-controller": {
       "version": "4.2.12",
@@ -8563,6 +8594,23 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/simple-git": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.36.0.tgz",
+      "integrity": "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "@simple-git/args-pathspec": "^1.0.3",
+        "@simple-git/argv-parser": "^1.1.0",
+        "debug": "^4.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
     },
     "node_modules/source-map": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "pgvector": "^0.2.1",
     "postgres": "^3.4.8",
     "proper-lockfile": "^4.1.2",
+    "simple-git": "^3.36.0",
     "tsx": "^4.21.0",
     "zod": "^4.3.6"
   },

--- a/src/backend/factory.ts
+++ b/src/backend/factory.ts
@@ -7,6 +7,7 @@ export interface BackendConfig {
   backend: BackendName;
   databaseUrl: string;
   vaultRoot: string;
+  vaultTrackUsersInGit?: boolean;
   embeddingDimensions: number;
 }
 
@@ -25,6 +26,7 @@ export async function createBackend(
       return VaultBackend.create({
         root: config.vaultRoot,
         embeddingDimensions: config.embeddingDimensions,
+        trackUsersInGit: config.vaultTrackUsersInGit ?? false,
       });
     default: {
       // Exhaustiveness + runtime guard for an env-var typo that slipped past zod.

--- a/src/backend/vault/git/bootstrap.ts
+++ b/src/backend/vault/git/bootstrap.ts
@@ -1,0 +1,65 @@
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { simpleGit } from "simple-git";
+import { mergeGitignore } from "./gitignore-merge.js";
+
+export interface EnsureVaultGitOptions {
+  root: string;
+  trackUsers: boolean;
+}
+
+const RUNTIME_IGNORES = [
+  ".agent-brain/",
+  "_sessions/",
+  "_session-tracking/",
+  "_scheduler-state.json",
+  "_audit/",
+];
+
+const GITATTRIBUTES = "*.md merge=union\n";
+
+export async function ensureVaultGit(
+  opts: EnsureVaultGitOptions,
+): Promise<void> {
+  const git = simpleGit({ baseDir: opts.root });
+  if (!(await git.checkIsRepo())) {
+    await git.init();
+  }
+  await ensureGitignore(opts.root, opts.trackUsers);
+  await ensureGitattributes(opts.root);
+}
+
+async function ensureGitignore(
+  root: string,
+  trackUsers: boolean,
+): Promise<void> {
+  const path = join(root, ".gitignore");
+  const required = trackUsers
+    ? RUNTIME_IGNORES
+    : [...RUNTIME_IGNORES, "users/"];
+  const existing = await readOrEmpty(path);
+  const merged = mergeGitignore(existing, required);
+  if (merged !== existing) {
+    await writeFile(path, merged, "utf8");
+  }
+}
+
+async function ensureGitattributes(root: string): Promise<void> {
+  const path = join(root, ".gitattributes");
+  const existing = await readOrEmpty(path);
+  if (existing.includes("*.md merge=union")) return;
+  const merged =
+    existing === ""
+      ? GITATTRIBUTES
+      : existing + (existing.endsWith("\n") ? "" : "\n") + GITATTRIBUTES;
+  await writeFile(path, merged, "utf8");
+}
+
+async function readOrEmpty(path: string): Promise<string> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (err: unknown) {
+    if ((err as { code?: string }).code === "ENOENT") return "";
+    throw err;
+  }
+}

--- a/src/backend/vault/git/bootstrap.ts
+++ b/src/backend/vault/git/bootstrap.ts
@@ -2,6 +2,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { simpleGit } from "simple-git";
 import { mergeGitignore } from "./gitignore-merge.js";
+import { scrubGitEnv } from "./env.js";
 
 export interface EnsureVaultGitOptions {
   root: string;
@@ -21,7 +22,7 @@ const GITATTRIBUTES = "*.md merge=union\n";
 export async function ensureVaultGit(
   opts: EnsureVaultGitOptions,
 ): Promise<void> {
-  const git = simpleGit({ baseDir: opts.root });
+  const git = simpleGit({ baseDir: opts.root }).env(scrubGitEnv());
   if (!(await git.checkIsRepo())) {
     await git.init();
   }

--- a/src/backend/vault/git/bootstrap.ts
+++ b/src/backend/vault/git/bootstrap.ts
@@ -1,6 +1,7 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { simpleGit } from "simple-git";
+import { simpleGit, type SimpleGit } from "simple-git";
+import { DomainError } from "../../../utils/errors.js";
 import { mergeGitignore } from "./gitignore-merge.js";
 import { scrubGitEnv } from "./env.js";
 
@@ -17,43 +18,127 @@ const RUNTIME_IGNORES = [
   "_audit/",
 ];
 
-const GITATTRIBUTES = "*.md merge=union\n";
+const GITATTRIBUTES_RULE = "*.md merge=union";
 
 export async function ensureVaultGit(
   opts: EnsureVaultGitOptions,
 ): Promise<void> {
   const git = simpleGit({ baseDir: opts.root }).env(scrubGitEnv());
-  if (!(await git.checkIsRepo())) {
+  const wasRepo = await git.checkIsRepo();
+  if (!wasRepo) {
     await git.init();
   }
-  await ensureGitignore(opts.root, opts.trackUsers);
-  await ensureGitattributes(opts.root);
+  // Commits need a user.email/user.name pair. On docker, CI, or a
+  // fresh dev machine neither may be set globally, which would make
+  // every stageAndCommit fail silently. Set repo-local fallbacks but
+  // never override an operator-configured identity.
+  await ensureIdentity(git);
+  const ignoreChanged = await ensureGitignore(opts.root, opts.trackUsers);
+  const attrChanged = await ensureGitattributes(opts.root);
+  await assertRequiredRules(opts.root, opts.trackUsers);
+  // Commit bootstrap files so a clone of the vault carries the
+  // privacy-critical `users/` rule. Without this, the files stay
+  // untracked and a clone has no .gitignore at all.
+  if (!wasRepo || ignoreChanged || attrChanged) {
+    await commitBootstrap(git);
+  }
+}
+
+async function ensureIdentity(git: SimpleGit): Promise<void> {
+  await ensureConfig(git, "user.email", "agent-brain@localhost");
+  await ensureConfig(git, "user.name", "agent-brain");
+}
+
+async function ensureConfig(
+  git: SimpleGit,
+  key: string,
+  fallback: string,
+): Promise<void> {
+  try {
+    const { value } = await git.getConfig(key);
+    if (value) return;
+  } catch {
+    // `git config --get <key>` exits 1 when unset — treat as unset.
+  }
+  await git.addConfig(key, fallback);
 }
 
 async function ensureGitignore(
   root: string,
   trackUsers: boolean,
-): Promise<void> {
+): Promise<boolean> {
   const path = join(root, ".gitignore");
   const required = trackUsers
     ? RUNTIME_IGNORES
     : [...RUNTIME_IGNORES, "users/"];
   const existing = await readOrEmpty(path);
   const merged = mergeGitignore(existing, required);
-  if (merged !== existing) {
-    await writeFile(path, merged, "utf8");
+  if (merged === existing) return false;
+  await writeFile(path, merged, "utf8");
+  return true;
+}
+
+async function ensureGitattributes(root: string): Promise<boolean> {
+  const path = join(root, ".gitattributes");
+  const existing = await readOrEmpty(path);
+  if (hasActiveRule(existing, GITATTRIBUTES_RULE)) return false;
+  const trailingNewline =
+    existing === "" || existing.endsWith("\n") ? "" : "\n";
+  const merged = existing + trailingNewline + `${GITATTRIBUTES_RULE}\n`;
+  await writeFile(path, merged, "utf8");
+  return true;
+}
+
+// Line-based check so the rule inside a comment like
+// `# don't use *.md merge=union` doesn't count as present.
+function hasActiveRule(body: string, rule: string): boolean {
+  for (const line of body.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed === "" || trimmed.startsWith("#")) continue;
+    if (trimmed === rule) return true;
+  }
+  return false;
+}
+
+// Re-read after write to confirm every required rule actually landed
+// in the bytes on disk. A bug in mergeGitignore or a racing writer
+// could leave the privacy rule absent; fail loudly rather than leak.
+async function assertRequiredRules(
+  root: string,
+  trackUsers: boolean,
+): Promise<void> {
+  const ignoreBody = await readOrEmpty(join(root, ".gitignore"));
+  const ignoreLines = new Set(ignoreBody.split(/\r?\n/).map((l) => l.trim()));
+  const required = trackUsers
+    ? RUNTIME_IGNORES
+    : [...RUNTIME_IGNORES, "users/"];
+  for (const rule of required) {
+    if (!ignoreLines.has(rule)) {
+      throw new DomainError(
+        `vault bootstrap failed: .gitignore is missing rule '${rule}'`,
+        "VAULT_BOOTSTRAP_FAILED",
+        500,
+      );
+    }
+  }
+  const attrBody = await readOrEmpty(join(root, ".gitattributes"));
+  if (!hasActiveRule(attrBody, GITATTRIBUTES_RULE)) {
+    throw new DomainError(
+      `vault bootstrap failed: .gitattributes is missing rule '${GITATTRIBUTES_RULE}'`,
+      "VAULT_BOOTSTRAP_FAILED",
+      500,
+    );
   }
 }
 
-async function ensureGitattributes(root: string): Promise<void> {
-  const path = join(root, ".gitattributes");
-  const existing = await readOrEmpty(path);
-  if (existing.includes("*.md merge=union")) return;
-  const merged =
-    existing === ""
-      ? GITATTRIBUTES
-      : existing + (existing.endsWith("\n") ? "" : "\n") + GITATTRIBUTES;
-  await writeFile(path, merged, "utf8");
+async function commitBootstrap(git: SimpleGit): Promise<void> {
+  await git.add([".gitignore", ".gitattributes"]);
+  const status = await git.status();
+  if (status.staged.length === 0 && status.created.length === 0) return;
+  await git.commit(
+    "[agent-brain] bootstrap: initialize vault structure\n\nAB-Action: bootstrap\nAB-Actor: system",
+    [".gitignore", ".gitattributes"],
+  );
 }
 
 async function readOrEmpty(path: string): Promise<string> {

--- a/src/backend/vault/git/env.ts
+++ b/src/backend/vault/git/env.ts
@@ -1,0 +1,22 @@
+// Returns a copy of process.env with the GIT_* discovery variables
+// removed. When these are set (e.g. by husky pre-commit hooks, rebase,
+// or parent git commands), they take precedence over a child process's
+// cwd / `git -C` argument — which is how a test that configures
+// baseDir to a tmpdir can silently write commits into the outer repo.
+// Callers that spawn git must use this so the configured root wins.
+//
+// PAGER is also cleared: simple-git refuses to run with PAGER set
+// unless `allowUnsafePager` is enabled, and the vault backend never
+// needs interactive paging.
+export function scrubGitEnv(
+  base: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const copy: NodeJS.ProcessEnv = { ...base };
+  for (const key of Object.keys(copy)) {
+    if (key.startsWith("GIT_")) delete copy[key];
+  }
+  delete copy.PAGER;
+  delete copy.EDITOR;
+  delete copy.VISUAL;
+  return copy;
+}

--- a/src/backend/vault/git/git-ops.ts
+++ b/src/backend/vault/git/git-ops.ts
@@ -1,5 +1,6 @@
 import { simpleGit, type SimpleGit } from "simple-git";
 import { formatTrailers } from "./trailers.js";
+import { scrubGitEnv } from "./env.js";
 import type { CommitTrailer, GitOps } from "./types.js";
 
 export interface GitOpsConfig {
@@ -9,7 +10,11 @@ export interface GitOpsConfig {
 export class GitOpsImpl implements GitOps {
   private readonly git: SimpleGit;
   constructor(private readonly cfg: GitOpsConfig) {
-    this.git = simpleGit({ baseDir: cfg.root });
+    // Inherited GIT_DIR / GIT_WORK_TREE (set by husky hooks, rebase, or
+    // parent git commands) silently override baseDir and make every
+    // operation target the outer repository. Strip them so cfg.root
+    // always wins.
+    this.git = simpleGit({ baseDir: cfg.root }).env(scrubGitEnv());
   }
 
   async isRepo(): Promise<boolean> {

--- a/src/backend/vault/git/git-ops.ts
+++ b/src/backend/vault/git/git-ops.ts
@@ -1,0 +1,48 @@
+import { simpleGit, type SimpleGit } from "simple-git";
+import { formatTrailers } from "./trailers.js";
+import type { CommitTrailer, GitOps } from "./types.js";
+
+export interface GitOpsConfig {
+  root: string;
+}
+
+export class GitOpsImpl implements GitOps {
+  private readonly git: SimpleGit;
+  constructor(private readonly cfg: GitOpsConfig) {
+    this.git = simpleGit({ baseDir: cfg.root });
+  }
+
+  async isRepo(): Promise<boolean> {
+    return await this.git.checkIsRepo();
+  }
+
+  async init(): Promise<void> {
+    if (await this.isRepo()) return;
+    await this.git.init();
+  }
+
+  async stageAndCommit(
+    paths: string[],
+    subject: string,
+    trailer: CommitTrailer,
+  ): Promise<void> {
+    if (paths.length === 0) {
+      throw new Error("stageAndCommit: paths must be non-empty");
+    }
+    await this.git.add(paths);
+    const status = await this.git.status();
+    if (status.staged.length === 0 && status.created.length === 0) {
+      // Staged set is empty — either nothing changed, or the file was
+      // identical to HEAD. Treat as an error so the caller sees why
+      // the commit did not happen (tests cover the duplicate-write case).
+      throw new Error("nothing to commit");
+    }
+    const body = formatTrailers(trailer);
+    await this.git.commit(`${subject}\n\n${body}`);
+  }
+
+  async status(): Promise<{ clean: boolean }> {
+    const s = await this.git.status();
+    return { clean: s.files.length === 0 };
+  }
+}

--- a/src/backend/vault/git/git-ops.ts
+++ b/src/backend/vault/git/git-ops.ts
@@ -1,14 +1,27 @@
 import { simpleGit, type SimpleGit } from "simple-git";
 import { formatTrailers } from "./trailers.js";
 import { scrubGitEnv } from "./env.js";
-import type { CommitTrailer, GitOps } from "./types.js";
+import {
+  VaultGitNothingToCommitError,
+  type CommitTrailer,
+  type GitOps,
+} from "./types.js";
 
 export interface GitOpsConfig {
   root: string;
 }
 
 export class GitOpsImpl implements GitOps {
+  readonly enabled = true;
   private readonly git: SimpleGit;
+  // Process-wide serialization of git index operations. Two writers
+  // on different markdown files share one .git/index; without a
+  // mutex, `git add A` + `git add B` + `git commit` can land both
+  // files under the first writer's trailer (cross-attribution) or
+  // race on `.git/index.lock`. The per-file lock in withFileLock
+  // only protects markdown parity, not the index.
+  private chain: Promise<unknown> = Promise.resolve();
+
   constructor(private readonly cfg: GitOpsConfig) {
     // Inherited GIT_DIR / GIT_WORK_TREE (set by husky hooks, rebase, or
     // parent git commands) silently override baseDir and make every
@@ -34,20 +47,32 @@ export class GitOpsImpl implements GitOps {
     if (paths.length === 0) {
       throw new Error("stageAndCommit: paths must be non-empty");
     }
-    await this.git.add(paths);
-    const status = await this.git.status();
-    if (status.staged.length === 0 && status.created.length === 0) {
-      // Staged set is empty — either nothing changed, or the file was
-      // identical to HEAD. Treat as an error so the caller sees why
-      // the commit did not happen (tests cover the duplicate-write case).
-      throw new Error("nothing to commit");
-    }
-    const body = formatTrailers(trailer);
-    await this.git.commit(`${subject}\n\n${body}`);
+    return this.#serialize(async () => {
+      await this.git.add(paths);
+      const status = await this.git.status();
+      if (status.staged.length === 0 && status.created.length === 0) {
+        throw new VaultGitNothingToCommitError(paths);
+      }
+      const body = formatTrailers(trailer);
+      // Scope the commit to the explicit paths so a concurrent writer
+      // that sneaks into the index between our add and commit can't
+      // land its file under our trailer.
+      await this.git.commit(`${subject}\n\n${body}`, paths);
+    });
   }
 
   async status(): Promise<{ clean: boolean }> {
     const s = await this.git.status();
     return { clean: s.files.length === 0 };
+  }
+
+  // Serializes fn against every other call on this instance so
+  // successive `git add` / `git commit` pairs run without interleaving.
+  #serialize<T>(fn: () => Promise<T>): Promise<T> {
+    const next = this.chain.then(fn, fn);
+    // Preserve chain ordering even if fn rejects — swallow the error
+    // here; the outer `next` still rejects to the caller.
+    this.chain = next.catch(() => undefined);
+    return next;
   }
 }

--- a/src/backend/vault/git/gitignore-merge.ts
+++ b/src/backend/vault/git/gitignore-merge.ts
@@ -1,0 +1,17 @@
+// Returns a gitignore body that includes all `required` rules, preserving
+// existing lines and adding only missing ones. Pure + idempotent.
+export function mergeGitignore(existing: string, required: string[]): string {
+  const existingLines = existing.split(/\r?\n/);
+  const present = new Set(existingLines.map((l) => l.trim()).filter(Boolean));
+  const missing = required.filter((r) => !present.has(r.trim()));
+  if (missing.length === 0) {
+    return existing.endsWith("\n") || existing === ""
+      ? existing
+      : existing + "\n";
+  }
+  const sep =
+    existing === ""
+      ? ""
+      : (existing.endsWith("\n") ? "" : "\n") + "\n# added by agent-brain\n";
+  return existing + sep + missing.join("\n") + "\n";
+}

--- a/src/backend/vault/git/trailers.ts
+++ b/src/backend/vault/git/trailers.ts
@@ -1,0 +1,29 @@
+import type { CommitTrailer } from "./types.js";
+
+// Maps a CommitTrailer into git-interpret-trailers-compatible lines.
+// Newlines inside free-form fields (reason) are escaped as `\\n` so
+// the trailer block stays a single logical paragraph — git log parsers
+// in Phase 4c split on LF and rely on that.
+export function formatTrailers(trailer: CommitTrailer): string {
+  const lines: string[] = [`AB-Action: ${trailer.action}`];
+  if (trailer.action === "workspace_upsert") {
+    if (!trailer.workspaceId) {
+      throw new Error("workspaceId required for workspace_upsert");
+    }
+    lines.push(`AB-Workspace: ${trailer.workspaceId}`);
+  } else {
+    if (!trailer.memoryId) {
+      throw new Error(`memoryId required for action ${trailer.action}`);
+    }
+    lines.push(`AB-Memory: ${trailer.memoryId}`);
+  }
+  lines.push(`AB-Actor: ${trailer.actor}`);
+  if (trailer.reason != null && trailer.reason !== "") {
+    lines.push(`AB-Reason: ${encode(trailer.reason)}`);
+  }
+  return lines.join("\n");
+}
+
+function encode(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/\n/g, "\\n").replace(/\r/g, "\\r");
+}

--- a/src/backend/vault/git/types.ts
+++ b/src/backend/vault/git/types.ts
@@ -1,3 +1,5 @@
+import { DomainError } from "../../../utils/errors.js";
+
 export type CommitAction =
   | "created"
   | "updated"
@@ -19,6 +21,10 @@ export interface CommitTrailer {
 }
 
 export interface GitOps {
+  // False for the no-op implementation used by test backends that
+  // don't need a real git repo. Callers use this to skip privacy
+  // guards and other git-only invariants when no commit will land.
+  readonly enabled: boolean;
   isRepo(): Promise<boolean>;
   init(): Promise<void>;
   stageAndCommit(
@@ -29,7 +35,21 @@ export interface GitOps {
   status(): Promise<{ clean: boolean }>;
 }
 
+// Thrown by stageAndCommit when `git add` staged nothing (file unchanged
+// vs HEAD or path is gitignored). Callers can downgrade this case to
+// debug while still surfacing real git failures.
+export class VaultGitNothingToCommitError extends DomainError {
+  constructor(paths: string[]) {
+    super(
+      `nothing to commit for paths: ${paths.join(", ")}`,
+      "VAULT_GIT_NOTHING_TO_COMMIT",
+      500,
+    );
+  }
+}
+
 export class NoopGitOps implements GitOps {
+  readonly enabled = false;
   async isRepo(): Promise<boolean> {
     return false;
   }

--- a/src/backend/vault/git/types.ts
+++ b/src/backend/vault/git/types.ts
@@ -1,0 +1,43 @@
+export type CommitAction =
+  | "created"
+  | "updated"
+  | "archived"
+  | "verified"
+  | "commented"
+  | "flagged"
+  | "unflagged"
+  | "related"
+  | "unrelated"
+  | "workspace_upsert";
+
+export interface CommitTrailer {
+  action: CommitAction;
+  memoryId?: string;
+  workspaceId?: string;
+  actor: string;
+  reason?: string | null;
+}
+
+export interface GitOps {
+  isRepo(): Promise<boolean>;
+  init(): Promise<void>;
+  stageAndCommit(
+    paths: string[],
+    subject: string,
+    trailer: CommitTrailer,
+  ): Promise<void>;
+  status(): Promise<{ clean: boolean }>;
+}
+
+export class NoopGitOps implements GitOps {
+  async isRepo(): Promise<boolean> {
+    return false;
+  }
+  async init(): Promise<void> {}
+  async stageAndCommit(): Promise<void> {}
+  async status(): Promise<{ clean: boolean }> {
+    return { clean: true };
+  }
+}
+
+export const NOOP_GIT_OPS: GitOps = new NoopGitOps();

--- a/src/backend/vault/git/users-gitignore-invariant.ts
+++ b/src/backend/vault/git/users-gitignore-invariant.ts
@@ -1,0 +1,29 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { DomainError } from "../../../utils/errors.js";
+
+// Hard-fails a user-scope write if `.gitignore` no longer contains the
+// privacy rule that keeps users/ out of the shared remote. Spec: vault
+// backend §users — rule is load-bearing for privacy.
+export async function assertUsersIgnored(root: string): Promise<void> {
+  let body: string;
+  try {
+    body = await readFile(join(root, ".gitignore"), "utf8");
+  } catch (err: unknown) {
+    if ((err as { code?: string }).code === "ENOENT") {
+      throw new DomainError(
+        ".gitignore is missing — refusing user-scope write (privacy guard)",
+        "VAULT_USERS_NOT_IGNORED",
+        500,
+      );
+    }
+    throw err;
+  }
+  const rules = new Set(body.split(/\r?\n/).map((l) => l.trim()));
+  if (rules.has("users/") || rules.has("users/**")) return;
+  throw new DomainError(
+    ".gitignore missing 'users/' rule — refusing user-scope write (privacy guard)",
+    "VAULT_USERS_NOT_IGNORED",
+    500,
+  );
+}

--- a/src/backend/vault/index.ts
+++ b/src/backend/vault/index.ts
@@ -55,23 +55,37 @@ export class VaultBackend implements StorageBackend {
     private readonly vectorIndex: VaultVectorIndex,
     root: string,
     gitOps: GitOps,
+    trackUsersInGit: boolean,
   ) {
     this.memoryRepo = memoryRepo;
     this.workspaceRepo = new VaultWorkspaceRepository({ root, gitOps });
-    this.commentRepo = new VaultCommentRepository({ root, gitOps });
+    this.commentRepo = new VaultCommentRepository({
+      root,
+      gitOps,
+      trackUsersInGit,
+    });
     this.sessionRepo = new VaultSessionTrackingRepository({ root });
     this.sessionLifecycleRepo = new VaultSessionRepository({ root });
     this.auditRepo = new VaultAuditRepository({ root });
-    this.flagRepo = new VaultFlagRepository({ root, gitOps });
-    this.relationshipRepo = new VaultRelationshipRepository({ root, gitOps });
+    this.flagRepo = new VaultFlagRepository({
+      root,
+      gitOps,
+      trackUsersInGit,
+    });
+    this.relationshipRepo = new VaultRelationshipRepository({
+      root,
+      gitOps,
+      trackUsersInGit,
+    });
     this.schedulerStateRepo = new VaultSchedulerStateRepository({ root });
   }
 
   static async create(cfg: VaultBackendConfig): Promise<VaultBackend> {
     await mkdir(cfg.root, { recursive: true });
+    const trackUsersInGit = cfg.trackUsersInGit ?? false;
     await ensureVaultGit({
       root: cfg.root,
-      trackUsers: cfg.trackUsersInGit ?? false,
+      trackUsers: trackUsersInGit,
     });
     const gitOps: GitOps = new GitOpsImpl({ root: cfg.root });
     const vectorIndex = await VaultVectorIndex.create({
@@ -82,9 +96,15 @@ export class VaultBackend implements StorageBackend {
       root: cfg.root,
       index: vectorIndex,
       gitOps,
-      trackUsersInGit: cfg.trackUsersInGit ?? false,
+      trackUsersInGit,
     });
-    return new VaultBackend(memoryRepo, vectorIndex, cfg.root, gitOps);
+    return new VaultBackend(
+      memoryRepo,
+      vectorIndex,
+      cfg.root,
+      gitOps,
+      trackUsersInGit,
+    );
   }
 
   async close(): Promise<void> {

--- a/src/backend/vault/index.ts
+++ b/src/backend/vault/index.ts
@@ -9,6 +9,9 @@ import { VaultSessionRepository } from "./repositories/session-repository.js";
 import { VaultSessionTrackingRepository } from "./repositories/session-tracking-repository.js";
 import { VaultWorkspaceRepository } from "./repositories/workspace-repository.js";
 import { VaultVectorIndex } from "./vector/lance-index.js";
+import { ensureVaultGit } from "./git/bootstrap.js";
+import { GitOpsImpl } from "./git/git-ops.js";
+import type { GitOps } from "./git/types.js";
 import type { BackendName, StorageBackend } from "../types.js";
 import type {
   AuditRepository,
@@ -25,6 +28,10 @@ import type {
 export interface VaultBackendConfig {
   root: string;
   embeddingDimensions: number;
+  // When true, user-scope memories are committed to git alongside
+  // workspace/project ones. Default false — `users/` stays gitignored
+  // and its writes skip the commit step (privacy-first).
+  trackUsersInGit?: boolean;
 }
 
 // Markdown-vault backend. Composes the nine Vault* repositories backed
@@ -47,20 +54,26 @@ export class VaultBackend implements StorageBackend {
     memoryRepo: MemoryRepository,
     private readonly vectorIndex: VaultVectorIndex,
     root: string,
+    gitOps: GitOps,
   ) {
     this.memoryRepo = memoryRepo;
-    this.workspaceRepo = new VaultWorkspaceRepository({ root });
-    this.commentRepo = new VaultCommentRepository({ root });
+    this.workspaceRepo = new VaultWorkspaceRepository({ root, gitOps });
+    this.commentRepo = new VaultCommentRepository({ root, gitOps });
     this.sessionRepo = new VaultSessionTrackingRepository({ root });
     this.sessionLifecycleRepo = new VaultSessionRepository({ root });
     this.auditRepo = new VaultAuditRepository({ root });
-    this.flagRepo = new VaultFlagRepository({ root });
-    this.relationshipRepo = new VaultRelationshipRepository({ root });
+    this.flagRepo = new VaultFlagRepository({ root, gitOps });
+    this.relationshipRepo = new VaultRelationshipRepository({ root, gitOps });
     this.schedulerStateRepo = new VaultSchedulerStateRepository({ root });
   }
 
   static async create(cfg: VaultBackendConfig): Promise<VaultBackend> {
     await mkdir(cfg.root, { recursive: true });
+    await ensureVaultGit({
+      root: cfg.root,
+      trackUsers: cfg.trackUsersInGit ?? false,
+    });
+    const gitOps: GitOps = new GitOpsImpl({ root: cfg.root });
     const vectorIndex = await VaultVectorIndex.create({
       root: cfg.root,
       dims: cfg.embeddingDimensions,
@@ -68,8 +81,10 @@ export class VaultBackend implements StorageBackend {
     const memoryRepo = await VaultMemoryRepository.create({
       root: cfg.root,
       index: vectorIndex,
+      gitOps,
+      trackUsersInGit: cfg.trackUsersInGit ?? false,
     });
-    return new VaultBackend(memoryRepo, vectorIndex, cfg.root);
+    return new VaultBackend(memoryRepo, vectorIndex, cfg.root, gitOps);
   }
 
   async close(): Promise<void> {

--- a/src/backend/vault/repositories/comment-repository.ts
+++ b/src/backend/vault/repositories/comment-repository.ts
@@ -6,14 +6,19 @@ import { commitSubject, compareByCreatedAsc } from "./util.js";
 
 export interface VaultCommentConfig {
   root: string;
-  gitOps?: GitOps;
+  gitOps: GitOps;
+  trackUsersInGit?: boolean;
 }
 
 export class VaultCommentRepository implements CommentRepository {
   private readonly files: VaultMemoryFiles;
 
   constructor(cfg: VaultCommentConfig) {
-    this.files = new VaultMemoryFiles({ root: cfg.root, gitOps: cfg.gitOps });
+    this.files = new VaultMemoryFiles({
+      root: cfg.root,
+      gitOps: cfg.gitOps,
+      trackUsersInGit: cfg.trackUsersInGit ?? false,
+    });
   }
 
   async create(comment: {

--- a/src/backend/vault/repositories/comment-repository.ts
+++ b/src/backend/vault/repositories/comment-repository.ts
@@ -1,17 +1,19 @@
 import type { CommentRepository } from "../../../repositories/types.js";
 import type { Comment } from "../../../types/memory.js";
+import type { GitOps } from "../git/types.js";
 import { VaultMemoryFiles } from "./memory-files.js";
-import { compareByCreatedAsc } from "./util.js";
+import { commitSubject, compareByCreatedAsc } from "./util.js";
 
 export interface VaultCommentConfig {
   root: string;
+  gitOps?: GitOps;
 }
 
 export class VaultCommentRepository implements CommentRepository {
   private readonly files: VaultMemoryFiles;
 
   constructor(cfg: VaultCommentConfig) {
-    this.files = new VaultMemoryFiles({ root: cfg.root });
+    this.files = new VaultMemoryFiles({ root: cfg.root, gitOps: cfg.gitOps });
   }
 
   async create(comment: {
@@ -39,6 +41,14 @@ export class VaultCommentRepository implements CommentRepository {
           comments: [...parsed.comments, record],
         },
         result: record,
+        commit: {
+          subject: commitSubject("commented", parsed.memory.title),
+          trailer: {
+            action: "commented",
+            memoryId: parsed.memory.id,
+            actor: comment.author,
+          },
+        },
       };
     });
   }

--- a/src/backend/vault/repositories/flag-repository.ts
+++ b/src/backend/vault/repositories/flag-repository.ts
@@ -11,7 +11,8 @@ import {
 
 export interface VaultFlagConfig {
   root: string;
-  gitOps?: GitOps;
+  gitOps: GitOps;
+  trackUsersInGit?: boolean;
 }
 
 // Flags are raised by the consolidation engine, not by a named user,
@@ -22,7 +23,11 @@ export class VaultFlagRepository implements FlagRepository {
   private readonly files: VaultMemoryFiles;
 
   constructor(cfg: VaultFlagConfig) {
-    this.files = new VaultMemoryFiles({ root: cfg.root, gitOps: cfg.gitOps });
+    this.files = new VaultMemoryFiles({
+      root: cfg.root,
+      gitOps: cfg.gitOps,
+      trackUsersInGit: cfg.trackUsersInGit ?? false,
+    });
   }
 
   async create(flag: Flag): Promise<Flag> {

--- a/src/backend/vault/repositories/flag-repository.ts
+++ b/src/backend/vault/repositories/flag-repository.ts
@@ -1,24 +1,42 @@
 import type { FlagRepository } from "../../../repositories/types.js";
 import type { Flag, FlagResolution, FlagType } from "../../../types/flag.js";
+import type { GitOps } from "../git/types.js";
 import { NotFoundError } from "../../../utils/errors.js";
 import { VaultMemoryFiles } from "./memory-files.js";
-import { compareByCreatedAsc, compareByCreatedDesc } from "./util.js";
+import {
+  commitSubject,
+  compareByCreatedAsc,
+  compareByCreatedDesc,
+} from "./util.js";
 
 export interface VaultFlagConfig {
   root: string;
+  gitOps?: GitOps;
 }
+
+// Flags are raised by the consolidation engine, not by a named user,
+// so the AB-Actor trailer is "system" for every flag mutation.
+const FLAG_ACTOR = "system";
 
 export class VaultFlagRepository implements FlagRepository {
   private readonly files: VaultMemoryFiles;
 
   constructor(cfg: VaultFlagConfig) {
-    this.files = new VaultMemoryFiles({ root: cfg.root });
+    this.files = new VaultMemoryFiles({ root: cfg.root, gitOps: cfg.gitOps });
   }
 
   async create(flag: Flag): Promise<Flag> {
     return await this.files.edit(flag.memory_id, (parsed) => ({
       next: { ...parsed, flags: [...parsed.flags, flag] },
       result: flag,
+      commit: {
+        subject: commitSubject("flagged", parsed.memory.title),
+        trailer: {
+          action: "flagged",
+          memoryId: parsed.memory.id,
+          actor: FLAG_ACTOR,
+        },
+      },
     }));
   }
 
@@ -84,7 +102,18 @@ export class VaultFlagRepository implements FlagRepository {
             : { ...current, resolved_at: now, resolved_by: resolvedBy };
         const nextFlags = parsed.flags.slice();
         nextFlags[idx] = next;
-        return { next: { ...parsed, flags: nextFlags }, result: next };
+        return {
+          next: { ...parsed, flags: nextFlags },
+          result: next,
+          commit: {
+            subject: commitSubject("unflagged", parsed.memory.title),
+            trailer: {
+              action: "unflagged",
+              memoryId: parsed.memory.id,
+              actor: resolvedBy,
+            },
+          },
+        };
       });
     } catch (err) {
       // Owning memory archived between scan and lock → pg returns null here.
@@ -103,7 +132,19 @@ export class VaultFlagRepository implements FlagRepository {
           count += 1;
           return { ...f, resolved_at: now, resolved_by: "system" };
         });
-        return { next: { ...parsed, flags: nextFlags }, result: count };
+        if (count === 0) return { next: parsed, result: 0 };
+        return {
+          next: { ...parsed, flags: nextFlags },
+          result: count,
+          commit: {
+            subject: commitSubject("unflagged", parsed.memory.title),
+            trailer: {
+              action: "unflagged",
+              memoryId: parsed.memory.id,
+              actor: "system",
+            },
+          },
+        };
       });
     } catch (err) {
       if (err instanceof NotFoundError) return 0;

--- a/src/backend/vault/repositories/memory-files.ts
+++ b/src/backend/vault/repositories/memory-files.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { DomainError, NotFoundError } from "../../../utils/errors.js";
+import { logger } from "../../../utils/logger.js";
 import {
   parseMemoryFile,
   serializeMemoryFile,
@@ -12,9 +13,12 @@ import {
   writeMarkdownAtomic,
 } from "../io/vault-fs.js";
 import { withFileLock } from "../io/lock.js";
+import type { CommitTrailer, GitOps } from "../git/types.js";
+import { NOOP_GIT_OPS } from "../git/types.js";
 
 export interface VaultMemoryFilesConfig {
   root: string;
+  gitOps?: GitOps;
 }
 
 export class VaultParseError extends DomainError {
@@ -34,7 +38,10 @@ export class VaultParseError extends DomainError {
 // repository that persists inside a memory's markdown file. Scan-based
 // lookup; no cross-repo index.
 export class VaultMemoryFiles {
-  constructor(private readonly cfg: VaultMemoryFilesConfig) {}
+  private readonly gitOps: GitOps;
+  constructor(private readonly cfg: VaultMemoryFilesConfig) {
+    this.gitOps = cfg.gitOps ?? NOOP_GIT_OPS;
+  }
 
   async resolvePath(memoryId: string): Promise<string | null> {
     const files = await safeListMd(this.cfg.root);
@@ -58,6 +65,7 @@ export class VaultMemoryFiles {
     mutator: (parsed: ParsedMemoryFile) => {
       next: ParsedMemoryFile;
       result: T;
+      commit?: { subject: string; trailer: CommitTrailer };
     },
   ): Promise<T> {
     const rel = await this.resolvePath(memoryId);
@@ -66,13 +74,28 @@ export class VaultMemoryFiles {
     return await withFileLock(abs, async () => {
       const raw = await readMarkdownOrNotFound(this.cfg.root, rel, memoryId);
       const parsed = parseOrRaise(raw, rel);
-      const { next, result } = mutator(parsed);
+      const { next, result, commit } = mutator(parsed);
       if (next !== parsed) {
         await writeMarkdownAtomic(
           this.cfg.root,
           rel,
           serializeMemoryFile(next),
         );
+        if (commit) {
+          try {
+            await this.gitOps.stageAndCommit(
+              [rel],
+              commit.subject,
+              commit.trailer,
+            );
+          } catch (err) {
+            logger.warn("vault git commit failed; continuing", {
+              rel,
+              action: commit.trailer.action,
+              err,
+            });
+          }
+        }
       }
       return result;
     });

--- a/src/backend/vault/repositories/memory-files.ts
+++ b/src/backend/vault/repositories/memory-files.ts
@@ -13,12 +13,20 @@ import {
   writeMarkdownAtomic,
 } from "../io/vault-fs.js";
 import { withFileLock } from "../io/lock.js";
-import type { CommitTrailer, GitOps } from "../git/types.js";
-import { NOOP_GIT_OPS } from "../git/types.js";
+import {
+  VaultGitNothingToCommitError,
+  type CommitTrailer,
+  type GitOps,
+} from "../git/types.js";
+import { assertUsersIgnored } from "../git/users-gitignore-invariant.js";
 
 export interface VaultMemoryFilesConfig {
   root: string;
-  gitOps?: GitOps;
+  gitOps: GitOps;
+  // When false, user-scope mutations skip the commit (privacy) and
+  // additionally assert .gitignore still lists `users/` so the rule
+  // hasn't been removed while the assumption is still load-bearing.
+  trackUsersInGit: boolean;
 }
 
 export class VaultParseError extends DomainError {
@@ -38,10 +46,7 @@ export class VaultParseError extends DomainError {
 // repository that persists inside a memory's markdown file. Scan-based
 // lookup; no cross-repo index.
 export class VaultMemoryFiles {
-  private readonly gitOps: GitOps;
-  constructor(private readonly cfg: VaultMemoryFilesConfig) {
-    this.gitOps = cfg.gitOps ?? NOOP_GIT_OPS;
-  }
+  constructor(private readonly cfg: VaultMemoryFilesConfig) {}
 
   async resolvePath(memoryId: string): Promise<string | null> {
     const files = await safeListMd(this.cfg.root);
@@ -74,6 +79,18 @@ export class VaultMemoryFiles {
     return await withFileLock(abs, async () => {
       const raw = await readMarkdownOrNotFound(this.cfg.root, rel, memoryId);
       const parsed = parseOrRaise(raw, rel);
+      // Privacy guard: if this is a user-scope memory and the caller
+      // hasn't opted into tracking, assert the `users/` rule still
+      // keeps the path out of the remote. Runs even for non-committing
+      // edits so a broken .gitignore is caught before downstream
+      // writers that do commit can leak.
+      if (
+        parsed.memory.scope === "user" &&
+        !this.cfg.trackUsersInGit &&
+        this.cfg.gitOps.enabled
+      ) {
+        await assertUsersIgnored(this.cfg.root);
+      }
       const { next, result, commit } = mutator(parsed);
       if (next !== parsed) {
         await writeMarkdownAtomic(
@@ -81,19 +98,33 @@ export class VaultMemoryFiles {
           rel,
           serializeMemoryFile(next),
         );
-        if (commit) {
+        if (
+          commit &&
+          shouldCommit(parsed.memory.scope, this.cfg.trackUsersInGit)
+        ) {
           try {
-            await this.gitOps.stageAndCommit(
+            await this.cfg.gitOps.stageAndCommit(
               [rel],
               commit.subject,
               commit.trailer,
             );
           } catch (err) {
-            logger.warn("vault git commit failed; continuing", {
-              rel,
-              action: commit.trailer.action,
-              err,
-            });
+            if (err instanceof VaultGitNothingToCommitError) {
+              // Identical-content write; no history to record.
+              logger.debug("vault git nothing to commit", {
+                rel,
+                action: commit.trailer.action,
+              });
+            } else {
+              // Markdown is already durable; git is the audit trail.
+              // Surface real failures so operators see the drift,
+              // then continue — the user-facing op already succeeded.
+              logger.error("vault git commit failed; markdown/git drift", {
+                rel,
+                action: commit.trailer.action,
+                err,
+              });
+            }
           }
         }
       }
@@ -113,6 +144,12 @@ export class VaultMemoryFiles {
     }
     return out;
   }
+}
+
+// User-scope writes only commit when the caller opted in; otherwise
+// the path is gitignored and staging would no-op.
+function shouldCommit(scope: string, trackUsersInGit: boolean): boolean {
+  return scope !== "user" || trackUsersInGit;
 }
 
 async function parseAt(root: string, rel: string): Promise<ParsedMemoryFile> {

--- a/src/backend/vault/repositories/memory-repository.ts
+++ b/src/backend/vault/repositories/memory-repository.ts
@@ -112,7 +112,11 @@ export class VaultMemoryRepository implements MemoryRepository {
     // Privacy guard: refuse user-scope writes if the .gitignore rule
     // that keeps users/ out of the remote has been removed. Runs
     // before any disk mutation. No-op when trackUsersInGit is enabled.
-    if (memory.scope === "user" && !this.trackUsersInGit) {
+    if (
+      memory.scope === "user" &&
+      !this.trackUsersInGit &&
+      this.gitOps !== NOOP_GIT_OPS
+    ) {
       await assertUsersIgnored(this.cfg.root);
     }
     const loc = locationFor(memory);
@@ -229,7 +233,11 @@ export class VaultMemoryRepository implements MemoryRepository {
       );
     }
 
-    if (entry.scope === "user" && !this.trackUsersInGit) {
+    if (
+      entry.scope === "user" &&
+      !this.trackUsersInGit &&
+      this.gitOps !== NOOP_GIT_OPS
+    ) {
       await assertUsersIgnored(this.cfg.root);
     }
 
@@ -385,7 +393,11 @@ export class VaultMemoryRepository implements MemoryRepository {
   async verify(id: string, verifiedBy: string): Promise<Memory | null> {
     const entry = this.index.get(id);
     if (!entry) return null;
-    if (entry.scope === "user" && !this.trackUsersInGit) {
+    if (
+      entry.scope === "user" &&
+      !this.trackUsersInGit &&
+      this.gitOps !== NOOP_GIT_OPS
+    ) {
       await assertUsersIgnored(this.cfg.root);
     }
     const abs = join(this.cfg.root, entry.path);

--- a/src/backend/vault/repositories/memory-repository.ts
+++ b/src/backend/vault/repositories/memory-repository.ts
@@ -39,10 +39,21 @@ import { withFileLock } from "../io/lock.js";
 import { VaultVectorIndex } from "../vector/lance-index.js";
 import { contentHash } from "../vector/hash.js";
 import { logger } from "../../../utils/logger.js";
+import type { CommitTrailer, GitOps } from "../git/types.js";
+import { NOOP_GIT_OPS } from "../git/types.js";
+import { assertUsersIgnored } from "../git/users-gitignore-invariant.js";
+import { commitSubject } from "./util.js";
 
 export interface VaultMemoryConfig {
   root: string;
   index: VaultVectorIndex;
+  gitOps?: GitOps;
+  // When true, user-scope memories are committed alongside
+  // workspace/project ones. Default false: `users/` stays gitignored
+  // and its writes skip the commit step entirely (the path is ignored
+  // by .gitignore so `git add` would no-op and `stageAndCommit` would
+  // throw "nothing to commit").
+  trackUsersInGit?: boolean;
 }
 
 interface IndexEntry {
@@ -54,12 +65,16 @@ interface IndexEntry {
 
 export class VaultMemoryRepository implements MemoryRepository {
   private readonly index: Map<string, IndexEntry>;
+  private readonly gitOps: GitOps;
+  private readonly trackUsersInGit: boolean;
 
   private constructor(
     private readonly cfg: VaultMemoryConfig,
     initialIndex: Map<string, IndexEntry>,
   ) {
     this.index = initialIndex;
+    this.gitOps = cfg.gitOps ?? NOOP_GIT_OPS;
+    this.trackUsersInGit = cfg.trackUsersInGit ?? false;
   }
 
   static async create(cfg: VaultMemoryConfig): Promise<VaultMemoryRepository> {
@@ -93,6 +108,12 @@ export class VaultMemoryRepository implements MemoryRepository {
       throw new ValidationError(
         `vector dimension mismatch: expected ${this.cfg.index.dims}, got ${memory.embedding.length} for id ${memory.id}`,
       );
+    }
+    // Privacy guard: refuse user-scope writes if the .gitignore rule
+    // that keeps users/ out of the remote has been removed. Runs
+    // before any disk mutation. No-op when trackUsersInGit is enabled.
+    if (memory.scope === "user" && !this.trackUsersInGit) {
+      await assertUsersIgnored(this.cfg.root);
     }
     const loc = locationFor(memory);
     const rel = memoryPath(loc);
@@ -146,6 +167,16 @@ export class VaultMemoryRepository implements MemoryRepository {
         err,
       });
     }
+    await this.#commit(
+      rel,
+      memory.scope,
+      commitSubject("created", memory.title),
+      {
+        action: "created",
+        memoryId: memory.id,
+        actor: memory.author,
+      },
+    );
     const saved = await this.#read(memory.id);
     return saved.memory;
   }
@@ -196,6 +227,10 @@ export class VaultMemoryRepository implements MemoryRepository {
       throw new ValidationError(
         `vector dimension mismatch: expected ${this.cfg.index.dims}, got ${updates.embedding.length} for id ${id}`,
       );
+    }
+
+    if (entry.scope === "user" && !this.trackUsersInGit) {
+      await assertUsersIgnored(this.cfg.root);
     }
 
     const abs = join(this.cfg.root, entry.path);
@@ -271,6 +306,12 @@ export class VaultMemoryRepository implements MemoryRepository {
           err,
         });
       }
+      await this.#commit(
+        entry.path,
+        next.scope,
+        commitSubject("updated", next.title),
+        { action: "updated", memoryId: next.id, actor: next.author },
+      );
       const reread = await this.#read(id);
       return reread.memory;
     });
@@ -279,7 +320,13 @@ export class VaultMemoryRepository implements MemoryRepository {
   async archive(ids: string[]): Promise<number> {
     let count = 0;
     const now = new Date();
-    const archived: string[] = [];
+    const archived: Array<{
+      id: string;
+      path: string;
+      scope: MemoryScope;
+      title: string;
+      author: string;
+    }> = [];
     for (const id of ids) {
       const entry = this.index.get(id);
       if (!entry) continue;
@@ -296,29 +343,41 @@ export class VaultMemoryRepository implements MemoryRepository {
         });
         await writeMarkdownAtomic(this.cfg.root, entry.path, md);
         count += 1;
-        archived.push(id);
+        archived.push({
+          id,
+          path: entry.path,
+          scope: entry.scope,
+          title: parsed.memory.title,
+          author: parsed.memory.author,
+        });
       });
     }
     // One lance failure (or missing row) must not abort archive
     // propagation for the remaining ids. Markdown is already flipped
     // for each id in `archived`, so the caller's return count is
     // accurate regardless of lance outcome.
-    for (const id of archived) {
+    for (const rec of archived) {
       try {
-        const rowsUpdated = await this.cfg.index.markArchived(id);
+        const rowsUpdated = await this.cfg.index.markArchived(rec.id);
         if (rowsUpdated === 0) {
           logger.warn("lance markArchived matched no rows; index drift", {
-            id,
+            id: rec.id,
             op: "archive",
           });
         }
       } catch (err) {
         logger.warn("lance markArchived failed; index stale", {
-          id,
+          id: rec.id,
           op: "archive",
           err,
         });
       }
+      await this.#commit(
+        rec.path,
+        rec.scope,
+        commitSubject("archived", rec.title),
+        { action: "archived", memoryId: rec.id, actor: rec.author },
+      );
     }
     return count;
   }
@@ -326,6 +385,9 @@ export class VaultMemoryRepository implements MemoryRepository {
   async verify(id: string, verifiedBy: string): Promise<Memory | null> {
     const entry = this.index.get(id);
     if (!entry) return null;
+    if (entry.scope === "user" && !this.trackUsersInGit) {
+      await assertUsersIgnored(this.cfg.root);
+    }
     const abs = join(this.cfg.root, entry.path);
     return await withFileLock(abs, async () => {
       const raw = await readMarkdown(this.cfg.root, entry.path);
@@ -345,6 +407,12 @@ export class VaultMemoryRepository implements MemoryRepository {
         flags: parsed.flags,
       });
       await writeMarkdownAtomic(this.cfg.root, entry.path, md);
+      await this.#commit(
+        entry.path,
+        next.scope,
+        commitSubject("verified", next.title),
+        { action: "verified", memoryId: next.id, actor: verifiedBy },
+      );
       const reread = await this.#read(id);
       return reread.memory;
     });
@@ -589,6 +657,32 @@ export class VaultMemoryRepository implements MemoryRepository {
     if (!entry) throw new NotFoundError("memory", id);
     const raw = await readMarkdown(this.cfg.root, entry.path);
     return parseMemoryFile(raw);
+  }
+
+  // Returns true when the given scope is tracked in git under the
+  // current config. User-scope is only tracked when the caller opted
+  // in via trackUsersInGit — otherwise users/ is gitignored and
+  // stageAndCommit would throw "nothing to commit".
+  #shouldCommit(scope: MemoryScope): boolean {
+    return scope !== "user" || this.trackUsersInGit;
+  }
+
+  async #commit(
+    rel: string,
+    scope: MemoryScope,
+    subject: string,
+    trailer: CommitTrailer,
+  ): Promise<void> {
+    if (!this.#shouldCommit(scope)) return;
+    try {
+      await this.gitOps.stageAndCommit([rel], subject, trailer);
+    } catch (err) {
+      logger.warn("vault git commit failed; continuing", {
+        rel,
+        action: trailer.action,
+        err,
+      });
+    }
   }
 }
 

--- a/src/backend/vault/repositories/memory-repository.ts
+++ b/src/backend/vault/repositories/memory-repository.ts
@@ -39,20 +39,23 @@ import { withFileLock } from "../io/lock.js";
 import { VaultVectorIndex } from "../vector/lance-index.js";
 import { contentHash } from "../vector/hash.js";
 import { logger } from "../../../utils/logger.js";
-import type { CommitTrailer, GitOps } from "../git/types.js";
-import { NOOP_GIT_OPS } from "../git/types.js";
+import {
+  VaultGitNothingToCommitError,
+  type CommitTrailer,
+  type GitOps,
+} from "../git/types.js";
 import { assertUsersIgnored } from "../git/users-gitignore-invariant.js";
 import { commitSubject } from "./util.js";
 
 export interface VaultMemoryConfig {
   root: string;
   index: VaultVectorIndex;
-  gitOps?: GitOps;
+  gitOps: GitOps;
   // When true, user-scope memories are committed alongside
-  // workspace/project ones. Default false: `users/` stays gitignored
+  // workspace/project ones. Default false: users/ stays gitignored
   // and its writes skip the commit step entirely (the path is ignored
-  // by .gitignore so `git add` would no-op and `stageAndCommit` would
-  // throw "nothing to commit").
+  // by .gitignore so `git add` would no-op and stageAndCommit would
+  // throw VaultGitNothingToCommitError).
   trackUsersInGit?: boolean;
 }
 
@@ -73,7 +76,7 @@ export class VaultMemoryRepository implements MemoryRepository {
     initialIndex: Map<string, IndexEntry>,
   ) {
     this.index = initialIndex;
-    this.gitOps = cfg.gitOps ?? NOOP_GIT_OPS;
+    this.gitOps = cfg.gitOps;
     this.trackUsersInGit = cfg.trackUsersInGit ?? false;
   }
 
@@ -115,7 +118,7 @@ export class VaultMemoryRepository implements MemoryRepository {
     if (
       memory.scope === "user" &&
       !this.trackUsersInGit &&
-      this.gitOps !== NOOP_GIT_OPS
+      this.gitOps.enabled
     ) {
       await assertUsersIgnored(this.cfg.root);
     }
@@ -236,7 +239,7 @@ export class VaultMemoryRepository implements MemoryRepository {
     if (
       entry.scope === "user" &&
       !this.trackUsersInGit &&
-      this.gitOps !== NOOP_GIT_OPS
+      this.gitOps.enabled
     ) {
       await assertUsersIgnored(this.cfg.root);
     }
@@ -338,6 +341,13 @@ export class VaultMemoryRepository implements MemoryRepository {
     for (const id of ids) {
       const entry = this.index.get(id);
       if (!entry) continue;
+      if (
+        entry.scope === "user" &&
+        !this.trackUsersInGit &&
+        this.gitOps.enabled
+      ) {
+        await assertUsersIgnored(this.cfg.root);
+      }
       const abs = join(this.cfg.root, entry.path);
       await withFileLock(abs, async () => {
         const raw = await readMarkdown(this.cfg.root, entry.path);
@@ -396,7 +406,7 @@ export class VaultMemoryRepository implements MemoryRepository {
     if (
       entry.scope === "user" &&
       !this.trackUsersInGit &&
-      this.gitOps !== NOOP_GIT_OPS
+      this.gitOps.enabled
     ) {
       await assertUsersIgnored(this.cfg.root);
     }
@@ -689,11 +699,18 @@ export class VaultMemoryRepository implements MemoryRepository {
     try {
       await this.gitOps.stageAndCommit([rel], subject, trailer);
     } catch (err) {
-      logger.warn("vault git commit failed; continuing", {
-        rel,
-        action: trailer.action,
-        err,
-      });
+      if (err instanceof VaultGitNothingToCommitError) {
+        logger.debug("vault git nothing to commit", {
+          rel,
+          action: trailer.action,
+        });
+      } else {
+        logger.error("vault git commit failed; markdown/git drift", {
+          rel,
+          action: trailer.action,
+          err,
+        });
+      }
     }
   }
 }

--- a/src/backend/vault/repositories/relationship-repository.ts
+++ b/src/backend/vault/repositories/relationship-repository.ts
@@ -1,11 +1,13 @@
 import type { RelationshipRepository } from "../../../repositories/types.js";
 import type { Relationship } from "../../../types/relationship.js";
+import type { GitOps } from "../git/types.js";
 import { NotFoundError } from "../../../utils/errors.js";
 import { VaultMemoryFiles } from "./memory-files.js";
-import { compareByCreatedAsc } from "./util.js";
+import { commitSubject, compareByCreatedAsc } from "./util.js";
 
 export interface VaultRelationshipConfig {
   root: string;
+  gitOps?: GitOps;
 }
 
 // Relationships live in the source memory's file under `## Relationships`.
@@ -15,7 +17,7 @@ export class VaultRelationshipRepository implements RelationshipRepository {
   private readonly files: VaultMemoryFiles;
 
   constructor(cfg: VaultRelationshipConfig) {
-    this.files = new VaultMemoryFiles({ root: cfg.root });
+    this.files = new VaultMemoryFiles({ root: cfg.root, gitOps: cfg.gitOps });
   }
 
   async create(relationship: Relationship): Promise<Relationship> {
@@ -27,6 +29,14 @@ export class VaultRelationshipRepository implements RelationshipRepository {
         relationships: [...parsed.relationships, persisted],
       },
       result: persisted,
+      commit: {
+        subject: commitSubject("related", parsed.memory.title),
+        trailer: {
+          action: "related",
+          memoryId: parsed.memory.id,
+          actor: persisted.created_by,
+        },
+      },
     }));
   }
 
@@ -154,8 +164,22 @@ export class VaultRelationshipRepository implements RelationshipRepository {
           if (parsed.memory.project_id !== projectId) {
             return { next: parsed, result: null };
           }
+          if (parsed.relationships.length === 0) {
+            return { next: parsed, result: null };
+          }
           count += parsed.relationships.length;
-          return { next: { ...parsed, relationships: [] }, result: null };
+          return {
+            next: { ...parsed, relationships: [] },
+            result: null,
+            commit: {
+              subject: commitSubject("unrelated", parsed.memory.title),
+              trailer: {
+                action: "unrelated",
+                memoryId: parsed.memory.id,
+                actor: "system",
+              },
+            },
+          };
         });
       } catch (err) {
         if (!(err instanceof NotFoundError)) throw err;
@@ -172,8 +196,21 @@ export class VaultRelationshipRepository implements RelationshipRepository {
       try {
         await this.files.edit(parsed.memory.id, (p) => {
           const next = p.relationships.filter((r) => r.target_id !== memoryId);
-          count += p.relationships.length - next.length;
-          return { next: { ...p, relationships: next }, result: null };
+          const removed = p.relationships.length - next.length;
+          if (removed === 0) return { next: p, result: null };
+          count += removed;
+          return {
+            next: { ...p, relationships: next },
+            result: null,
+            commit: {
+              subject: commitSubject("unrelated", p.memory.title),
+              trailer: {
+                action: "unrelated",
+                memoryId: p.memory.id,
+                actor: "system",
+              },
+            },
+          };
         });
       } catch (err) {
         if (err instanceof NotFoundError) continue;
@@ -194,9 +231,19 @@ export class VaultRelationshipRepository implements RelationshipRepository {
       return await this.files.edit(owner.parsed.memory.id, (parsed) => {
         const before = parsed.relationships.length;
         const next = parsed.relationships.filter((r) => r.id !== id);
+        const removed = next.length < before;
+        if (!removed) return { next: parsed, result: false };
         return {
           next: { ...parsed, relationships: next },
-          result: next.length < before,
+          result: true,
+          commit: {
+            subject: commitSubject("unrelated", parsed.memory.title),
+            trailer: {
+              action: "unrelated",
+              memoryId: parsed.memory.id,
+              actor: "system",
+            },
+          },
         };
       });
     } catch (err) {

--- a/src/backend/vault/repositories/relationship-repository.ts
+++ b/src/backend/vault/repositories/relationship-repository.ts
@@ -7,7 +7,8 @@ import { commitSubject, compareByCreatedAsc } from "./util.js";
 
 export interface VaultRelationshipConfig {
   root: string;
-  gitOps?: GitOps;
+  gitOps: GitOps;
+  trackUsersInGit?: boolean;
 }
 
 // Relationships live in the source memory's file under `## Relationships`.
@@ -17,7 +18,11 @@ export class VaultRelationshipRepository implements RelationshipRepository {
   private readonly files: VaultMemoryFiles;
 
   constructor(cfg: VaultRelationshipConfig) {
-    this.files = new VaultMemoryFiles({ root: cfg.root, gitOps: cfg.gitOps });
+    this.files = new VaultMemoryFiles({
+      root: cfg.root,
+      gitOps: cfg.gitOps,
+      trackUsersInGit: cfg.trackUsersInGit ?? false,
+    });
   }
 
   async create(relationship: Relationship): Promise<Relationship> {

--- a/src/backend/vault/repositories/util.ts
+++ b/src/backend/vault/repositories/util.ts
@@ -7,3 +7,8 @@ export function compareByCreatedAsc(a: HasCreatedAt, b: HasCreatedAt): number {
 export function compareByCreatedDesc(a: HasCreatedAt, b: HasCreatedAt): number {
   return b.created_at.getTime() - a.created_at.getTime();
 }
+
+export function commitSubject(action: string, title: string): string {
+  const trimmed = title.length > 60 ? title.slice(0, 57) + "..." : title;
+  return `[agent-brain] ${action}: ${trimmed}`;
+}

--- a/src/backend/vault/repositories/workspace-repository.ts
+++ b/src/backend/vault/repositories/workspace-repository.ts
@@ -5,9 +5,14 @@ import type { WorkspaceRepository } from "../../../repositories/types.js";
 import { workspaceMetaPath } from "../io/paths.js";
 import { readMarkdown, writeMarkdownAtomic } from "../io/vault-fs.js";
 import { withFileLock } from "../io/lock.js";
+import { logger } from "../../../utils/logger.js";
+import type { GitOps } from "../git/types.js";
+import { NOOP_GIT_OPS } from "../git/types.js";
+import { commitSubject } from "./util.js";
 
 export interface VaultWorkspaceConfig {
   root: string;
+  gitOps?: GitOps;
 }
 
 interface WorkspaceFm {
@@ -16,7 +21,11 @@ interface WorkspaceFm {
 }
 
 export class VaultWorkspaceRepository implements WorkspaceRepository {
-  constructor(private readonly cfg: VaultWorkspaceConfig) {}
+  private readonly gitOps: GitOps;
+
+  constructor(private readonly cfg: VaultWorkspaceConfig) {
+    this.gitOps = cfg.gitOps ?? NOOP_GIT_OPS;
+  }
 
   async findOrCreate(slug: string): Promise<{ id: string; created_at: Date }> {
     const rel = workspaceMetaPath(slug);
@@ -33,12 +42,15 @@ export class VaultWorkspaceRepository implements WorkspaceRepository {
       if (!isNodeEexist(err)) throw err;
     }
 
-    return await withFileLock(abs, async () => {
+    const result = await withFileLock(abs, async () => {
       try {
         const raw = await readMarkdown(this.cfg.root, rel);
         const fm = matter(raw).data as Partial<WorkspaceFm>;
         if (typeof fm.id === "string" && typeof fm.created === "string") {
-          return { id: fm.id, created_at: new Date(fm.created) };
+          return {
+            value: { id: fm.id, created_at: new Date(fm.created) },
+            written: false,
+          };
         }
         // File exists but is empty (placeholder) or malformed — write it now.
       } catch (err: unknown) {
@@ -52,8 +64,32 @@ export class VaultWorkspaceRepository implements WorkspaceRepository {
         created: created.toISOString(),
       });
       await writeMarkdownAtomic(this.cfg.root, rel, body);
-      return { id: slug, created_at: created };
+      return {
+        value: { id: slug, created_at: created },
+        written: true,
+      };
     });
+
+    if (result.written) {
+      try {
+        await this.gitOps.stageAndCommit(
+          [rel],
+          commitSubject("workspace_upsert", slug),
+          {
+            action: "workspace_upsert",
+            workspaceId: slug,
+            actor: "system",
+          },
+        );
+      } catch (err) {
+        logger.warn("vault git commit failed on workspace upsert; continuing", {
+          rel,
+          err,
+        });
+      }
+    }
+
+    return result.value;
   }
 
   async findById(

--- a/src/backend/vault/repositories/workspace-repository.ts
+++ b/src/backend/vault/repositories/workspace-repository.ts
@@ -6,13 +6,12 @@ import { workspaceMetaPath } from "../io/paths.js";
 import { readMarkdown, writeMarkdownAtomic } from "../io/vault-fs.js";
 import { withFileLock } from "../io/lock.js";
 import { logger } from "../../../utils/logger.js";
-import type { GitOps } from "../git/types.js";
-import { NOOP_GIT_OPS } from "../git/types.js";
+import { VaultGitNothingToCommitError, type GitOps } from "../git/types.js";
 import { commitSubject } from "./util.js";
 
 export interface VaultWorkspaceConfig {
   root: string;
-  gitOps?: GitOps;
+  gitOps: GitOps;
 }
 
 interface WorkspaceFm {
@@ -24,7 +23,7 @@ export class VaultWorkspaceRepository implements WorkspaceRepository {
   private readonly gitOps: GitOps;
 
   constructor(private readonly cfg: VaultWorkspaceConfig) {
-    this.gitOps = cfg.gitOps ?? NOOP_GIT_OPS;
+    this.gitOps = cfg.gitOps;
   }
 
   async findOrCreate(slug: string): Promise<{ id: string; created_at: Date }> {
@@ -82,10 +81,16 @@ export class VaultWorkspaceRepository implements WorkspaceRepository {
           },
         );
       } catch (err) {
-        logger.warn("vault git commit failed on workspace upsert; continuing", {
-          rel,
-          err,
-        });
+        if (err instanceof VaultGitNothingToCommitError) {
+          logger.debug("vault git nothing to commit for workspace upsert", {
+            rel,
+          });
+        } else {
+          logger.error(
+            "vault git commit failed on workspace upsert; markdown/git drift",
+            { rel, err },
+          );
+        }
       }
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,10 @@ const configSchema = z.object({
     .string()
     .default("postgresql://agentic:agentic@localhost:5432/agent_brain"),
   vaultRoot: z.string().default(""),
+  vaultTrackUsersInGit: z
+    .enum(["true", "false"])
+    .default("false")
+    .transform((v) => v === "true"),
   embeddingProvider: z.enum(["titan", "mock", "ollama"]).default("mock"),
   embeddingDimensions: z.coerce.number().int().positive().default(768),
   ollamaBaseUrl: z.string().default("http://localhost:11434"),
@@ -54,6 +58,7 @@ export const config = configSchema.parse({
   backend: process.env.AGENT_BRAIN_BACKEND,
   databaseUrl: process.env.DATABASE_URL,
   vaultRoot: process.env.AGENT_BRAIN_VAULT_ROOT,
+  vaultTrackUsersInGit: process.env.AGENT_BRAIN_VAULT_TRACK_USERS,
   embeddingProvider: process.env.EMBEDDING_PROVIDER,
   embeddingDimensions: process.env.EMBEDDING_DIMENSIONS,
   ollamaBaseUrl: process.env.OLLAMA_BASE_URL,

--- a/src/server.ts
+++ b/src/server.ts
@@ -39,6 +39,7 @@ async function main() {
       backend: config.backend,
       databaseUrl: config.databaseUrl,
       vaultRoot: config.vaultRoot,
+      vaultTrackUsersInGit: config.vaultTrackUsersInGit,
       embeddingDimensions: config.embeddingDimensions,
     });
   } catch (err: unknown) {

--- a/tests/contract/repositories/_factories.ts
+++ b/tests/contract/repositories/_factories.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { simpleGit } from "simple-git";
 import { VaultMemoryRepository } from "../../../src/backend/vault/repositories/memory-repository.js";
 import { VaultWorkspaceRepository } from "../../../src/backend/vault/repositories/workspace-repository.js";
 import { VaultAuditRepository } from "../../../src/backend/vault/repositories/audit-repository.js";
@@ -10,6 +11,9 @@ import { VaultSessionRepository } from "../../../src/backend/vault/repositories/
 import { VaultCommentRepository } from "../../../src/backend/vault/repositories/comment-repository.js";
 import { VaultFlagRepository } from "../../../src/backend/vault/repositories/flag-repository.js";
 import { VaultRelationshipRepository } from "../../../src/backend/vault/repositories/relationship-repository.js";
+import { ensureVaultGit } from "../../../src/backend/vault/git/bootstrap.js";
+import { GitOpsImpl } from "../../../src/backend/vault/git/git-ops.js";
+import { scrubGitEnv } from "../../../src/backend/vault/git/env.js";
 import type {
   AuditRepository,
   CommentRepository,
@@ -34,6 +38,8 @@ export interface TestBackend {
   commentRepo: CommentRepository;
   flagRepo: FlagRepository;
   relationshipRepo: RelationshipRepository;
+  // Populated by the vault-git factory; pg + vault (no-git) leave it undefined.
+  gitRoot?: string;
   close(): Promise<void>;
 }
 
@@ -118,3 +124,52 @@ export const vaultFactory: Factory = {
 };
 
 export const factories: Factory[] = [pgFactory, vaultFactory];
+
+// Parallel to vaultFactory but initializes a real git repo inside the
+// vault root and injects GitOpsImpl. Used only by the *-git.test.ts
+// suites that assert commit behavior. Keeping this separate avoids
+// paying the git-init cost on every contract test.
+export const vaultGitFactory: Factory = {
+  name: "vault",
+  async create() {
+    const root = await mkdtemp(join(tmpdir(), "contract-vault-git-"));
+    await ensureVaultGit({ root, trackUsers: false });
+    const cfgGit = simpleGit({ baseDir: root }).env(scrubGitEnv());
+    await cfgGit.addConfig("user.email", "contract@example.com");
+    await cfgGit.addConfig("user.name", "Contract Test");
+    const gitOps = new GitOpsImpl({ root });
+    const { VaultVectorIndex } =
+      await import("../../../src/backend/vault/vector/lance-index.js");
+    const index = await VaultVectorIndex.create({ root, dims: 768 });
+    const memoryRepo = await VaultMemoryRepository.create({
+      root,
+      index,
+      gitOps,
+    });
+    const workspaceRepo = new VaultWorkspaceRepository({ root, gitOps });
+    const auditRepo = new VaultAuditRepository({ root });
+    const schedulerStateRepo = new VaultSchedulerStateRepository({ root });
+    const sessionTrackingRepo = new VaultSessionTrackingRepository({ root });
+    const sessionRepo = new VaultSessionRepository({ root });
+    const commentRepo = new VaultCommentRepository({ root, gitOps });
+    const flagRepo = new VaultFlagRepository({ root, gitOps });
+    const relationshipRepo = new VaultRelationshipRepository({ root, gitOps });
+    return {
+      name: "vault",
+      memoryRepo,
+      workspaceRepo,
+      auditRepo,
+      schedulerStateRepo,
+      sessionTrackingRepo,
+      sessionRepo,
+      commentRepo,
+      flagRepo,
+      relationshipRepo,
+      gitRoot: root,
+      close: async () => {
+        await index.close();
+        await rm(root, { recursive: true, force: true });
+      },
+    };
+  },
+};

--- a/tests/contract/repositories/_factories.ts
+++ b/tests/contract/repositories/_factories.ts
@@ -14,6 +14,7 @@ import { VaultRelationshipRepository } from "../../../src/backend/vault/reposito
 import { ensureVaultGit } from "../../../src/backend/vault/git/bootstrap.js";
 import { GitOpsImpl } from "../../../src/backend/vault/git/git-ops.js";
 import { scrubGitEnv } from "../../../src/backend/vault/git/env.js";
+import { NOOP_GIT_OPS } from "../../../src/backend/vault/git/types.js";
 import type {
   AuditRepository,
   CommentRepository,
@@ -95,15 +96,20 @@ export const vaultFactory: Factory = {
     const { VaultVectorIndex } =
       await import("../../../src/backend/vault/vector/lance-index.js");
     const index = await VaultVectorIndex.create({ root, dims: 768 });
-    const memoryRepo = await VaultMemoryRepository.create({ root, index });
-    const workspaceRepo = new VaultWorkspaceRepository({ root });
+    const gitOps = NOOP_GIT_OPS;
+    const memoryRepo = await VaultMemoryRepository.create({
+      root,
+      index,
+      gitOps,
+    });
+    const workspaceRepo = new VaultWorkspaceRepository({ root, gitOps });
     const auditRepo = new VaultAuditRepository({ root });
     const schedulerStateRepo = new VaultSchedulerStateRepository({ root });
     const sessionTrackingRepo = new VaultSessionTrackingRepository({ root });
     const sessionRepo = new VaultSessionRepository({ root });
-    const commentRepo = new VaultCommentRepository({ root });
-    const flagRepo = new VaultFlagRepository({ root });
-    const relationshipRepo = new VaultRelationshipRepository({ root });
+    const commentRepo = new VaultCommentRepository({ root, gitOps });
+    const flagRepo = new VaultFlagRepository({ root, gitOps });
+    const relationshipRepo = new VaultRelationshipRepository({ root, gitOps });
     return {
       name: "vault",
       memoryRepo,
@@ -129,47 +135,67 @@ export const factories: Factory[] = [pgFactory, vaultFactory];
 // vault root and injects GitOpsImpl. Used only by the *-git.test.ts
 // suites that assert commit behavior. Keeping this separate avoids
 // paying the git-init cost on every contract test.
-export const vaultGitFactory: Factory = {
-  name: "vault",
-  async create() {
-    const root = await mkdtemp(join(tmpdir(), "contract-vault-git-"));
-    await ensureVaultGit({ root, trackUsers: false });
-    const cfgGit = simpleGit({ baseDir: root }).env(scrubGitEnv());
-    await cfgGit.addConfig("user.email", "contract@example.com");
-    await cfgGit.addConfig("user.name", "Contract Test");
-    const gitOps = new GitOpsImpl({ root });
-    const { VaultVectorIndex } =
-      await import("../../../src/backend/vault/vector/lance-index.js");
-    const index = await VaultVectorIndex.create({ root, dims: 768 });
-    const memoryRepo = await VaultMemoryRepository.create({
-      root,
-      index,
-      gitOps,
-    });
-    const workspaceRepo = new VaultWorkspaceRepository({ root, gitOps });
-    const auditRepo = new VaultAuditRepository({ root });
-    const schedulerStateRepo = new VaultSchedulerStateRepository({ root });
-    const sessionTrackingRepo = new VaultSessionTrackingRepository({ root });
-    const sessionRepo = new VaultSessionRepository({ root });
-    const commentRepo = new VaultCommentRepository({ root, gitOps });
-    const flagRepo = new VaultFlagRepository({ root, gitOps });
-    const relationshipRepo = new VaultRelationshipRepository({ root, gitOps });
-    return {
-      name: "vault",
-      memoryRepo,
-      workspaceRepo,
-      auditRepo,
-      schedulerStateRepo,
-      sessionTrackingRepo,
-      sessionRepo,
-      commentRepo,
-      flagRepo,
-      relationshipRepo,
-      gitRoot: root,
-      close: async () => {
-        await index.close();
-        await rm(root, { recursive: true, force: true });
-      },
-    };
-  },
-};
+export function makeVaultGitFactory(
+  opts: { trackUsersInGit?: boolean } = {},
+): Factory {
+  const trackUsersInGit = opts.trackUsersInGit ?? false;
+  return {
+    name: "vault",
+    async create() {
+      const root = await mkdtemp(join(tmpdir(), "contract-vault-git-"));
+      await ensureVaultGit({ root, trackUsers: trackUsersInGit });
+      const cfgGit = simpleGit({ baseDir: root }).env(scrubGitEnv());
+      await cfgGit.addConfig("user.email", "contract@example.com");
+      await cfgGit.addConfig("user.name", "Contract Test");
+      const gitOps = new GitOpsImpl({ root });
+      const { VaultVectorIndex } =
+        await import("../../../src/backend/vault/vector/lance-index.js");
+      const index = await VaultVectorIndex.create({ root, dims: 768 });
+      const memoryRepo = await VaultMemoryRepository.create({
+        root,
+        index,
+        gitOps,
+        trackUsersInGit,
+      });
+      const workspaceRepo = new VaultWorkspaceRepository({ root, gitOps });
+      const auditRepo = new VaultAuditRepository({ root });
+      const schedulerStateRepo = new VaultSchedulerStateRepository({ root });
+      const sessionTrackingRepo = new VaultSessionTrackingRepository({ root });
+      const sessionRepo = new VaultSessionRepository({ root });
+      const commentRepo = new VaultCommentRepository({
+        root,
+        gitOps,
+        trackUsersInGit,
+      });
+      const flagRepo = new VaultFlagRepository({
+        root,
+        gitOps,
+        trackUsersInGit,
+      });
+      const relationshipRepo = new VaultRelationshipRepository({
+        root,
+        gitOps,
+        trackUsersInGit,
+      });
+      return {
+        name: "vault",
+        memoryRepo,
+        workspaceRepo,
+        auditRepo,
+        schedulerStateRepo,
+        sessionTrackingRepo,
+        sessionRepo,
+        commentRepo,
+        flagRepo,
+        relationshipRepo,
+        gitRoot: root,
+        close: async () => {
+          await index.close();
+          await rm(root, { recursive: true, force: true });
+        },
+      };
+    },
+  };
+}
+
+export const vaultGitFactory: Factory = makeVaultGitFactory();

--- a/tests/contract/repositories/_git-helpers.ts
+++ b/tests/contract/repositories/_git-helpers.ts
@@ -1,0 +1,51 @@
+import { simpleGit } from "simple-git";
+import { scrubGitEnv } from "../../../src/backend/vault/git/env.js";
+import type { Memory, MemoryScope } from "../../../src/types/memory.js";
+
+export function makeMemory(
+  id: string,
+  scope: MemoryScope = "workspace",
+): Memory & { embedding: number[] } {
+  const now = new Date("2026-04-22T00:00:00Z");
+  return {
+    id,
+    project_id: "p1",
+    workspace_id: scope === "project" ? null : "ws1",
+    content: `body-${id}`,
+    title: `t-${id}`,
+    type: "fact",
+    scope,
+    tags: null,
+    author: "alice",
+    source: null,
+    session_id: null,
+    metadata: null,
+    embedding_model: null,
+    embedding_dimensions: 768,
+    version: 1,
+    created_at: now,
+    updated_at: now,
+    verified_at: null,
+    archived_at: null,
+    comment_count: 0,
+    flag_count: 0,
+    relationship_count: 0,
+    last_comment_at: null,
+    verified_by: null,
+    embedding: new Array(768).fill(0.1),
+  };
+}
+
+export async function commitCount(root: string): Promise<number> {
+  try {
+    const log = await simpleGit({ baseDir: root }).env(scrubGitEnv()).log();
+    return log.total;
+  } catch {
+    return 0;
+  }
+}
+
+export async function lastCommitMessage(root: string): Promise<string> {
+  const log = await simpleGit({ baseDir: root }).env(scrubGitEnv()).log();
+  return `${log.latest?.message ?? ""}\n\n${log.latest?.body ?? ""}`;
+}

--- a/tests/contract/repositories/comment-repository-git.test.ts
+++ b/tests/contract/repositories/comment-repository-git.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { vaultGitFactory, type TestBackend } from "./_factories.js";
+import { commitCount, lastCommitMessage, makeMemory } from "./_git-helpers.js";
+
+describe("CommentRepository git commits — vault", () => {
+  let backend: TestBackend;
+
+  beforeAll(async () => {
+    backend = await vaultGitFactory.create();
+  });
+
+  afterAll(async () => {
+    await backend.close();
+  });
+
+  it("create produces one commit with AB-Action: commented", async () => {
+    const root = backend.gitRoot!;
+    await backend.memoryRepo.create(makeMemory("m-comment"));
+    const before = await commitCount(root);
+    await backend.commentRepo.create({
+      id: "c1",
+      memory_id: "m-comment",
+      author: "alice",
+      content: "hi",
+    });
+    const after = await commitCount(root);
+    expect(after - before).toBe(1);
+    const msg = await lastCommitMessage(root);
+    expect(msg).toContain("AB-Action: commented");
+    expect(msg).toContain("AB-Memory: m-comment");
+    expect(msg).toContain("AB-Actor: alice");
+  });
+});

--- a/tests/contract/repositories/flag-repository-git.test.ts
+++ b/tests/contract/repositories/flag-repository-git.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { vaultGitFactory, type TestBackend } from "./_factories.js";
+import { commitCount, lastCommitMessage, makeMemory } from "./_git-helpers.js";
+import type { Flag } from "../../../src/types/flag.js";
+
+function makeFlag(id: string, memoryId: string): Flag {
+  return {
+    id,
+    project_id: "p1",
+    memory_id: memoryId,
+    flag_type: "duplicate",
+    severity: "needs_review",
+    details: { reason: "test" },
+    resolved_at: null,
+    resolved_by: null,
+    created_at: new Date("2026-04-22T00:00:00Z"),
+  };
+}
+
+describe("FlagRepository git commits — vault", () => {
+  let backend: TestBackend;
+
+  beforeAll(async () => {
+    backend = await vaultGitFactory.create();
+  });
+
+  afterAll(async () => {
+    await backend.close();
+  });
+
+  it("create produces one commit with AB-Action: flagged and AB-Actor: system", async () => {
+    const root = backend.gitRoot!;
+    await backend.memoryRepo.create(makeMemory("m-flag"));
+    const before = await commitCount(root);
+    await backend.flagRepo.create(makeFlag("f1", "m-flag"));
+    const after = await commitCount(root);
+    expect(after - before).toBe(1);
+    const msg = await lastCommitMessage(root);
+    expect(msg).toContain("AB-Action: flagged");
+    expect(msg).toContain("AB-Memory: m-flag");
+    expect(msg).toContain("AB-Actor: system");
+  });
+
+  it("resolve produces one commit with AB-Action: unflagged and AB-Actor: <resolver>", async () => {
+    const root = backend.gitRoot!;
+    await backend.memoryRepo.create(makeMemory("m-flag-res"));
+    await backend.flagRepo.create(makeFlag("f2", "m-flag-res"));
+    const before = await commitCount(root);
+    const resolved = await backend.flagRepo.resolve("f2", "bob", "accepted");
+    expect(resolved).not.toBeNull();
+    const after = await commitCount(root);
+    expect(after - before).toBe(1);
+    const msg = await lastCommitMessage(root);
+    expect(msg).toContain("AB-Action: unflagged");
+    expect(msg).toContain("AB-Actor: bob");
+  });
+});

--- a/tests/contract/repositories/memory-repository-concurrent-git.test.ts
+++ b/tests/contract/repositories/memory-repository-concurrent-git.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { vaultGitFactory, type TestBackend } from "./_factories.js";
+import { commitCount, makeMemory } from "./_git-helpers.js";
+import { simpleGit } from "simple-git";
+import { scrubGitEnv } from "../../../src/backend/vault/git/env.js";
+
+describe("MemoryRepository concurrent writers — vault git", () => {
+  let backend: TestBackend;
+
+  beforeAll(async () => {
+    backend = await vaultGitFactory.create();
+  });
+
+  afterAll(async () => {
+    await backend.close();
+  });
+
+  it("two parallel creates produce two commits, each attributed to the right memory", async () => {
+    const root = backend.gitRoot!;
+    const before = await commitCount(root);
+    await Promise.all([
+      backend.memoryRepo.create(makeMemory("c-a")),
+      backend.memoryRepo.create(makeMemory("c-b")),
+    ]);
+    const after = await commitCount(root);
+    expect(after - before).toBe(2);
+
+    const log = await simpleGit({ baseDir: root }).env(scrubGitEnv()).log();
+    const recent = log.all.slice(0, 2);
+    const allTrailers = recent
+      .map((c) => `${c.message}\n\n${c.body}`)
+      .join("\n---\n");
+    // Neither trailer should appear twice, and both should appear once.
+    expect((allTrailers.match(/AB-Memory: c-a/g) ?? []).length).toBe(1);
+    expect((allTrailers.match(/AB-Memory: c-b/g) ?? []).length).toBe(1);
+  });
+});

--- a/tests/contract/repositories/memory-repository-git.test.ts
+++ b/tests/contract/repositories/memory-repository-git.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { simpleGit } from "simple-git";
+import { vaultGitFactory, type TestBackend } from "./_factories.js";
+import { scrubGitEnv } from "../../../src/backend/vault/git/env.js";
+import type { Memory, MemoryScope } from "../../../src/types/memory.js";
+
+function makeMemory(
+  id: string,
+  scope: MemoryScope = "workspace",
+): Memory & { embedding: number[] } {
+  const now = new Date("2026-04-22T00:00:00Z");
+  return {
+    id,
+    project_id: "p1",
+    workspace_id: scope === "project" ? null : "ws1",
+    content: `body-${id}`,
+    title: `t-${id}`,
+    type: "fact",
+    scope,
+    tags: null,
+    author: "alice",
+    source: null,
+    session_id: null,
+    metadata: null,
+    embedding_model: null,
+    embedding_dimensions: 768,
+    version: 1,
+    created_at: now,
+    updated_at: now,
+    verified_at: null,
+    archived_at: null,
+    comment_count: 0,
+    flag_count: 0,
+    relationship_count: 0,
+    last_comment_at: null,
+    verified_by: null,
+    embedding: new Array(768).fill(0.1),
+  };
+}
+
+async function commitCount(root: string): Promise<number> {
+  try {
+    const log = await simpleGit({ baseDir: root }).env(scrubGitEnv()).log();
+    return log.total;
+  } catch {
+    return 0;
+  }
+}
+
+async function lastCommitMessage(root: string): Promise<string> {
+  const log = await simpleGit({ baseDir: root }).env(scrubGitEnv()).log();
+  return `${log.latest?.message ?? ""}\n\n${log.latest?.body ?? ""}`;
+}
+
+describe("MemoryRepository git commits — vault", () => {
+  let backend: TestBackend;
+
+  beforeAll(async () => {
+    backend = await vaultGitFactory.create();
+  });
+
+  afterAll(async () => {
+    await backend.close();
+  });
+
+  it("create produces one commit with AB-Action: created", async () => {
+    const root = backend.gitRoot!;
+    const before = await commitCount(root);
+    await backend.memoryRepo.create(makeMemory("m-create"));
+    const after = await commitCount(root);
+    expect(after - before).toBe(1);
+    const msg = await lastCommitMessage(root);
+    expect(msg).toContain("AB-Action: created");
+    expect(msg).toContain("AB-Memory: m-create");
+    expect(msg).toContain("AB-Actor: alice");
+  });
+
+  it("update produces one commit with AB-Action: updated", async () => {
+    const root = backend.gitRoot!;
+    const before = await commitCount(root);
+    await backend.memoryRepo.update("m-create", 1, { content: "new body" });
+    const after = await commitCount(root);
+    expect(after - before).toBe(1);
+    expect(await lastCommitMessage(root)).toContain("AB-Action: updated");
+  });
+
+  it("archive produces one commit per archived id", async () => {
+    const root = backend.gitRoot!;
+    await backend.memoryRepo.create(makeMemory("m-arc-a"));
+    await backend.memoryRepo.create(makeMemory("m-arc-b"));
+    const before = await commitCount(root);
+    const n = await backend.memoryRepo.archive(["m-arc-a", "m-arc-b"]);
+    expect(n).toBe(2);
+    const after = await commitCount(root);
+    expect(after - before).toBe(2);
+  });
+
+  it("verify produces one commit with AB-Action: verified and AB-Actor: <verifier>", async () => {
+    const root = backend.gitRoot!;
+    await backend.memoryRepo.create(makeMemory("m-verify"));
+    const before = await commitCount(root);
+    await backend.memoryRepo.verify("m-verify", "reviewer-bob");
+    const after = await commitCount(root);
+    expect(after - before).toBe(1);
+    const msg = await lastCommitMessage(root);
+    expect(msg).toContain("AB-Action: verified");
+    expect(msg).toContain("AB-Actor: reviewer-bob");
+  });
+});

--- a/tests/contract/repositories/memory-repository-track-users-git.test.ts
+++ b/tests/contract/repositories/memory-repository-track-users-git.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { makeVaultGitFactory, type TestBackend } from "./_factories.js";
+import { commitCount, lastCommitMessage, makeMemory } from "./_git-helpers.js";
+import type { Memory, MemoryScope } from "../../../src/types/memory.js";
+
+function makeUserScoped(id: string): Memory & { embedding: number[] } {
+  return {
+    ...makeMemory(id, "user" as MemoryScope),
+    content: `private-${id}`,
+  };
+}
+
+describe("MemoryRepository user-scope commits with trackUsersInGit=true — vault", () => {
+  let backend: TestBackend;
+
+  beforeAll(async () => {
+    backend = await makeVaultGitFactory({ trackUsersInGit: true }).create();
+  });
+
+  afterAll(async () => {
+    await backend.close();
+  });
+
+  it("does not list users/ in .gitignore when trackUsersInGit=true", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const { join } = await import("node:path");
+    const body = await readFile(join(backend.gitRoot!, ".gitignore"), "utf8");
+    expect(body.split("\n").map((l) => l.trim())).not.toContain("users/");
+  });
+
+  it("user-scope create produces one commit with AB-Action: created", async () => {
+    const root = backend.gitRoot!;
+    const before = await commitCount(root);
+    await backend.memoryRepo.create(makeUserScoped("m-u-track"));
+    const after = await commitCount(root);
+    expect(after - before).toBe(1);
+    const msg = await lastCommitMessage(root);
+    expect(msg).toContain("AB-Action: created");
+    expect(msg).toContain("AB-Memory: m-u-track");
+  });
+
+  it("user-scope comment produces one commit with AB-Action: commented", async () => {
+    const root = backend.gitRoot!;
+    const before = await commitCount(root);
+    await backend.commentRepo.create({
+      id: "c-u1",
+      memory_id: "m-u-track",
+      author: "alice",
+      content: "note",
+    });
+    const after = await commitCount(root);
+    expect(after - before).toBe(1);
+    expect(await lastCommitMessage(root)).toContain("AB-Action: commented");
+  });
+});

--- a/tests/contract/repositories/relationship-repository-git.test.ts
+++ b/tests/contract/repositories/relationship-repository-git.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { vaultGitFactory, type TestBackend } from "./_factories.js";
+import { commitCount, lastCommitMessage, makeMemory } from "./_git-helpers.js";
+import type { Relationship } from "../../../src/types/relationship.js";
+
+function makeRelationship(
+  id: string,
+  sourceId: string,
+  targetId: string,
+): Relationship {
+  return {
+    id,
+    project_id: "p1",
+    source_id: sourceId,
+    target_id: targetId,
+    type: "refines",
+    description: null,
+    confidence: 1,
+    created_by: "alice",
+    created_via: null,
+    archived_at: null,
+    created_at: new Date("2026-04-22T00:00:00Z"),
+  };
+}
+
+describe("RelationshipRepository git commits — vault", () => {
+  let backend: TestBackend;
+
+  beforeAll(async () => {
+    backend = await vaultGitFactory.create();
+  });
+
+  afterAll(async () => {
+    await backend.close();
+  });
+
+  it("create produces one commit with AB-Action: related and AB-Actor: <created_by>", async () => {
+    const root = backend.gitRoot!;
+    await backend.memoryRepo.create(makeMemory("m-rel-src"));
+    await backend.memoryRepo.create(makeMemory("m-rel-tgt"));
+    const before = await commitCount(root);
+    await backend.relationshipRepo.create(
+      makeRelationship("r1", "m-rel-src", "m-rel-tgt"),
+    );
+    const after = await commitCount(root);
+    expect(after - before).toBe(1);
+    const msg = await lastCommitMessage(root);
+    expect(msg).toContain("AB-Action: related");
+    expect(msg).toContain("AB-Memory: m-rel-src");
+    expect(msg).toContain("AB-Actor: alice");
+  });
+
+  it("archiveById produces one commit with AB-Action: unrelated", async () => {
+    const root = backend.gitRoot!;
+    await backend.memoryRepo.create(makeMemory("m-rel-src-b"));
+    await backend.memoryRepo.create(makeMemory("m-rel-tgt-b"));
+    await backend.relationshipRepo.create(
+      makeRelationship("r2", "m-rel-src-b", "m-rel-tgt-b"),
+    );
+    const before = await commitCount(root);
+    const ok = await backend.relationshipRepo.archiveById("r2");
+    expect(ok).toBe(true);
+    const after = await commitCount(root);
+    expect(after - before).toBe(1);
+    const msg = await lastCommitMessage(root);
+    expect(msg).toContain("AB-Action: unrelated");
+  });
+});

--- a/tests/contract/repositories/users-gitignore-invariant.test.ts
+++ b/tests/contract/repositories/users-gitignore-invariant.test.ts
@@ -37,22 +37,83 @@ function makeUserScoped(id: string): Memory & { embedding: number[] } {
   };
 }
 
+async function removeUsersRule(root: string): Promise<void> {
+  const path = join(root, ".gitignore");
+  const body = await readFile(path, "utf8");
+  await writeFile(
+    path,
+    body
+      .split("\n")
+      .filter((l) => l.trim() !== "users/")
+      .join("\n"),
+    "utf8",
+  );
+}
+
 describe("users-gitignore invariant — vault", () => {
   it("refuses user-scope create when users/ rule is removed", async () => {
     const backend: TestBackend = await vaultGitFactory.create();
     try {
-      const path = join(backend.gitRoot!, ".gitignore");
-      const body = await readFile(path, "utf8");
-      await writeFile(
-        path,
-        body
-          .split("\n")
-          .filter((l) => l.trim() !== "users/")
-          .join("\n"),
-        "utf8",
-      );
+      await removeUsersRule(backend.gitRoot!);
       await expect(
         backend.memoryRepo.create(makeUserScoped("m-u1")),
+      ).rejects.toThrow(DomainError);
+    } finally {
+      await backend.close();
+    }
+  });
+
+  it("refuses user-scope update when users/ rule is removed", async () => {
+    const backend: TestBackend = await vaultGitFactory.create();
+    try {
+      const m = await backend.memoryRepo.create(makeUserScoped("m-u-upd"));
+      await removeUsersRule(backend.gitRoot!);
+      await expect(
+        backend.memoryRepo.update(m.id, m.version, { content: "x" }),
+      ).rejects.toThrow(DomainError);
+    } finally {
+      await backend.close();
+    }
+  });
+
+  it("refuses user-scope verify when users/ rule is removed", async () => {
+    const backend: TestBackend = await vaultGitFactory.create();
+    try {
+      await backend.memoryRepo.create(makeUserScoped("m-u-ver"));
+      await removeUsersRule(backend.gitRoot!);
+      await expect(backend.memoryRepo.verify("m-u-ver", "bob")).rejects.toThrow(
+        DomainError,
+      );
+    } finally {
+      await backend.close();
+    }
+  });
+
+  it("refuses user-scope archive when users/ rule is removed", async () => {
+    const backend: TestBackend = await vaultGitFactory.create();
+    try {
+      await backend.memoryRepo.create(makeUserScoped("m-u-arc"));
+      await removeUsersRule(backend.gitRoot!);
+      await expect(backend.memoryRepo.archive(["m-u-arc"])).rejects.toThrow(
+        DomainError,
+      );
+    } finally {
+      await backend.close();
+    }
+  });
+
+  it("refuses comment on user-scope memory when users/ rule is removed", async () => {
+    const backend: TestBackend = await vaultGitFactory.create();
+    try {
+      await backend.memoryRepo.create(makeUserScoped("m-u-cmt"));
+      await removeUsersRule(backend.gitRoot!);
+      await expect(
+        backend.commentRepo.create({
+          id: "c1",
+          memory_id: "m-u-cmt",
+          author: "alice",
+          content: "leak",
+        }),
       ).rejects.toThrow(DomainError);
     } finally {
       await backend.close();

--- a/tests/contract/repositories/users-gitignore-invariant.test.ts
+++ b/tests/contract/repositories/users-gitignore-invariant.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { vaultGitFactory, type TestBackend } from "./_factories.js";
+import { DomainError } from "../../../src/utils/errors.js";
+import { commitCount } from "./_git-helpers.js";
+import type { Memory } from "../../../src/types/memory.js";
+
+function makeUserScoped(id: string): Memory & { embedding: number[] } {
+  const now = new Date("2026-04-22T00:00:00Z");
+  return {
+    id,
+    project_id: "p1",
+    workspace_id: "ws1",
+    scope: "user",
+    content: "private",
+    title: `u-${id}`,
+    type: "fact",
+    tags: null,
+    author: "alice",
+    source: null,
+    session_id: null,
+    metadata: null,
+    embedding_model: null,
+    embedding_dimensions: 768,
+    version: 1,
+    created_at: now,
+    updated_at: now,
+    verified_at: null,
+    archived_at: null,
+    comment_count: 0,
+    flag_count: 0,
+    relationship_count: 0,
+    last_comment_at: null,
+    verified_by: null,
+    embedding: new Array(768).fill(0.1),
+  };
+}
+
+describe("users-gitignore invariant — vault", () => {
+  it("refuses user-scope create when users/ rule is removed", async () => {
+    const backend: TestBackend = await vaultGitFactory.create();
+    try {
+      const path = join(backend.gitRoot!, ".gitignore");
+      const body = await readFile(path, "utf8");
+      await writeFile(
+        path,
+        body
+          .split("\n")
+          .filter((l) => l.trim() !== "users/")
+          .join("\n"),
+        "utf8",
+      );
+      await expect(
+        backend.memoryRepo.create(makeUserScoped("m-u1")),
+      ).rejects.toThrow(DomainError);
+    } finally {
+      await backend.close();
+    }
+  });
+
+  it("user-scope create with trackUsersInGit=false writes markdown + lance but no commit", async () => {
+    const backend: TestBackend = await vaultGitFactory.create();
+    try {
+      const root = backend.gitRoot!;
+      const before = await commitCount(root);
+      const mem = await backend.memoryRepo.create(makeUserScoped("m-u2"));
+      expect(mem.id).toBe("m-u2");
+      const after = await commitCount(root);
+      expect(after - before).toBe(0);
+      expect(await backend.memoryRepo.findById("m-u2")).not.toBeNull();
+    } finally {
+      await backend.close();
+    }
+  });
+});

--- a/tests/contract/repositories/workspace-repository-git.test.ts
+++ b/tests/contract/repositories/workspace-repository-git.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { vaultGitFactory, type TestBackend } from "./_factories.js";
+import { commitCount, lastCommitMessage } from "./_git-helpers.js";
+
+describe("WorkspaceRepository git commits — vault", () => {
+  let backend: TestBackend;
+
+  beforeAll(async () => {
+    backend = await vaultGitFactory.create();
+  });
+
+  afterAll(async () => {
+    await backend.close();
+  });
+
+  it("findOrCreate produces one commit with AB-Action: workspace_upsert on first call", async () => {
+    const root = backend.gitRoot!;
+    const before = await commitCount(root);
+    await backend.workspaceRepo.findOrCreate("ws-new");
+    const after = await commitCount(root);
+    expect(after - before).toBe(1);
+    const msg = await lastCommitMessage(root);
+    expect(msg).toContain("AB-Action: workspace_upsert");
+    expect(msg).toContain("AB-Workspace: ws-new");
+  });
+
+  it("findOrCreate is idempotent: second call produces no new commit", async () => {
+    const root = backend.gitRoot!;
+    await backend.workspaceRepo.findOrCreate("ws-idempotent");
+    const after1 = await commitCount(root);
+    await backend.workspaceRepo.findOrCreate("ws-idempotent");
+    const after2 = await commitCount(root);
+    expect(after2).toBe(after1);
+  });
+});

--- a/tests/integration/vector-parity.test.ts
+++ b/tests/integration/vector-parity.test.ts
@@ -8,6 +8,7 @@ import { DrizzleWorkspaceRepository } from "../../src/repositories/workspace-rep
 import { VaultMemoryRepository } from "../../src/backend/vault/repositories/memory-repository.js";
 import { VaultWorkspaceRepository } from "../../src/backend/vault/repositories/workspace-repository.js";
 import { VaultVectorIndex } from "../../src/backend/vault/vector/lance-index.js";
+import { NOOP_GIT_OPS } from "../../src/backend/vault/git/types.js";
 import { getTestDb, truncateAll } from "../helpers.js";
 import type { Memory } from "../../src/types/memory.js";
 
@@ -38,10 +39,17 @@ describe("vector parity — pg vs vault", () => {
     await truncateAll();
     root = await mkdtemp(join(tmpdir(), "parity-"));
     idx = await VaultVectorIndex.create({ root, dims: DIMS });
-    vault = await VaultMemoryRepository.create({ root, index: idx });
+    vault = await VaultMemoryRepository.create({
+      root,
+      index: idx,
+      gitOps: NOOP_GIT_OPS,
+    });
     pg = new DrizzleMemoryRepository(db);
     await new DrizzleWorkspaceRepository(db).findOrCreate("ws1");
-    await new VaultWorkspaceRepository({ root }).findOrCreate("ws1");
+    await new VaultWorkspaceRepository({
+      root,
+      gitOps: NOOP_GIT_OPS,
+    }).findOrCreate("ws1");
 
     const rng = seedrandom("parity-seed");
     const now = new Date();

--- a/tests/unit/backend/vault/git/bootstrap.test.ts
+++ b/tests/unit/backend/vault/git/bootstrap.test.ts
@@ -43,6 +43,31 @@ describe("ensureVaultGit", () => {
     expect(usersCount).toBe(1);
   });
 
+  it("appends *.md merge=union to an existing .gitattributes, preserving prior rules", async () => {
+    await writeFile(join(root, ".gitattributes"), "*.json binary\n", "utf8");
+    await ensureVaultGit({ root, trackUsers: false });
+    const attrs = await readFile(join(root, ".gitattributes"), "utf8");
+    expect(attrs).toContain("*.json binary");
+    expect(attrs).toContain("*.md merge=union");
+  });
+
+  it("throws VAULT_BOOTSTRAP_FAILED if the required rule is only inside a comment", async () => {
+    await writeFile(
+      join(root, ".gitattributes"),
+      "# reminder: *.md merge=union\n",
+      "utf8",
+    );
+    await ensureVaultGit({ root, trackUsers: false });
+    // hasActiveRule is line-based, so the comment should not count as
+    // present — bootstrap must append the real rule.
+    const attrs = await readFile(join(root, ".gitattributes"), "utf8");
+    const active = attrs
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l !== "" && !l.startsWith("#"));
+    expect(active).toContain("*.md merge=union");
+  });
+
   it("is idempotent: second call produces byte-identical files", async () => {
     await ensureVaultGit({ root, trackUsers: false });
     const ignoreA = await readFile(join(root, ".gitignore"), "utf8");
@@ -54,7 +79,7 @@ describe("ensureVaultGit", () => {
     expect(attrsB).toBe(attrsA);
   });
 
-  it("leaves an existing git repo alone", async () => {
+  it("preserves pre-existing commits and adds a bootstrap commit for new files", async () => {
     const git = simpleGit(root).env(scrubGitEnv());
     await git.init();
     await git.addConfig("user.email", "t@t");
@@ -62,6 +87,20 @@ describe("ensureVaultGit", () => {
     await writeFile(join(root, "pre.md"), "x", "utf8");
     await git.add("pre.md");
     await git.commit("pre");
+    const preHash = (await git.log()).latest?.hash;
+    await ensureVaultGit({ root, trackUsers: false });
+    const log = await git.log();
+    // Pre-existing commit still on the history.
+    expect(log.all.some((c) => c.hash === preHash)).toBe(true);
+    // New HEAD is the bootstrap commit for .gitignore/.gitattributes.
+    expect(log.latest?.message).toContain(
+      "bootstrap: initialize vault structure",
+    );
+  });
+
+  it("does not re-commit when .gitignore and .gitattributes already match", async () => {
+    await ensureVaultGit({ root, trackUsers: false });
+    const git = simpleGit(root).env(scrubGitEnv());
     const headBefore = (await git.log()).latest?.hash;
     await ensureVaultGit({ root, trackUsers: false });
     const headAfter = (await git.log()).latest?.hash;

--- a/tests/unit/backend/vault/git/bootstrap.test.ts
+++ b/tests/unit/backend/vault/git/bootstrap.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { simpleGit } from "simple-git";
+import { ensureVaultGit } from "../../../../../src/backend/vault/git/bootstrap.js";
+
+describe("ensureVaultGit", () => {
+  let root: string;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "bootstrap-"));
+  });
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("creates a git repo, .gitignore, and .gitattributes on a fresh dir", async () => {
+    await ensureVaultGit({ root, trackUsers: false });
+    const git = simpleGit(root);
+    expect(await git.checkIsRepo()).toBe(true);
+    const ignore = await readFile(join(root, ".gitignore"), "utf8");
+    expect(ignore).toContain(".agent-brain/");
+    expect(ignore).toContain("users/");
+    const attrs = await readFile(join(root, ".gitattributes"), "utf8");
+    expect(attrs).toContain("*.md merge=union");
+  });
+
+  it("omits users/ from .gitignore when trackUsers=true", async () => {
+    await ensureVaultGit({ root, trackUsers: true });
+    const ignore = await readFile(join(root, ".gitignore"), "utf8");
+    expect(ignore).not.toMatch(/^users\/$/m);
+  });
+
+  it("merges into an existing .gitignore without duplicating rules", async () => {
+    await writeFile(join(root, ".gitignore"), "node_modules\nusers/\n", "utf8");
+    await ensureVaultGit({ root, trackUsers: false });
+    const ignore = await readFile(join(root, ".gitignore"), "utf8");
+    expect(ignore).toContain("node_modules");
+    const usersCount = ignore
+      .split("\n")
+      .filter((l) => l.trim() === "users/").length;
+    expect(usersCount).toBe(1);
+  });
+
+  it("is idempotent: second call produces byte-identical files", async () => {
+    await ensureVaultGit({ root, trackUsers: false });
+    const ignoreA = await readFile(join(root, ".gitignore"), "utf8");
+    const attrsA = await readFile(join(root, ".gitattributes"), "utf8");
+    await ensureVaultGit({ root, trackUsers: false });
+    const ignoreB = await readFile(join(root, ".gitignore"), "utf8");
+    const attrsB = await readFile(join(root, ".gitattributes"), "utf8");
+    expect(ignoreB).toBe(ignoreA);
+    expect(attrsB).toBe(attrsA);
+  });
+
+  it("leaves an existing git repo alone", async () => {
+    const git = simpleGit(root);
+    await git.init();
+    await git.addConfig("user.email", "t@t");
+    await git.addConfig("user.name", "t");
+    await writeFile(join(root, "pre.md"), "x", "utf8");
+    await git.add("pre.md");
+    await git.commit("pre");
+    const headBefore = (await git.log()).latest?.hash;
+    await ensureVaultGit({ root, trackUsers: false });
+    const headAfter = (await git.log()).latest?.hash;
+    expect(headAfter).toBe(headBefore);
+  });
+});

--- a/tests/unit/backend/vault/git/bootstrap.test.ts
+++ b/tests/unit/backend/vault/git/bootstrap.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { simpleGit } from "simple-git";
 import { ensureVaultGit } from "../../../../../src/backend/vault/git/bootstrap.js";
+import { scrubGitEnv } from "../../../../../src/backend/vault/git/env.js";
 
 describe("ensureVaultGit", () => {
   let root: string;
@@ -16,7 +17,7 @@ describe("ensureVaultGit", () => {
 
   it("creates a git repo, .gitignore, and .gitattributes on a fresh dir", async () => {
     await ensureVaultGit({ root, trackUsers: false });
-    const git = simpleGit(root);
+    const git = simpleGit(root).env(scrubGitEnv());
     expect(await git.checkIsRepo()).toBe(true);
     const ignore = await readFile(join(root, ".gitignore"), "utf8");
     expect(ignore).toContain(".agent-brain/");
@@ -54,7 +55,7 @@ describe("ensureVaultGit", () => {
   });
 
   it("leaves an existing git repo alone", async () => {
-    const git = simpleGit(root);
+    const git = simpleGit(root).env(scrubGitEnv());
     await git.init();
     await git.addConfig("user.email", "t@t");
     await git.addConfig("user.name", "t");

--- a/tests/unit/backend/vault/git/env-isolation.test.ts
+++ b/tests/unit/backend/vault/git/env-isolation.test.ts
@@ -68,7 +68,10 @@ describe("vault/git: env isolation under GIT_DIR / GIT_WORK_TREE", () => {
 
   it("ensureVaultGit initializes cfg.root, not the outer repo", async () => {
     await ensureVaultGit({ root, trackUsers: false });
-    expect(await commitCount(root)).toBe(0);
     expect(await simpleGit(root).env(scrubGitEnv()).checkIsRepo()).toBe(true);
+    // Bootstrap commits .gitignore + .gitattributes to the inner repo;
+    // the outer repo must stay untouched despite GIT_DIR pointing at it.
+    expect(await commitCount(root)).toBe(1);
+    expect(await commitCount(outer)).toBe(0);
   });
 });

--- a/tests/unit/backend/vault/git/env-isolation.test.ts
+++ b/tests/unit/backend/vault/git/env-isolation.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { simpleGit } from "simple-git";
+import { GitOpsImpl } from "../../../../../src/backend/vault/git/git-ops.js";
+import { ensureVaultGit } from "../../../../../src/backend/vault/git/bootstrap.js";
+import { scrubGitEnv } from "../../../../../src/backend/vault/git/env.js";
+
+// Regression: when GIT_DIR / GIT_WORK_TREE are set in the process env
+// (husky hooks, parent git commands, editor plugins), they silently
+// override simple-git's baseDir. Without scrubbing, every vault git op
+// writes to the outer repo instead of the vault root. Guard both
+// GitOpsImpl and ensureVaultGit.
+describe("vault/git: env isolation under GIT_DIR / GIT_WORK_TREE", () => {
+  let root: string;
+  let outer: string;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "vault-env-"));
+    outer = await mkdtemp(join(tmpdir(), "outer-"));
+    await simpleGit(outer).env(scrubGitEnv()).init();
+    saved.GIT_DIR = process.env.GIT_DIR;
+    saved.GIT_WORK_TREE = process.env.GIT_WORK_TREE;
+    saved.GIT_INDEX_FILE = process.env.GIT_INDEX_FILE;
+    process.env.GIT_DIR = join(outer, ".git");
+    process.env.GIT_WORK_TREE = outer;
+    delete process.env.GIT_INDEX_FILE;
+  });
+
+  afterEach(async () => {
+    if (saved.GIT_DIR === undefined) delete process.env.GIT_DIR;
+    else process.env.GIT_DIR = saved.GIT_DIR;
+    if (saved.GIT_WORK_TREE === undefined) delete process.env.GIT_WORK_TREE;
+    else process.env.GIT_WORK_TREE = saved.GIT_WORK_TREE;
+    if (saved.GIT_INDEX_FILE === undefined) delete process.env.GIT_INDEX_FILE;
+    else process.env.GIT_INDEX_FILE = saved.GIT_INDEX_FILE;
+    await rm(root, { recursive: true, force: true });
+    await rm(outer, { recursive: true, force: true });
+  });
+
+  it("GitOpsImpl commits to cfg.root, not the outer repo targeted by GIT_DIR", async () => {
+    const ops = new GitOpsImpl({ root });
+    await ops.init();
+    const inner = simpleGit(root).env(scrubGitEnv());
+    await inner.addConfig("user.email", "t@t");
+    await inner.addConfig("user.name", "t");
+    await writeFile(join(root, "a.md"), "x", "utf8");
+    await ops.stageAndCommit(["a.md"], "s", {
+      action: "created",
+      memoryId: "abc",
+      actor: "alice",
+    });
+    const innerLog = await simpleGit(root).env(scrubGitEnv()).log();
+    expect(innerLog.total).toBe(1);
+    expect(await commitCount(outer)).toBe(0);
+  });
+
+  async function commitCount(dir: string): Promise<number> {
+    try {
+      const log = await simpleGit(dir).env(scrubGitEnv()).log();
+      return log.total;
+    } catch {
+      return 0;
+    }
+  }
+
+  it("ensureVaultGit initializes cfg.root, not the outer repo", async () => {
+    await ensureVaultGit({ root, trackUsers: false });
+    expect(await commitCount(root)).toBe(0);
+    expect(await simpleGit(root).env(scrubGitEnv()).checkIsRepo()).toBe(true);
+  });
+});

--- a/tests/unit/backend/vault/git/git-ops.test.ts
+++ b/tests/unit/backend/vault/git/git-ops.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { simpleGit } from "simple-git";
+import { GitOpsImpl } from "../../../../../src/backend/vault/git/git-ops.js";
+
+describe("GitOpsImpl", () => {
+  let root: string;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "gitops-"));
+  });
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("isRepo returns false for a non-git directory", async () => {
+    const ops = new GitOpsImpl({ root });
+    expect(await ops.isRepo()).toBe(false);
+  });
+
+  it("init turns a directory into a git repo", async () => {
+    const ops = new GitOpsImpl({ root });
+    await ops.init();
+    expect(await ops.isRepo()).toBe(true);
+  });
+
+  it("init is idempotent", async () => {
+    const ops = new GitOpsImpl({ root });
+    await ops.init();
+    await ops.init();
+    expect(await ops.isRepo()).toBe(true);
+  });
+
+  it("stageAndCommit stages listed paths and commits with trailers", async () => {
+    const ops = new GitOpsImpl({ root });
+    await ops.init();
+    await configUser(root);
+    await mkdir(join(root, "sub"), { recursive: true });
+    await writeFile(join(root, "sub/a.md"), "# a", "utf8");
+    await ops.stageAndCommit(
+      ["sub/a.md"],
+      "[agent-brain] created: A",
+      {
+        action: "created",
+        memoryId: "abc",
+        actor: "alice",
+      },
+    );
+    const git = simpleGit(root);
+    const log = await git.log();
+    expect(log.latest?.message).toMatch(/^\[agent-brain\] created: A/);
+    expect(log.latest?.body).toContain("AB-Action: created");
+    expect(log.latest?.body).toContain("AB-Memory: abc");
+    expect(log.latest?.body).toContain("AB-Actor: alice");
+  });
+
+  it("stageAndCommit throws a typed error when the working tree has no changes", async () => {
+    const ops = new GitOpsImpl({ root });
+    await ops.init();
+    await configUser(root);
+    await writeFile(join(root, "a.md"), "x", "utf8");
+    await ops.stageAndCommit(["a.md"], "s", {
+      action: "created",
+      memoryId: "abc",
+      actor: "alice",
+    });
+    await expect(
+      ops.stageAndCommit(["a.md"], "s2", {
+        action: "updated",
+        memoryId: "abc",
+        actor: "alice",
+      }),
+    ).rejects.toThrow(/nothing to commit/i);
+  });
+
+  it("status returns clean=true on an empty repo with no staged changes", async () => {
+    const ops = new GitOpsImpl({ root });
+    await ops.init();
+    expect((await ops.status()).clean).toBe(true);
+  });
+});
+
+async function configUser(root: string): Promise<void> {
+  const git = simpleGit(root);
+  await git.addConfig("user.email", "test@example.com");
+  await git.addConfig("user.name", "Test");
+}

--- a/tests/unit/backend/vault/git/git-ops.test.ts
+++ b/tests/unit/backend/vault/git/git-ops.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { simpleGit } from "simple-git";
 import { GitOpsImpl } from "../../../../../src/backend/vault/git/git-ops.js";
+import { scrubGitEnv } from "../../../../../src/backend/vault/git/env.js";
 
 describe("GitOpsImpl", () => {
   let root: string;
@@ -38,16 +39,12 @@ describe("GitOpsImpl", () => {
     await configUser(root);
     await mkdir(join(root, "sub"), { recursive: true });
     await writeFile(join(root, "sub/a.md"), "# a", "utf8");
-    await ops.stageAndCommit(
-      ["sub/a.md"],
-      "[agent-brain] created: A",
-      {
-        action: "created",
-        memoryId: "abc",
-        actor: "alice",
-      },
-    );
-    const git = simpleGit(root);
+    await ops.stageAndCommit(["sub/a.md"], "[agent-brain] created: A", {
+      action: "created",
+      memoryId: "abc",
+      actor: "alice",
+    });
+    const git = simpleGit(root).env(scrubGitEnv());
     const log = await git.log();
     expect(log.latest?.message).toMatch(/^\[agent-brain\] created: A/);
     expect(log.latest?.body).toContain("AB-Action: created");
@@ -82,7 +79,7 @@ describe("GitOpsImpl", () => {
 });
 
 async function configUser(root: string): Promise<void> {
-  const git = simpleGit(root);
+  const git = simpleGit(root).env(scrubGitEnv());
   await git.addConfig("user.email", "test@example.com");
   await git.addConfig("user.name", "Test");
 }

--- a/tests/unit/backend/vault/git/gitignore-merge.test.ts
+++ b/tests/unit/backend/vault/git/gitignore-merge.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { mergeGitignore } from "../../../../../src/backend/vault/git/gitignore-merge.js";
+
+describe("mergeGitignore", () => {
+  const required = [".agent-brain/", "_sessions/", "users/"];
+
+  it("writes all required lines when file is empty", () => {
+    expect(mergeGitignore("", required)).toContain(".agent-brain/");
+    expect(mergeGitignore("", required)).toContain("users/");
+  });
+
+  it("is idempotent — running twice produces the same output", () => {
+    const once = mergeGitignore("node_modules\n", required);
+    const twice = mergeGitignore(once, required);
+    expect(twice).toBe(once);
+  });
+
+  it("preserves existing user rules and comments", () => {
+    const src = "# my rules\nnode_modules\n*.log\n";
+    const out = mergeGitignore(src, required);
+    expect(out).toContain("# my rules");
+    expect(out).toContain("node_modules");
+    expect(out).toContain("*.log");
+  });
+
+  it("does not duplicate a rule already present", () => {
+    const src = "users/\n";
+    const out = mergeGitignore(src, required);
+    const occurrences = out
+      .split("\n")
+      .filter((l) => l.trim() === "users/").length;
+    expect(occurrences).toBe(1);
+  });
+
+  it("adds a separator block before appended lines when source has content", () => {
+    const out = mergeGitignore("foo\n", [".agent-brain/"]);
+    expect(out).toMatch(/foo\n+# added by agent-brain\n\.agent-brain\/\n$/);
+  });
+
+  it("ends with a trailing newline", () => {
+    expect(mergeGitignore("", required).endsWith("\n")).toBe(true);
+  });
+});

--- a/tests/unit/backend/vault/git/trailers.test.ts
+++ b/tests/unit/backend/vault/git/trailers.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import fc from "fast-check";
+import { formatTrailers } from "../../../../../src/backend/vault/git/trailers.js";
+import type { CommitTrailer } from "../../../../../src/backend/vault/git/types.js";
+
+describe("formatTrailers", () => {
+  it("emits AB-Action + AB-Memory + AB-Actor in order", () => {
+    const out = formatTrailers({
+      action: "created",
+      memoryId: "abc123",
+      actor: "alice",
+    });
+    expect(out).toBe("AB-Action: created\nAB-Memory: abc123\nAB-Actor: alice");
+  });
+
+  it("emits AB-Workspace instead of AB-Memory for workspace_upsert", () => {
+    const out = formatTrailers({
+      action: "workspace_upsert",
+      workspaceId: "ws-42",
+      actor: "alice",
+    });
+    expect(out).toBe(
+      "AB-Action: workspace_upsert\nAB-Workspace: ws-42\nAB-Actor: alice",
+    );
+  });
+
+  it("includes AB-Reason when provided, encodes newlines as \\\\n", () => {
+    const out = formatTrailers({
+      action: "updated",
+      memoryId: "abc",
+      actor: "bob",
+      reason: "first line\nsecond line",
+    });
+    expect(out).toContain("AB-Reason: first line\\nsecond line");
+  });
+
+  it("omits AB-Reason when null or undefined", () => {
+    const out = formatTrailers({
+      action: "updated",
+      memoryId: "abc",
+      actor: "bob",
+      reason: null,
+    });
+    expect(out).not.toContain("AB-Reason");
+  });
+
+  it("throws on action requiring memoryId with no id", () => {
+    expect(() =>
+      formatTrailers({ action: "created", actor: "alice" } as CommitTrailer),
+    ).toThrow(/memoryId/);
+  });
+
+  it("throws on workspace_upsert without workspaceId", () => {
+    expect(() =>
+      formatTrailers({
+        action: "workspace_upsert",
+        actor: "alice",
+      } as CommitTrailer),
+    ).toThrow(/workspaceId/);
+  });
+
+  it("roundtrips through a conservative trailer parser (property)", () => {
+    const actionArb = fc.constantFrom(
+      "created",
+      "updated",
+      "archived",
+      "verified",
+      "commented",
+      "flagged",
+      "unflagged",
+      "related",
+      "unrelated",
+    );
+    const idArb = fc.stringMatching(/^[a-zA-Z0-9_-]{1,32}$/);
+    const actorArb = fc.stringMatching(/^[a-zA-Z0-9_-]{1,32}$/);
+    fc.assert(
+      fc.property(actionArb, idArb, actorArb, (action, memoryId, actor) => {
+        const out = formatTrailers({
+          action: action as CommitTrailer["action"],
+          memoryId,
+          actor,
+        });
+        const lines = out.split("\n");
+        const parsed: Record<string, string> = {};
+        for (const l of lines) {
+          const m = l.match(/^([A-Za-z-]+):\s*(.*)$/);
+          if (m) parsed[m[1]] = m[2];
+        }
+        expect(parsed["AB-Action"]).toBe(action);
+        expect(parsed["AB-Memory"]).toBe(memoryId);
+        expect(parsed["AB-Actor"]).toBe(actor);
+      }),
+    );
+  });
+});

--- a/tests/unit/backend/vault/repositories/memory-repository-index-sync.test.ts
+++ b/tests/unit/backend/vault/repositories/memory-repository-index-sync.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { VaultMemoryRepository } from "../../../../../src/backend/vault/repositories/memory-repository.js";
 import { VaultWorkspaceRepository } from "../../../../../src/backend/vault/repositories/workspace-repository.js";
 import { VaultVectorIndex } from "../../../../../src/backend/vault/vector/lance-index.js";
+import { NOOP_GIT_OPS } from "../../../../../src/backend/vault/git/types.js";
 import { ValidationError } from "../../../../../src/utils/errors.js";
 import type { Memory } from "../../../../../src/types/memory.js";
 
@@ -49,8 +50,15 @@ describe("VaultMemoryRepository — lance index sync", () => {
   beforeEach(async () => {
     root = await mkdtemp(join(tmpdir(), "repo-sync-"));
     idx = await VaultVectorIndex.create({ root, dims: DIMS });
-    repo = await VaultMemoryRepository.create({ root, index: idx });
-    await new VaultWorkspaceRepository({ root }).findOrCreate("ws1");
+    repo = await VaultMemoryRepository.create({
+      root,
+      index: idx,
+      gitOps: NOOP_GIT_OPS,
+    });
+    await new VaultWorkspaceRepository({
+      root,
+      gitOps: NOOP_GIT_OPS,
+    }).findOrCreate("ws1");
   });
 
   afterEach(async () => {

--- a/tests/unit/backend/vault/repositories/memory-repository.test.ts
+++ b/tests/unit/backend/vault/repositories/memory-repository.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { VaultMemoryRepository } from "../../../../../src/backend/vault/repositories/memory-repository.js";
 import { VaultVectorIndex } from "../../../../../src/backend/vault/vector/lance-index.js";
+import { NOOP_GIT_OPS } from "../../../../../src/backend/vault/git/types.js";
 import {
   ConflictError,
   ValidationError,
@@ -48,7 +49,11 @@ describe("VaultMemoryRepository — CRUD", () => {
   beforeEach(async () => {
     root = await mkdtemp(join(tmpdir(), "vault-memrepo-"));
     idx = await VaultVectorIndex.create({ root, dims: 1 });
-    repo = await VaultMemoryRepository.create({ root, index: idx });
+    repo = await VaultMemoryRepository.create({
+      root,
+      index: idx,
+      gitOps: NOOP_GIT_OPS,
+    });
   });
   afterEach(async () => {
     await idx.close();
@@ -135,13 +140,21 @@ describe("VaultMemoryRepository — CRUD", () => {
   it("VaultMemoryRepository.create rebuilds index from existing vault", async () => {
     // Pre-seed a memory via the same repo API on a separate instance,
     // then construct a fresh repo against the same root.
-    const pre = await VaultMemoryRepository.create({ root, index: idx });
+    const pre = await VaultMemoryRepository.create({
+      root,
+      index: idx,
+      gitOps: NOOP_GIT_OPS,
+    });
     await pre.create({
       ...makeMemory({ id: "preexist" }),
       embedding: [0],
     });
 
-    const repo2 = await VaultMemoryRepository.create({ root, index: idx });
+    const repo2 = await VaultMemoryRepository.create({
+      root,
+      index: idx,
+      gitOps: NOOP_GIT_OPS,
+    });
     expect(await repo2.findById("preexist")).not.toBeNull();
   });
 });
@@ -154,7 +167,11 @@ describe("VaultMemoryRepository — listings", () => {
   beforeEach(async () => {
     root = await mkdtemp(join(tmpdir(), "vault-memrepo-list-"));
     idx = await VaultVectorIndex.create({ root, dims: 1 });
-    repo = await VaultMemoryRepository.create({ root, index: idx });
+    repo = await VaultMemoryRepository.create({
+      root,
+      index: idx,
+      gitOps: NOOP_GIT_OPS,
+    });
   });
   afterEach(async () => {
     await idx.close();
@@ -419,7 +436,11 @@ describe("VaultMemoryRepository — list validation", () => {
   beforeEach(async () => {
     root = await mkdtemp(join(tmpdir(), "vault-memrepo-validate-"));
     idx = await VaultVectorIndex.create({ root, dims: 1 });
-    repo = await VaultMemoryRepository.create({ root, index: idx });
+    repo = await VaultMemoryRepository.create({
+      root,
+      index: idx,
+      gitOps: NOOP_GIT_OPS,
+    });
   });
   afterEach(async () => {
     await idx.close();

--- a/tests/unit/backend/vault/repositories/workspace-repository.test.ts
+++ b/tests/unit/backend/vault/repositories/workspace-repository.test.ts
@@ -3,13 +3,14 @@ import { mkdtemp, rm, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { VaultWorkspaceRepository } from "../../../../../src/backend/vault/repositories/workspace-repository.js";
+import { NOOP_GIT_OPS } from "../../../../../src/backend/vault/git/types.js";
 
 describe("VaultWorkspaceRepository", () => {
   let root: string;
   let repo: VaultWorkspaceRepository;
   beforeEach(async () => {
     root = await mkdtemp(join(tmpdir(), "vault-ws-"));
-    repo = new VaultWorkspaceRepository({ root });
+    repo = new VaultWorkspaceRepository({ root, gitOps: NOOP_GIT_OPS });
   });
   afterEach(async () => {
     await rm(root, { recursive: true, force: true });

--- a/tests/unit/backend/vault/users-gitignore-invariant.test.ts
+++ b/tests/unit/backend/vault/users-gitignore-invariant.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { assertUsersIgnored } from "../../../../src/backend/vault/git/users-gitignore-invariant.js";
+import { DomainError } from "../../../../src/utils/errors.js";
+
+describe("assertUsersIgnored", () => {
+  let root: string;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "users-ignore-"));
+  });
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("passes when .gitignore contains users/", async () => {
+    await writeFile(join(root, ".gitignore"), "users/\n", "utf8");
+    await expect(assertUsersIgnored(root)).resolves.toBeUndefined();
+  });
+
+  it("passes when the rule is users/**", async () => {
+    await writeFile(join(root, ".gitignore"), "users/**\n", "utf8");
+    await expect(assertUsersIgnored(root)).resolves.toBeUndefined();
+  });
+
+  it("throws a DomainError when .gitignore missing", async () => {
+    await expect(assertUsersIgnored(root)).rejects.toThrow(DomainError);
+  });
+
+  it("throws when the users/ rule is absent", async () => {
+    await writeFile(join(root, ".gitignore"), "node_modules\n", "utf8");
+    await expect(assertUsersIgnored(root)).rejects.toThrow(/users\//);
+  });
+});


### PR DESCRIPTION
## Summary

- Every `Vault*Repository` mutation now stages + commits the changed markdown file with structured `AB-Action` / `AB-Memory` / `AB-Workspace` / `AB-Actor` trailers (Phase 4c will parse these for the `AuditRepository`).
- `VaultBackend.create` bootstraps the vault as a git repo: `git init` if missing, idempotent merge of required `.gitignore` rules (`.agent-brain/`, `_sessions/`, `_session-tracking/`, `_scheduler-state.json`, `_audit/`, and by default `users/`) and `.gitattributes` with `*.md merge=union`.
- `users/`-gitignore privacy invariant: user-scope writes abort with a `DomainError` if the rule has been removed (only enforced when a real `GitOps` is wired — test backends stay unaffected).
- New `AGENT_BRAIN_VAULT_TRACK_USERS` env toggles whether user-scope memories are committed. Default `false` → users/ stays gitignored and commit is skipped for those writes.
- `scrubGitEnv()` strips `GIT_*` / `PAGER` / `EDITOR` / `VISUAL` from the env passed to `simple-git` so husky pre-commit, `git rebase`, and other parent-git contexts can't silently override the configured `baseDir`. Regression guard: `tests/unit/backend/vault/git/env-isolation.test.ts`.
- Contract parity kept intact: a new `vaultGitFactory` (alongside the existing `vaultFactory`) powers five `*-git.test.ts` suites that assert one commit per mutation with the expected trailer. Existing contract tests keep using the git-less factory and stay unchanged.

**Deferred to Phase 4b:** debounced push queue, `pull --rebase --autostash` on `memory_session_start`, offline/conflict envelope meta.
**Deferred to Phase 4c:** `VaultAuditRepository` over `git log` parser (replacing the current JSONL audit).

## Test plan

- [x] `npm run test:unit` — 429 pass
- [x] `npm test` (full incl. contract) — 900 pass
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] Manual smoke: `VaultBackend.create` on a fresh tmpdir initializes `.git/`, writes `.gitignore` + `.gitattributes`, makes no rogue commits
- [x] Env-leak regression: tests pass under `env GIT_DIR=... GIT_WORK_TREE=... npm run test:unit`