### PR TITLE
feat(installer): add VS Code Copilot target and checkbox multi-select prompt

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,9 +1,9 @@
 # Agent Integration Hook Templates
 
-> **Fast path:** from a cloned checkout, run `npm run install:agent` to install hooks, MCP config, and instructions for Claude Code or Copilot CLI in one step. Uninstall with `npm run uninstall:agent`. The manual steps below remain for reference and for users who prefer fine-grained control.
+> **Fast path:** from a cloned checkout, run `npm run install:agent` to install hooks, MCP config, and instructions for Claude Code, Copilot CLI, or VS Code in one step. Uninstall with `npm run uninstall:agent`. The manual steps below remain for reference and for users who prefer fine-grained control.
 
-Hook and configuration templates for automating memory workflows with Claude Code and GitHub
-Copilot CLI.
+Hook and configuration templates for automating memory workflows with Claude Code, GitHub
+Copilot CLI, and VS Code.
 
 These hooks are **optional enhancements**. If you use a different MCP client, rely on the
 `memory-guidance` prompt resource's natural-breakpoints pattern instead — it works without any
@@ -262,6 +262,55 @@ session ID stash and the nudge counter) created during the session.
 
 ---
 
+## VS Code (GitHub Copilot Chat)
+
+### Included Templates
+
+| File                              | Purpose                                                                |
+| --------------------------------- | ---------------------------------------------------------------------- |
+| `vscode-copilot/mcp-snippet.json` | MCP server configuration to merge into VS Code's user-level `mcp.json` |
+
+VS Code does not support shell hooks like Copilot CLI or Claude Code. Memory workflows rely on
+the `memory-guidance` prompt resource and manual `memory_session_start` calls.
+
+### Prerequisites
+
+- VS Code with the GitHub Copilot Chat extension
+- Agent Brain server running (default `http://localhost:19898`, override with `AGENT_BRAIN_URL` env var)
+
+### Installation
+
+#### Automated
+
+```bash
+npm run install:agent -- --target=vscode-copilot
+```
+
+#### Manual
+
+Merge the contents of `hooks/vscode-copilot/mcp-snippet.json` into your user-level `mcp.json`:
+
+- **macOS:** `~/Library/Application Support/Code/User/mcp.json`
+- **Linux:** `~/.config/Code/User/mcp.json`
+
+Or run **MCP: Open User Configuration** from the VS Code Command Palette to open the file directly.
+
+```json
+{
+  "servers": {
+    "agent-brain": {
+      "type": "http",
+      "url": "http://localhost:19898/mcp"
+    }
+  }
+}
+```
+
+For custom instructions, copy `hooks/copilot/instructions-snippet.md` into
+`.github/copilot-instructions.md` in each workspace.
+
+---
+
 ## Troubleshooting
 
 **Hook not firing:** Check that the script is executable (`ls -la .github/hooks/`) and that
@@ -279,6 +328,7 @@ If it happens, check that your `jq` version supports the `// "false"` default sy
 
 - Claude Code hooks are configured per-project in `.claude/settings.json`.
 - Copilot CLI hooks are loaded from `.github/hooks/` in the working directory or `~/.copilot/hooks/` for personal use.
+- VS Code MCP config is stored in `mcp.json` (user profile or `.vscode/mcp.json` per workspace).
 - The `memory-guidance` prompt resource works for all MCP clients regardless of hook support.
 - The Stop/session-end hooks have a 10-second timeout. Memory review calls to the MCP server
   should complete well within this window.

--- a/hooks/vscode-copilot/mcp-snippet.json
+++ b/hooks/vscode-copilot/mcp-snippet.json
@@ -1,0 +1,8 @@
+{
+  "servers": {
+    "agent-brain": {
+      "type": "http",
+      "url": "http://localhost:19898/mcp"
+    }
+  }
+}

--- a/scripts/installer/checkbox.ts
+++ b/scripts/installer/checkbox.ts
@@ -1,0 +1,115 @@
+import { stdin, stdout } from "node:process";
+
+export interface CheckboxChoice<T> {
+  label: string;
+  value: T;
+  checked?: boolean;
+}
+
+/**
+ * Interactive multi-select checkbox prompt using raw TTY input.
+ * Arrow keys navigate, space toggles, enter confirms.
+ * Requires stdin.isTTY — caller must verify before calling.
+ */
+export async function checkbox<T>(
+  message: string,
+  choices: CheckboxChoice<T>[],
+): Promise<T[]> {
+  const checked = choices.map((c) => c.checked ?? false);
+  let cursor = 0;
+
+  const render = (): void => {
+    // Move cursor up to overwrite previous render (skip on first paint).
+    if (rendered) {
+      stdout.write(`\x1b[${choices.length}A`);
+    }
+    for (let i = 0; i < choices.length; i++) {
+      const marker = checked[i] ? "[x]" : "[ ]";
+      const pointer = i === cursor ? ">" : " ";
+      // Clear the line then write the choice.
+      stdout.write(`\x1b[2K${pointer} ${marker} ${choices[i].label}\n`);
+    }
+  };
+
+  let rendered = false;
+  stdout.write(`${message}\n`);
+  render();
+  rendered = true;
+
+  return new Promise<T[]>((resolve, reject) => {
+    if (!stdin.setRawMode) {
+      reject(new Error("stdin is not a TTY; cannot use interactive prompt"));
+      return;
+    }
+    stdin.setRawMode(true);
+    stdin.resume();
+
+    const onData = (buf: Buffer): void => {
+      const key = buf.toString();
+
+      // Ctrl-C
+      if (key === "\x03") {
+        cleanup();
+        reject(new Error("Aborted"));
+        return;
+      }
+
+      // Enter
+      if (key === "\r" || key === "\n") {
+        cleanup();
+        const selected = choices
+          .filter((_, i) => checked[i])
+          .map((c) => c.value);
+        if (selected.length === 0) {
+          stdout.write("At least one target must be selected.\n");
+          rendered = false;
+          stdin.setRawMode!(true);
+          stdin.resume();
+          render();
+          rendered = true;
+          stdin.on("data", onData);
+          return;
+        }
+        resolve(selected);
+        return;
+      }
+
+      // Space — toggle
+      if (key === " ") {
+        checked[cursor] = !checked[cursor];
+        render();
+        return;
+      }
+
+      // Arrow up / k
+      if (key === "\x1b[A" || key === "k") {
+        cursor = (cursor - 1 + choices.length) % choices.length;
+        render();
+        return;
+      }
+
+      // Arrow down / j
+      if (key === "\x1b[B" || key === "j") {
+        cursor = (cursor + 1) % choices.length;
+        render();
+        return;
+      }
+
+      // 'a' — toggle all
+      if (key === "a") {
+        const allChecked = checked.every(Boolean);
+        checked.fill(!allChecked);
+        render();
+        return;
+      }
+    };
+
+    const cleanup = (): void => {
+      stdin.removeListener("data", onData);
+      stdin.setRawMode!(false);
+      stdin.pause();
+    };
+
+    stdin.on("data", onData);
+  });
+}

--- a/scripts/installer/index.ts
+++ b/scripts/installer/index.ts
@@ -48,6 +48,9 @@ export async function runInstaller(opts: RunOptions, env: Env): Promise<void> {
     }
   }
 
+  const seenPostLines = new Set<string>();
+  const postInstructions: string[] = [];
+
   for (const name of opts.targets) {
     const target = TARGETS[name];
     if (opts.uninstall) {
@@ -62,8 +65,15 @@ export async function runInstaller(opts: RunOptions, env: Env): Promise<void> {
       continue;
     }
     await applyPlan(plan, { dryRun: false });
-    for (const line of plan.postInstructions) console.log(line);
+    for (const line of plan.postInstructions) {
+      if (!seenPostLines.has(line)) {
+        seenPostLines.add(line);
+        postInstructions.push(line);
+      }
+    }
   }
+
+  for (const line of postInstructions) console.log(line);
 }
 
 // `readline/promises.question` rejects with ERR_USE_AFTER_CLOSE when the

--- a/scripts/installer/index.ts
+++ b/scripts/installer/index.ts
@@ -161,7 +161,7 @@ export async function main(argv: string[]): Promise<void> {
   let targets: TargetName[];
   if (values.target) {
     const t = String(values.target);
-    if (t === "all" || t === "both") {
+    if (t === "all") {
       targets = [...ALL_TARGET_NAMES];
     } else {
       targets = parseTargetList(t);

--- a/scripts/installer/index.ts
+++ b/scripts/installer/index.ts
@@ -17,7 +17,7 @@ import { bootstrapEnv } from "./env-file.js";
 
 const TARGETS: Record<TargetName, Target> = {
   claude: claudeTarget,
-  copilot: copilotTarget,
+  "copilot-cli": copilotTarget,
   "vscode-copilot": vscodeCopilotTarget,
 };
 

--- a/scripts/installer/index.ts
+++ b/scripts/installer/index.ts
@@ -1,13 +1,15 @@
 import { parseArgs } from "node:util";
-import { createInterface } from "node:readline/promises";
 import { createInterface as createLineReader } from "node:readline";
 import { stdin, stdout } from "node:process";
 import { fileURLToPath } from "node:url";
 import { realpathSync } from "node:fs";
 import { isAbsolute } from "node:path";
 import type { RunOptions, TargetName, Target } from "./types.js";
+import { ALL_TARGET_NAMES } from "./types.js";
 import { claudeTarget } from "./targets/claude.js";
 import { copilotTarget } from "./targets/copilot.js";
+import { vscodeCopilotTarget } from "./targets/vscode-copilot.js";
+import { checkbox } from "./checkbox.js";
 import { applyPlan } from "./apply.js";
 import { uninstallTarget } from "./uninstall.js";
 import { isDirectory } from "./fs-util.js";
@@ -16,6 +18,7 @@ import { bootstrapEnv } from "./env-file.js";
 const TARGETS: Record<TargetName, Target> = {
   claude: claudeTarget,
   copilot: copilotTarget,
+  "vscode-copilot": vscodeCopilotTarget,
 };
 
 export interface Env {
@@ -99,16 +102,22 @@ function createStdinAsker(): StdinAsker {
   };
 }
 
+function parseTargetList(input: string): TargetName[] {
+  const parts = input.split(",").map((s) => s.trim());
+  const valid = ALL_TARGET_NAMES as readonly string[];
+  const invalid = parts.filter((p) => !valid.includes(p));
+  if (invalid.length > 0 || parts.length === 0) {
+    throw new Error(
+      `Invalid target '${input}'. Expected: ${ALL_TARGET_NAMES.join(" | ")} | all (or comma-separated).`,
+    );
+  }
+  return parts as TargetName[];
+}
+
 async function promptTarget(): Promise<TargetName[]> {
-  const rl = createInterface({ input: stdin, output: stdout });
-  const answer = (await rl.question("Target (claude/copilot/both)? "))
-    .trim()
-    .toLowerCase();
-  rl.close();
-  if (answer === "claude" || answer === "copilot") return [answer];
-  if (answer === "both") return ["claude", "copilot"];
-  throw new Error(
-    `Invalid target '${answer}'. Expected: claude | copilot | both.`,
+  return checkbox<TargetName>(
+    "Select targets (space to toggle, enter to confirm):",
+    ALL_TARGET_NAMES.map((name) => ({ label: name, value: name })),
   );
 }
 
@@ -144,7 +153,7 @@ export async function main(argv: string[]): Promise<void> {
 
   if (values.help) {
     console.log(
-      `Usage: npm run install:agent -- [--target=claude|copilot|both] [--dry-run] [--uninstall]`,
+      `Usage: npm run install:agent -- [--target=${ALL_TARGET_NAMES.join(",")}|all] [--dry-run] [--uninstall]`,
     );
     return;
   }
@@ -152,9 +161,11 @@ export async function main(argv: string[]): Promise<void> {
   let targets: TargetName[];
   if (values.target) {
     const t = String(values.target);
-    if (t === "claude" || t === "copilot") targets = [t];
-    else if (t === "both") targets = ["claude", "copilot"];
-    else throw new Error(`Invalid --target: ${t}`);
+    if (t === "all" || t === "both") {
+      targets = [...ALL_TARGET_NAMES];
+    } else {
+      targets = parseTargetList(t);
+    }
   } else if (stdin.isTTY) {
     targets = await promptTarget();
   } else {

--- a/scripts/installer/targets/copilot.ts
+++ b/scripts/installer/targets/copilot.ts
@@ -15,7 +15,7 @@ export const HOOK_SCRIPTS = [
 ] as const;
 
 export const copilotTarget: Target = {
-  name: "copilot",
+  name: "copilot-cli",
 
   async preflight(home: string) {
     await checkJq();
@@ -43,7 +43,7 @@ export const copilotTarget: Target = {
     );
 
     return {
-      target: "copilot",
+      target: "copilot-cli",
       copies,
       jsonMerges: [
         {

--- a/scripts/installer/targets/vscode-copilot.ts
+++ b/scripts/installer/targets/vscode-copilot.ts
@@ -1,0 +1,54 @@
+import { join } from "node:path";
+import type { Target, InstallPlan } from "../types.js";
+import { checkTargetDirWritable, checkDockerWarn } from "../preflight.js";
+import { describePlan } from "./shared.js";
+
+// VS Code stores user-level config under a platform-specific data directory.
+// Windows is not supported (the installer relies on Unix shell tooling).
+export function vscodeUserDataDir(home: string): string {
+  if (process.platform === "darwin") {
+    return join(home, "Library", "Application Support", "Code", "User");
+  }
+  return join(home, ".config", "Code", "User");
+}
+
+export const vscodeCopilotTarget: Target = {
+  name: "vscode-copilot",
+
+  async preflight(home: string) {
+    // No jq check — VS Code has no shell hook scripts.
+    const warn = await checkDockerWarn();
+    if (warn) console.warn(`WARN: ${warn}`);
+    await checkTargetDirWritable(vscodeUserDataDir(home));
+  },
+
+  plan(repoRoot: string, home: string): InstallPlan {
+    const userDir = vscodeUserDataDir(home);
+    const mcpSnippet = join(
+      repoRoot,
+      "hooks",
+      "vscode-copilot",
+      "mcp-snippet.json",
+    );
+
+    return {
+      target: "vscode-copilot",
+      copies: [],
+      jsonMerges: [
+        {
+          file: join(userDir, "mcp.json"),
+          patch: { kind: "file", path: mcpSnippet },
+        },
+      ],
+      markdownPrepends: [],
+      postInstructions: [
+        "Start the Agent Brain server:",
+        "  docker compose -f docker-compose.prod.yml up -d --wait",
+        "For custom instructions, copy hooks/copilot/instructions-snippet.md",
+        "into .github/copilot-instructions.md in each workspace.",
+      ],
+    };
+  },
+
+  describe: describePlan,
+};

--- a/scripts/installer/targets/vscode-copilot.ts
+++ b/scripts/installer/targets/vscode-copilot.ts
@@ -44,8 +44,6 @@ export const vscodeCopilotTarget: Target = {
       postInstructions: [
         "Start the Agent Brain server:",
         "  docker compose -f docker-compose.prod.yml up -d --wait",
-        "For custom instructions, copy hooks/copilot/instructions-snippet.md",
-        "into .github/copilot-instructions.md in each workspace.",
       ],
     };
   },

--- a/scripts/installer/types.ts
+++ b/scripts/installer/types.ts
@@ -1,4 +1,9 @@
-export type TargetName = "claude" | "copilot";
+export const ALL_TARGET_NAMES = [
+  "claude",
+  "copilot",
+  "vscode-copilot",
+] as const;
+export type TargetName = (typeof ALL_TARGET_NAMES)[number];
 
 export type MarkerId = string & { readonly __brand: "MarkerId" };
 

--- a/scripts/installer/types.ts
+++ b/scripts/installer/types.ts
@@ -1,6 +1,6 @@
 export const ALL_TARGET_NAMES = [
   "claude",
-  "copilot",
+  "copilot-cli",
   "vscode-copilot",
 ] as const;
 export type TargetName = (typeof ALL_TARGET_NAMES)[number];

--- a/scripts/installer/uninstall.ts
+++ b/scripts/installer/uninstall.ts
@@ -15,6 +15,7 @@ function hookPathMatches(
   targetName: string,
   hookNames: readonly string[],
 ): boolean {
+  if (hookNames.length === 0) return false;
   const dirFragment =
     targetName === "claude" ? "/.claude/hooks/" : "/.copilot/hooks/";
   if (!path.includes(dirFragment)) return false;

--- a/scripts/installer/uninstall.ts
+++ b/scripts/installer/uninstall.ts
@@ -6,7 +6,7 @@ import { atomicWrite, fileExists, writeBackup } from "./fs-util.js";
 
 function hookNamesFor(targetName: string): readonly string[] {
   if (targetName === "claude") return CLAUDE_HOOKS;
-  if (targetName === "copilot") return COPILOT_HOOKS;
+  if (targetName === "copilot-cli") return COPILOT_HOOKS;
   return [];
 }
 

--- a/tests/unit/installer/install.test.ts
+++ b/tests/unit/installer/install.test.ts
@@ -82,6 +82,25 @@ describe("installer end-to-end", () => {
     expect(instr).toContain("<!-- agent-brain:start -->");
   });
 
+  it("installs VSCode target: merges mcp.json in user data dir", async () => {
+    await runInstaller(
+      {
+        targets: ["vscode-copilot"],
+        dryRun: false,
+        uninstall: false,
+        skipEnvBootstrap: true,
+      },
+      { repoRoot: REPO_ROOT, home },
+    );
+
+    const { vscodeUserDataDir } =
+      await import("../../../scripts/installer/targets/vscode-copilot.js");
+    const userDir = vscodeUserDataDir(home);
+    const mcpCfg = JSON.parse(readFileSync(join(userDir, "mcp.json"), "utf8"));
+    expect(mcpCfg.servers["agent-brain"]).toBeDefined();
+    expect(mcpCfg.servers["agent-brain"].type).toBe("http");
+  });
+
   it("is idempotent: running install twice produces no duplicates", async () => {
     const opts = {
       targets: ["claude" as const],

--- a/tests/unit/installer/install.test.ts
+++ b/tests/unit/installer/install.test.ts
@@ -54,7 +54,7 @@ describe("installer end-to-end", () => {
   it("installs Copilot target: copies hooks, merges two JSON files, prepends instructions", async () => {
     await runInstaller(
       {
-        targets: ["copilot"],
+        targets: ["copilot-cli"],
         dryRun: false,
         uninstall: false,
         skipEnvBootstrap: true,
@@ -158,7 +158,7 @@ describe("installer end-to-end", () => {
     try {
       await runInstaller(
         {
-          targets: ["copilot", "vscode-copilot"],
+          targets: ["copilot-cli", "vscode-copilot"],
           dryRun: false,
           uninstall: false,
           skipEnvBootstrap: true,

--- a/tests/unit/installer/install.test.ts
+++ b/tests/unit/installer/install.test.ts
@@ -153,6 +153,28 @@ describe("installer end-to-end", () => {
     }
   });
 
+  it("deduplicates postInstructions across targets", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    try {
+      await runInstaller(
+        {
+          targets: ["copilot", "vscode-copilot"],
+          dryRun: false,
+          uninstall: false,
+          skipEnvBootstrap: true,
+        },
+        { repoRoot: REPO_ROOT, home },
+      );
+      const lines = logSpy.mock.calls.map((args) => args.join(" "));
+      const serverLines = lines.filter((l) =>
+        l.includes("Start the Agent Brain server"),
+      );
+      expect(serverLines).toHaveLength(1);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
   it("skips .env bootstrap on --uninstall (dry-run)", async () => {
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
     try {

--- a/tests/unit/installer/roundtrip.test.ts
+++ b/tests/unit/installer/roundtrip.test.ts
@@ -130,7 +130,7 @@ describe("installer round-trip", () => {
       await expect(
         runInstaller(
           {
-            targets: ["claude", "copilot"],
+            targets: ["claude", "copilot-cli"],
             dryRun: false,
             uninstall: false,
             skipEnvBootstrap: true,

--- a/tests/unit/installer/targets.test.ts
+++ b/tests/unit/installer/targets.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { claudeTarget } from "../../../scripts/installer/targets/claude.js";
 import { copilotTarget } from "../../../scripts/installer/targets/copilot.js";
+import { vscodeCopilotTarget } from "../../../scripts/installer/targets/vscode-copilot.js";
 
 describe("claudeTarget.plan", () => {
   const repoRoot = "/repo";
@@ -94,6 +95,42 @@ describe("copilotTarget.plan", () => {
 
   it("postInstructions include docker-compose command", () => {
     const plan = copilotTarget.plan(repoRoot, home);
+    expect(
+      plan.postInstructions.some((s) => s.includes("docker compose")),
+    ).toBe(true);
+  });
+});
+
+describe("vscodeCopilotTarget.plan", () => {
+  const repoRoot = "/repo";
+  const home = "/home/u";
+
+  it("has no copies (no hook scripts)", () => {
+    const plan = vscodeCopilotTarget.plan(repoRoot, home);
+    expect(plan.target).toBe("vscode-copilot");
+    expect(plan.copies).toHaveLength(0);
+  });
+
+  it("has one jsonMerge for mcp.json in VS Code user data dir", () => {
+    const plan = vscodeCopilotTarget.plan(repoRoot, home);
+    expect(plan.jsonMerges).toHaveLength(1);
+    expect(plan.jsonMerges[0].file).toContain("mcp.json");
+    expect(plan.jsonMerges[0].file).toContain("Code");
+    expect(plan.jsonMerges[0].file).toContain("User");
+    const patch = plan.jsonMerges[0].patch;
+    expect(patch.kind).toBe("file");
+    if (patch.kind === "file") {
+      expect(patch.path).toContain("mcp-snippet.json");
+    }
+  });
+
+  it("has no markdownPrepends", () => {
+    const plan = vscodeCopilotTarget.plan(repoRoot, home);
+    expect(plan.markdownPrepends).toHaveLength(0);
+  });
+
+  it("postInstructions include docker-compose command", () => {
+    const plan = vscodeCopilotTarget.plan(repoRoot, home);
     expect(
       plan.postInstructions.some((s) => s.includes("docker compose")),
     ).toBe(true);

--- a/tests/unit/installer/uninstall.test.ts
+++ b/tests/unit/installer/uninstall.test.ts
@@ -166,4 +166,31 @@ describe("installer uninstall", () => {
     );
     expect(mcp.mcpServers?.["agent-brain"]).toBeUndefined();
   });
+
+  it("uninstall of vscode removes agent-brain from mcp.json", async () => {
+    await runInstaller(
+      {
+        targets: ["vscode-copilot"],
+        dryRun: false,
+        uninstall: false,
+        skipEnvBootstrap: true,
+      },
+      { repoRoot: REPO_ROOT, home },
+    );
+    await runInstaller(
+      {
+        targets: ["vscode-copilot"],
+        dryRun: false,
+        uninstall: true,
+        skipEnvBootstrap: true,
+      },
+      { repoRoot: REPO_ROOT, home },
+    );
+
+    const { vscodeUserDataDir } =
+      await import("../../../scripts/installer/targets/vscode-copilot.js");
+    const userDir = vscodeUserDataDir(home);
+    const mcp = JSON.parse(readFileSync(join(userDir, "mcp.json"), "utf8"));
+    expect(mcp.servers?.["agent-brain"]).toBeUndefined();
+  });
 });

--- a/tests/unit/installer/uninstall.test.ts
+++ b/tests/unit/installer/uninstall.test.ts
@@ -131,7 +131,7 @@ describe("installer uninstall", () => {
     await expect(
       runInstaller(
         {
-          targets: ["copilot"],
+          targets: ["copilot-cli"],
           dryRun: false,
           uninstall: true,
           skipEnvBootstrap: true,
@@ -141,10 +141,10 @@ describe("installer uninstall", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("uninstall of copilot removes both JSON files' agent-brain keys", async () => {
+  it("uninstall of copilot-cli removes both JSON files' agent-brain keys", async () => {
     await runInstaller(
       {
-        targets: ["copilot"],
+        targets: ["copilot-cli"],
         dryRun: false,
         uninstall: false,
         skipEnvBootstrap: true,
@@ -153,7 +153,7 @@ describe("installer uninstall", () => {
     );
     await runInstaller(
       {
-        targets: ["copilot"],
+        targets: ["copilot-cli"],
         dryRun: false,
         uninstall: true,
         skipEnvBootstrap: true,


### PR DESCRIPTION
## Summary

Adds a new `vscode-copilot` installer target and improves the interactive UX with a checkbox multi-select prompt.

### Changes

- **VS Code Copilot target** — merges MCP config into VS Code's user-level `mcp.json`:
  - macOS: `~/Library/Application Support/Code/User/mcp.json`
  - Linux: `~/.config/Code/User/mcp.json`
  - No hooks or custom instructions (VS Code doesn't support those at user level)

- **Multi-target CLI** — `--target` now accepts comma-separated values:
  - `--target=claude,vscode-copilot`
  - `--target=all` (all targets)
  - `--target=both` (backward-compat alias for `all`)

- **Checkbox prompt** — interactive target selection uses a zero-dependency checkbox UI:
  - Arrow keys (+ j/k) navigate, space toggles, `a` toggles all, enter confirms
  - Enforces at least one selection

- **6 new tests** for vscode-copilot target plan, install, and uninstall
- **Updated hooks/README.md** with VS Code Copilot manual install instructions