### PR TITLE
feat(vault): Phase 4b — git sync (push queue + pull on session_start)

### DIFF
--- a/docs/superpowers/plans/2026-04-22-vault-backend-phase-4b-git-sync.md
+++ b/docs/superpowers/plans/2026-04-22-vault-backend-phase-4b-git-sync.md
@@ -1,0 +1,2711 @@
+# Vault Backend Phase 4b — Git Sync (Push Queue + Pull on Session Start) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the git-sync loop on the vault backend. Every commit from Phase 4a now debounced-pushes to `origin`. Every `memory_session_start` pulls with `--rebase --autostash`, reindexes the lance table for changed memory markdown, and surfaces offline / conflict / unpushed / parse-error state through envelope `meta`. A post-crash startup reconciliation collapses dirty markdown into a single recovery commit so the vault is never left partially synced.
+
+**Architecture:** Four new primitives under `src/backend/vault/git/` — `push-queue.ts`, `remote.ts`, `pull.ts`, `reconcile.ts` — plus a new `src/backend/vault/session-start.ts` orchestrator. `GitOpsImpl` gains an optional `afterCommit` callback that `VaultBackend.create` wires to `pushQueue.request()`. The `StorageBackend` interface gains a `sessionStart()` method returning backend-specific envelope meta; pg backend no-ops. `MemoryService.sessionStart` awaits the backend hook once at the start and merges its meta into the response envelope. Pull-path reindex relies on Phase 3 `content_hash` to skip re-embedding unchanged files.
+
+**Tech Stack:** `simple-git` (existing), Node.js, TypeScript, vitest, fast-check (existing), `@lancedb/lancedb` (existing).
+
+---
+
+## Spec
+
+`docs/superpowers/specs/2026-04-22-vault-backend-phase-4b-git-sync-design.md` (commit `908a0ec`). All design decisions (remote URL via `AGENT_BRAIN_VAULT_REMOTE_URL` env, debounce 5s, backoff `[5s, 30s, 5m, 30m]`, pull → rebase+autostash, reconcile-on-create, envelope meta schema) are locked there. This plan implements that spec.
+
+## File map
+
+### Create
+
+| Path                                              | Purpose                                                       |
+| ------------------------------------------------- | ------------------------------------------------------------- |
+| `src/backend/vault/git/push-queue.ts`             | `PushQueue` — debounced single-flight push with backoff       |
+| `src/backend/vault/git/remote.ts`                 | `ensureRemote({git, remoteUrl})` — add origin if absent       |
+| `src/backend/vault/git/pull.ts`                   | `syncFromRemote({git})` — pull --rebase --autostash           |
+| `src/backend/vault/git/reconcile.ts`              | `reconcileDirty({git, root})` — post-crash recovery commit    |
+| `src/backend/vault/session-start.ts`              | `runSessionStart(...)` + `diffReindex(...)` — orchestrator    |
+| `src/backend/vault/types.ts`                      | Shared vault types (currently none) — `VaultSessionStartMeta` |
+| `tests/unit/backend/vault/git/push-queue.test.ts` | Unit tests for push queue                                     |
+| `tests/unit/backend/vault/git/remote.test.ts`     | Unit tests for ensureRemote                                   |
+| `tests/unit/backend/vault/git/pull.test.ts`       | Unit tests for syncFromRemote                                 |
+| `tests/unit/backend/vault/git/reconcile.test.ts`  | Unit tests for reconcileDirty                                 |
+| `tests/unit/backend/vault/session-start.test.ts`  | Unit tests for runSessionStart + diffReindex                  |
+| `tests/integration/vault/two-clone-sync.test.ts`  | Two-clone integration test                                    |
+
+### Modify
+
+| Path                                                        | Change                                                                                                                                                                                                    |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/backend/types.ts`                                      | Add `sessionStart()` to `StorageBackend`, add `BackendSessionStartMeta` type                                                                                                                              |
+| `src/backend/postgres/index.ts`                             | Add no-op `sessionStart()` returning `{}`                                                                                                                                                                 |
+| `src/backend/vault/index.ts`                                | Add fields (`remoteUrl`, `pushDebounceMs`, `pushBackoffMs`) to `VaultBackendConfig`; wire `PushQueue` + `ensureRemote` + `reconcileDirty`; implement `sessionStart`; extend `close()` to drain push queue |
+| `src/backend/vault/git/types.ts`                            | Add optional `afterCommit?: () => void` to `GitOps` interface; `GitOpsImpl` calls it after successful commit; `NoopGitOps` no-ops the field                                                               |
+| `src/backend/vault/git/git-ops.ts`                          | Invoke `afterCommit` after `#serialize` block succeeds                                                                                                                                                    |
+| `src/backend/factory.ts`                                    | Plumb `AGENT_BRAIN_VAULT_REMOTE_URL` env var through to `VaultBackend.create`                                                                                                                             |
+| `src/services/memory-service.ts`                            | Call `backend.sessionStart()` from `MemoryService.sessionStart()`, merge returned meta into result envelope                                                                                               |
+| `src/tools/memory-session-start.ts`                         | No changes needed (envelope passes through)                                                                                                                                                               |
+| `tests/unit/server-boot.test.ts`                            | Extend with `AGENT_BRAIN_BACKEND=vault` + `AGENT_BRAIN_VAULT_REMOTE_URL=<bare>` smoke                                                                                                                     |
+| `tests/contract/repositories/_git-helpers.ts`               | Add helpers for bare-repo + clone setup used by integration test                                                                                                                                          |
+| `docs/superpowers/specs/2026-04-21-vault-backend-design.md` | Tick Phase 4 row with 4b-done note                                                                                                                                                                        |
+
+### Do not touch
+
+- `src/backend/vault/git/bootstrap.ts` (phase 4a, stable — remote config is separate)
+- `src/backend/vault/vector/lance-index.ts` (phase 3, stable)
+- Any `Vault*Repository` file — write pipeline unchanged
+- `users-gitignore-invariant.ts` — unchanged
+
+---
+
+## Task 1: Backend interface — `sessionStart` + envelope meta type
+
+**Goal:** Add the backend hook surface so both backends can opt into contributing envelope meta. No vault logic yet.
+
+**Files:**
+
+- Modify: `src/backend/types.ts`
+- Modify: `src/backend/postgres/index.ts`
+- Test: `tests/unit/backend/factory.test.ts` (add assertion)
+
+- [ ] **Step 1: Add meta type + interface method in `src/backend/types.ts`**
+
+Edit `src/backend/types.ts`. After the existing imports and above `StorageBackend`:
+
+```ts
+/**
+ * Envelope meta fields contributed by the backend at memory_session_start.
+ * All fields optional — absent means healthy. Merged into the MemoryService
+ * session-start envelope meta. The pg backend always returns {}; vault
+ * populates based on pull + push-queue state.
+ */
+export interface BackendSessionStartMeta {
+  offline?: true;
+  unpushed_commits?: number;
+  pull_conflict?: true;
+  parse_errors?: number;
+}
+```
+
+Then add to `StorageBackend`:
+
+```ts
+  /**
+   * Called by MemoryService.sessionStart before composing the response.
+   * Backend-specific sync/reconciliation. Returned fields merge into
+   * envelope meta.
+   */
+  sessionStart(): Promise<BackendSessionStartMeta>;
+```
+
+- [ ] **Step 2: Add no-op to `PostgresBackend`**
+
+Edit `src/backend/postgres/index.ts`. Find the class and add:
+
+```ts
+  async sessionStart(): Promise<BackendSessionStartMeta> {
+    return {};
+  }
+```
+
+Add `BackendSessionStartMeta` to the existing `from "../types.js"` import.
+
+- [ ] **Step 3: Add failing test in `tests/unit/backend/factory.test.ts`**
+
+Append:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { createBackend } from "../../../src/backend/factory.js";
+
+describe("backend sessionStart", () => {
+  it("pg backend returns empty meta", async () => {
+    const backend = await createBackend({ name: "postgres" });
+    try {
+      const meta = await backend.sessionStart();
+      expect(meta).toEqual({});
+    } finally {
+      await backend.close();
+    }
+  });
+});
+```
+
+(If the existing file already uses `createBackend`, slot the `it(...)` into an existing `describe`.)
+
+- [ ] **Step 4: Run test**
+
+```
+npx vitest run tests/unit/backend/factory.test.ts -t "pg backend returns empty meta"
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Verify vault backend compile fails (good — we'll fix next)**
+
+```
+npm run typecheck
+```
+
+Expected: `VaultBackend` missing `sessionStart` — one error.
+
+- [ ] **Step 6: Stub `VaultBackend.sessionStart` returning `{}` (temporary)**
+
+In `src/backend/vault/index.ts`, add:
+
+```ts
+  async sessionStart(): Promise<BackendSessionStartMeta> {
+    return {};
+  }
+```
+
+Add `BackendSessionStartMeta` to imports. This is a placeholder replaced by Task 10.
+
+- [ ] **Step 7: Run typecheck + full unit suite**
+
+```
+npm run typecheck && npm run test:unit
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```
+git add src/backend/types.ts src/backend/postgres/index.ts src/backend/vault/index.ts tests/unit/backend/factory.test.ts
+git commit -m "feat(vault-sync): add StorageBackend.sessionStart interface + meta type"
+```
+
+---
+
+## Task 2: `GitOps.afterCommit` hook
+
+**Goal:** Let `GitOpsImpl` fire a callback after every successful commit. Push queue subscribes to this in Task 11.
+
+**Files:**
+
+- Modify: `src/backend/vault/git/types.ts`
+- Modify: `src/backend/vault/git/git-ops.ts`
+- Test: `tests/unit/backend/vault/git/git-ops.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `tests/unit/backend/vault/git/git-ops.test.ts`:
+
+```ts
+it("fires afterCommit after a successful commit", async () => {
+  const root = await mkdtemp(join(tmpdir(), "git-ops-hook-"));
+  try {
+    const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+    await git.init();
+    await git.addConfig("user.email", "t@x", false, "local");
+    await git.addConfig("user.name", "t", false, "local");
+
+    const calls: number[] = [];
+    const ops = new GitOpsImpl({ root });
+    ops.afterCommit = () => calls.push(Date.now());
+
+    const path = "note.md";
+    await writeFile(join(root, path), "hi\n");
+    await ops.stageAndCommit([path], "[t] first", {
+      action: "created",
+      actor: "a",
+    });
+
+    expect(calls).toHaveLength(1);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+it("does not fire afterCommit when stageAndCommit throws", async () => {
+  const root = await mkdtemp(join(tmpdir(), "git-ops-hook-fail-"));
+  try {
+    const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+    await git.init();
+    await git.addConfig("user.email", "t@x", false, "local");
+    await git.addConfig("user.name", "t", false, "local");
+
+    const calls: number[] = [];
+    const ops = new GitOpsImpl({ root });
+    ops.afterCommit = () => calls.push(Date.now());
+
+    // Nothing to commit → VaultGitNothingToCommitError.
+    await writeFile(join(root, "ignored.md"), "x\n");
+    await git.add("ignored.md");
+    await git.commit("initial", ["ignored.md"]);
+    await expect(
+      ops.stageAndCommit(["ignored.md"], "again", {
+        action: "created",
+        actor: "a",
+      }),
+    ).rejects.toThrow();
+
+    expect(calls).toHaveLength(0);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+```
+
+Ensure `simpleGit`, `scrubGitEnv`, `writeFile`, `mkdtemp`, `rm`, `tmpdir`, `join`, `GitOpsImpl` are imported at the top of the file (follow existing test imports).
+
+- [ ] **Step 2: Run test — expect fail**
+
+```
+npx vitest run tests/unit/backend/vault/git/git-ops.test.ts -t "afterCommit"
+```
+
+Expected: FAIL (`afterCommit` does not exist on `GitOpsImpl`).
+
+- [ ] **Step 3: Add `afterCommit` field to `GitOps` interface**
+
+Edit `src/backend/vault/git/types.ts`. Inside `GitOps` interface:
+
+```ts
+  /**
+   * Optional callback invoked after every successful stageAndCommit.
+   * Fires outside the #serialize mutex but within the same async flow —
+   * callers get a synchronous "commit landed" signal. Failures in the
+   * callback are not propagated (fire-and-forget).
+   */
+  afterCommit?: () => void;
+```
+
+In `NoopGitOps` add:
+
+```ts
+  afterCommit?: () => void;
+```
+
+- [ ] **Step 4: Fire hook in `GitOpsImpl.stageAndCommit`**
+
+Edit `src/backend/vault/git/git-ops.ts`. In `stageAndCommit` after the `#serialize` block returns:
+
+```ts
+  async stageAndCommit(
+    paths: string[],
+    subject: string,
+    trailer: CommitTrailer,
+  ): Promise<void> {
+    if (paths.length === 0) {
+      throw new Error("stageAndCommit: paths must be non-empty");
+    }
+    await this.#serialize(async () => {
+      await this.git.add(paths);
+      const status = await this.git.status();
+      if (status.staged.length === 0 && status.created.length === 0) {
+        throw new VaultGitNothingToCommitError(paths);
+      }
+      const body = formatTrailers(trailer);
+      await this.git.commit(`${subject}\n\n${body}`, paths);
+    });
+    // Fire hook after the serialized block resolves so a callback that
+    // itself calls into git cannot deadlock on the mutex. Swallow hook
+    // errors — this is fire-and-forget.
+    try {
+      this.afterCommit?.();
+    } catch {
+      // ignored
+    }
+  }
+```
+
+Also add the public field:
+
+```ts
+export class GitOpsImpl implements GitOps {
+  readonly enabled = true;
+  afterCommit?: () => void;
+  // ...
+}
+```
+
+- [ ] **Step 5: Run test**
+
+```
+npx vitest run tests/unit/backend/vault/git/git-ops.test.ts -t "afterCommit"
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Full git-ops suite + typecheck**
+
+```
+npx vitest run tests/unit/backend/vault/git/git-ops.test.ts && npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```
+git add src/backend/vault/git/types.ts src/backend/vault/git/git-ops.ts tests/unit/backend/vault/git/git-ops.test.ts
+git commit -m "feat(vault-sync): add GitOps.afterCommit hook"
+```
+
+---
+
+## Task 3: `ensureRemote` — origin URL plumbing
+
+**Goal:** Read `AGENT_BRAIN_VAULT_REMOTE_URL` (or explicit config override), add `origin` on fresh init, warn on mismatch, leave existing alone.
+
+**Files:**
+
+- Create: `src/backend/vault/git/remote.ts`
+- Create: `tests/unit/backend/vault/git/remote.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/unit/backend/vault/git/remote.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { simpleGit } from "simple-git";
+import { scrubGitEnv } from "../../../../../src/backend/vault/git/env.js";
+import { ensureRemote } from "../../../../../src/backend/vault/git/remote.js";
+
+async function makeRepo(): Promise<{
+  root: string;
+  cleanup: () => Promise<void>;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "remote-test-"));
+  const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+  await git.init();
+  return { root, cleanup: () => rm(root, { recursive: true, force: true }) };
+}
+
+describe("ensureRemote", () => {
+  it("adds origin when absent + URL provided", async () => {
+    const { root, cleanup } = await makeRepo();
+    try {
+      const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+      await ensureRemote({ git, remoteUrl: "git@example.com:x/y.git" });
+      const remotes = await git.getRemotes(true);
+      const origin = remotes.find((r) => r.name === "origin");
+      expect(origin?.refs.fetch).toBe("git@example.com:x/y.git");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("no-ops when origin already matches", async () => {
+    const { root, cleanup } = await makeRepo();
+    try {
+      const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+      await git.addRemote("origin", "git@example.com:x/y.git");
+      await ensureRemote({ git, remoteUrl: "git@example.com:x/y.git" });
+      const remotes = await git.getRemotes(true);
+      expect(remotes).toHaveLength(1);
+      expect(remotes[0].refs.fetch).toBe("git@example.com:x/y.git");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("leaves mismatched origin in place + warns", async () => {
+    const { root, cleanup } = await makeRepo();
+    try {
+      const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+      await git.addRemote("origin", "git@existing:a/b.git");
+      await ensureRemote({ git, remoteUrl: "git@new:c/d.git" });
+      const remotes = await git.getRemotes(true);
+      expect(remotes[0].refs.fetch).toBe("git@existing:a/b.git");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("no-ops when no URL and no origin", async () => {
+    const { root, cleanup } = await makeRepo();
+    try {
+      const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+      await ensureRemote({ git, remoteUrl: undefined });
+      const remotes = await git.getRemotes(true);
+      expect(remotes).toHaveLength(0);
+    } finally {
+      await cleanup();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+```
+npx vitest run tests/unit/backend/vault/git/remote.test.ts
+```
+
+Expected: FAIL (module `remote.js` missing).
+
+- [ ] **Step 3: Implement `ensureRemote`**
+
+Create `src/backend/vault/git/remote.ts`:
+
+```ts
+import type { SimpleGit } from "simple-git";
+import { logger } from "../../../utils/logger.js";
+
+export interface EnsureRemoteConfig {
+  git: SimpleGit;
+  remoteUrl: string | undefined;
+}
+
+/**
+ * Adds `origin` to the vault repo when absent and `remoteUrl` is provided.
+ * Leaves any existing `origin` alone — users may have configured the
+ * remote manually and that intent wins. Mismatches are warn-logged.
+ * Idempotent.
+ */
+export async function ensureRemote(cfg: EnsureRemoteConfig): Promise<void> {
+  const remotes = await cfg.git.getRemotes(true);
+  const origin = remotes.find((r) => r.name === "origin");
+  if (origin) {
+    if (cfg.remoteUrl && origin.refs.fetch !== cfg.remoteUrl) {
+      logger.warn(
+        `vault: AGENT_BRAIN_VAULT_REMOTE_URL (${cfg.remoteUrl}) differs from existing origin (${origin.refs.fetch}); leaving existing`,
+      );
+    }
+    return;
+  }
+  if (!cfg.remoteUrl) return;
+  await cfg.git.addRemote("origin", cfg.remoteUrl);
+}
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```
+npx vitest run tests/unit/backend/vault/git/remote.test.ts
+```
+
+Expected: PASS (4/4).
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/backend/vault/git/remote.ts tests/unit/backend/vault/git/remote.test.ts
+git commit -m "feat(vault-sync): add ensureRemote"
+```
+
+---
+
+## Task 4: `PushQueue` — debounce + single-flight
+
+**Goal:** Class that coalesces rapid `request()` calls into one push, running one push subprocess at a time. No backoff yet.
+
+**Files:**
+
+- Create: `src/backend/vault/git/push-queue.ts`
+- Create: `tests/unit/backend/vault/git/push-queue.test.ts`
+
+- [ ] **Step 1: Write failing test (debounce + single-flight only)**
+
+Create `tests/unit/backend/vault/git/push-queue.test.ts`:
+
+```ts
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { PushQueue } from "../../../../../src/backend/vault/git/push-queue.js";
+
+interface FakePushResult {
+  resolve: (value: void) => void;
+  reject: (err: Error) => void;
+  calls: number;
+}
+
+function fakePusher(): { push: () => Promise<void>; state: FakePushResult } {
+  const state: FakePushResult = {
+    resolve: () => {},
+    reject: () => {},
+    calls: 0,
+  };
+  const push = () => {
+    state.calls += 1;
+    return new Promise<void>((resolve, reject) => {
+      state.resolve = resolve;
+      state.reject = reject;
+    });
+  };
+  return { push, state };
+}
+
+describe("PushQueue debounce + single-flight", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("coalesces rapid requests into one push", async () => {
+    const { push, state } = fakePusher();
+    const q = new PushQueue({ push, debounceMs: 100, backoffMs: [] });
+    q.request();
+    q.request();
+    q.request();
+    expect(state.calls).toBe(0);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(state.calls).toBe(1);
+    state.resolve();
+    await q.close();
+  });
+
+  it("bumps debounce on each request", async () => {
+    const { push, state } = fakePusher();
+    const q = new PushQueue({ push, debounceMs: 100, backoffMs: [] });
+    q.request();
+    await vi.advanceTimersByTimeAsync(60);
+    q.request();
+    await vi.advanceTimersByTimeAsync(60);
+    // Still not fired — second request reset timer to now+100.
+    expect(state.calls).toBe(0);
+    await vi.advanceTimersByTimeAsync(40);
+    expect(state.calls).toBe(1);
+    state.resolve();
+    await q.close();
+  });
+
+  it("single-flight: second push waits for first to finish", async () => {
+    const { push, state } = fakePusher();
+    const q = new PushQueue({ push, debounceMs: 100, backoffMs: [] });
+    q.request();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(state.calls).toBe(1);
+    // Trigger follow-up push while first in-flight.
+    q.request();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(state.calls).toBe(1); // still blocked behind in-flight
+    state.resolve();
+    // Allow microtask queue + scheduled follow-up.
+    await vi.advanceTimersByTimeAsync(100);
+    expect(state.calls).toBe(2);
+    state.resolve();
+    await q.close();
+  });
+
+  it("close() drains in-flight and cancels pending debounce", async () => {
+    const { push, state } = fakePusher();
+    const q = new PushQueue({ push, debounceMs: 100, backoffMs: [] });
+    q.request();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(state.calls).toBe(1);
+    state.resolve();
+    q.request();
+    const closed = q.close();
+    // Pending debounce cancelled — no new push.
+    await vi.advanceTimersByTimeAsync(1000);
+    await closed;
+    expect(state.calls).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+```
+npx vitest run tests/unit/backend/vault/git/push-queue.test.ts
+```
+
+Expected: FAIL (module missing).
+
+- [ ] **Step 3: Implement `PushQueue` (debounce + single-flight only, no backoff)**
+
+Create `src/backend/vault/git/push-queue.ts`:
+
+```ts
+import { logger } from "../../../utils/logger.js";
+
+export interface PushQueueConfig {
+  /**
+   * Performs the actual push. Injected so unit tests can use a fake
+   * and the real backend wires a simple-git wrapper in Task 11.
+   * Throwing any error keeps the queue in pending state; retry
+   * scheduling is handled by the backoff logic (Task 5).
+   */
+  push: () => Promise<void>;
+  debounceMs: number;
+  backoffMs: readonly number[];
+}
+
+type State =
+  | { kind: "idle" }
+  | { kind: "scheduled"; timer: NodeJS.Timeout }
+  | { kind: "in-flight"; follow: boolean }
+  | { kind: "backoff"; timer: NodeJS.Timeout; attempt: number };
+
+/**
+ * Debounced, single-flight push queue. `request()` bumps a debounce
+ * timer; when it fires, one push runs. Concurrent requests during an
+ * in-flight push queue exactly one follow-up on completion.
+ */
+export class PushQueue {
+  private state: State = { kind: "idle" };
+  private closing = false;
+
+  constructor(private readonly cfg: PushQueueConfig) {}
+
+  request(): void {
+    if (this.closing) return;
+    switch (this.state.kind) {
+      case "idle":
+        this.#schedule();
+        return;
+      case "scheduled":
+        clearTimeout(this.state.timer);
+        this.#schedule();
+        return;
+      case "in-flight":
+        this.state = { kind: "in-flight", follow: true };
+        return;
+      case "backoff":
+        // Do not shorten backoff — just mark that we still need to push.
+        // The backoff timer already owns the next attempt.
+        return;
+    }
+  }
+
+  async close(): Promise<void> {
+    this.closing = true;
+    if (this.state.kind === "scheduled") {
+      clearTimeout(this.state.timer);
+      this.state = { kind: "idle" };
+    }
+    if (this.state.kind === "backoff") {
+      clearTimeout(this.state.timer);
+      this.state = { kind: "idle" };
+    }
+    while (this.state.kind === "in-flight") {
+      await new Promise((r) => setImmediate(r));
+    }
+  }
+
+  #schedule(): void {
+    const timer = setTimeout(() => {
+      void this.#runPush();
+    }, this.cfg.debounceMs);
+    this.state = { kind: "scheduled", timer };
+  }
+
+  async #runPush(): Promise<void> {
+    this.state = { kind: "in-flight", follow: false };
+    try {
+      await this.cfg.push();
+      // Success path: drain follow-up if queued.
+      const follow = this.state.kind === "in-flight" && this.state.follow;
+      this.state = { kind: "idle" };
+      if (follow && !this.closing) {
+        this.#schedule();
+      }
+    } catch (err) {
+      // Backoff path — implemented in Task 5. For now just log + idle.
+      logger.warn(
+        `vault push failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      this.state = { kind: "idle" };
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```
+npx vitest run tests/unit/backend/vault/git/push-queue.test.ts
+```
+
+Expected: PASS (4/4).
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/backend/vault/git/push-queue.ts tests/unit/backend/vault/git/push-queue.test.ts
+git commit -m "feat(vault-sync): PushQueue debounce + single-flight"
+```
+
+---
+
+## Task 5: `PushQueue` — backoff on failure
+
+**Goal:** When `push` rejects, the queue enters `backoff` for `backoffMs[attempt]` before retrying, with `attempt` capped at the last index. Success resets `attempt` to 0.
+
+**Files:**
+
+- Modify: `src/backend/vault/git/push-queue.ts`
+- Modify: `tests/unit/backend/vault/git/push-queue.test.ts`
+
+- [ ] **Step 1: Write failing backoff tests**
+
+Append to `push-queue.test.ts`:
+
+```ts
+describe("PushQueue backoff", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retries according to backoffMs schedule", async () => {
+    const { push, state } = fakePusher();
+    const q = new PushQueue({
+      push,
+      debounceMs: 100,
+      backoffMs: [500, 2000],
+    });
+    q.request();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(state.calls).toBe(1);
+    state.reject(new Error("boom"));
+    // Wait for the rejection to propagate and state to flip to backoff.
+    await vi.advanceTimersByTimeAsync(0);
+
+    // No retry before 500ms.
+    await vi.advanceTimersByTimeAsync(499);
+    expect(state.calls).toBe(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(state.calls).toBe(2);
+
+    state.reject(new Error("boom again"));
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(state.calls).toBe(2);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(state.calls).toBe(3);
+    state.resolve();
+    await q.close();
+  });
+
+  it("stays at last backoff step after exhausting schedule", async () => {
+    const { push, state } = fakePusher();
+    const q = new PushQueue({ push, debounceMs: 100, backoffMs: [500] });
+    q.request();
+    await vi.advanceTimersByTimeAsync(100);
+    state.reject(new Error("1"));
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(500);
+    state.reject(new Error("2"));
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(state.calls).toBe(3);
+    state.resolve();
+    await q.close();
+  });
+
+  it("success resets backoff to 0", async () => {
+    const { push, state } = fakePusher();
+    const q = new PushQueue({
+      push,
+      debounceMs: 100,
+      backoffMs: [500, 2000],
+    });
+    q.request();
+    await vi.advanceTimersByTimeAsync(100);
+    state.reject(new Error("1"));
+    await vi.advanceTimersByTimeAsync(500);
+    state.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Trigger another push.
+    q.request();
+    await vi.advanceTimersByTimeAsync(100);
+    state.reject(new Error("2"));
+    await vi.advanceTimersByTimeAsync(0);
+    // Should wait 500ms (attempt=0) again, not 2000ms.
+    await vi.advanceTimersByTimeAsync(499);
+    expect(state.calls).toBe(3);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(state.calls).toBe(4);
+    state.resolve();
+    await q.close();
+  });
+
+  it("request during backoff does not shorten timer", async () => {
+    const { push, state } = fakePusher();
+    const q = new PushQueue({ push, debounceMs: 100, backoffMs: [1000] });
+    q.request();
+    await vi.advanceTimersByTimeAsync(100);
+    state.reject(new Error("boom"));
+    await vi.advanceTimersByTimeAsync(0);
+    q.request(); // during backoff
+    await vi.advanceTimersByTimeAsync(500);
+    expect(state.calls).toBe(1);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(state.calls).toBe(2);
+    state.resolve();
+    await q.close();
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+```
+npx vitest run tests/unit/backend/vault/git/push-queue.test.ts -t "backoff"
+```
+
+Expected: FAIL (tests see `calls` stuck at 1).
+
+- [ ] **Step 3: Implement backoff branch**
+
+Replace `#runPush` in `src/backend/vault/git/push-queue.ts`:
+
+```ts
+  private attempt = 0;
+
+  async #runPush(): Promise<void> {
+    this.state = { kind: "in-flight", follow: false };
+    try {
+      await this.cfg.push();
+      const follow = this.state.kind === "in-flight" && this.state.follow;
+      this.state = { kind: "idle" };
+      this.attempt = 0;
+      if (follow && !this.closing) {
+        this.#schedule();
+      }
+    } catch (err) {
+      logger.warn(
+        `vault push failed (attempt ${this.attempt + 1}): ${err instanceof Error ? err.message : String(err)}`,
+      );
+      if (this.closing) {
+        this.state = { kind: "idle" };
+        return;
+      }
+      const ms = this.#backoffMs();
+      this.attempt += 1;
+      const timer = setTimeout(() => {
+        void this.#runPush();
+      }, ms);
+      this.state = { kind: "backoff", timer, attempt: this.attempt };
+    }
+  }
+
+  #backoffMs(): number {
+    if (this.cfg.backoffMs.length === 0) return 0;
+    const idx = Math.min(this.attempt, this.cfg.backoffMs.length - 1);
+    return this.cfg.backoffMs[idx];
+  }
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```
+npx vitest run tests/unit/backend/vault/git/push-queue.test.ts
+```
+
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/backend/vault/git/push-queue.ts tests/unit/backend/vault/git/push-queue.test.ts
+git commit -m "feat(vault-sync): PushQueue failure backoff"
+```
+
+---
+
+## Task 6: `PushQueue.unpushedCommits()`
+
+**Goal:** Expose the `@{u}..HEAD` count so `sessionStart` can surface `unpushed_commits`. Accept a separate `unpushedCommits` function in `PushQueueConfig` (injected for testability).
+
+**Files:**
+
+- Modify: `src/backend/vault/git/push-queue.ts`
+- Modify: `tests/unit/backend/vault/git/push-queue.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `push-queue.test.ts`:
+
+```ts
+describe("PushQueue.unpushedCommits", () => {
+  it("delegates to injected counter", async () => {
+    const { push } = fakePusher();
+    const q = new PushQueue({
+      push,
+      debounceMs: 100,
+      backoffMs: [],
+      countUnpushed: async () => 7,
+    });
+    expect(await q.unpushedCommits()).toBe(7);
+    await q.close();
+  });
+
+  it("returns 0 when counter throws (no upstream configured)", async () => {
+    const { push } = fakePusher();
+    const q = new PushQueue({
+      push,
+      debounceMs: 100,
+      backoffMs: [],
+      countUnpushed: async () => {
+        throw new Error("no upstream");
+      },
+    });
+    expect(await q.unpushedCommits()).toBe(0);
+    await q.close();
+  });
+
+  it("returns 0 when counter not provided", async () => {
+    const { push } = fakePusher();
+    const q = new PushQueue({ push, debounceMs: 100, backoffMs: [] });
+    expect(await q.unpushedCommits()).toBe(0);
+    await q.close();
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect fail (`countUnpushed` unknown; method missing)**
+
+```
+npx vitest run tests/unit/backend/vault/git/push-queue.test.ts -t "unpushedCommits"
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Extend config + add method**
+
+Edit `src/backend/vault/git/push-queue.ts`:
+
+```ts
+export interface PushQueueConfig {
+  push: () => Promise<void>;
+  countUnpushed?: () => Promise<number>;
+  debounceMs: number;
+  backoffMs: readonly number[];
+}
+```
+
+Inside `PushQueue`:
+
+```ts
+  async unpushedCommits(): Promise<number> {
+    if (!this.cfg.countUnpushed) return 0;
+    try {
+      return await this.cfg.countUnpushed();
+    } catch {
+      return 0;
+    }
+  }
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```
+npx vitest run tests/unit/backend/vault/git/push-queue.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/backend/vault/git/push-queue.ts tests/unit/backend/vault/git/push-queue.test.ts
+git commit -m "feat(vault-sync): PushQueue unpushedCommits()"
+```
+
+---
+
+## Task 7: `syncFromRemote` — pull --rebase --autostash
+
+**Goal:** Pull the vault, classify outcome as `success | offline | conflict`, collect `changedPaths` (for reindex). Never throws on offline/conflict.
+
+**Files:**
+
+- Create: `src/backend/vault/git/pull.ts`
+- Create: `tests/unit/backend/vault/git/pull.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/unit/backend/vault/git/pull.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { simpleGit } from "simple-git";
+import { scrubGitEnv } from "../../../../../src/backend/vault/git/env.js";
+import { syncFromRemote } from "../../../../../src/backend/vault/git/pull.js";
+
+async function setupOriginAndClone(): Promise<{
+  origin: string;
+  clone: string;
+  cleanup: () => Promise<void>;
+}> {
+  const dir = await mkdtemp(join(tmpdir(), "pull-test-"));
+  const origin = join(dir, "origin.git");
+  const clone = join(dir, "clone");
+  await mkdir(origin);
+  await simpleGit().env(scrubGitEnv()).cwd(origin).init(true);
+  await simpleGit().env(scrubGitEnv()).clone(origin, clone);
+  const git = simpleGit({ baseDir: clone }).env(scrubGitEnv());
+  await git.addConfig("user.email", "t@x", false, "local");
+  await git.addConfig("user.name", "t", false, "local");
+  await writeFile(join(clone, "first.md"), "hello\n");
+  await git.add("first.md");
+  await git.commit("initial");
+  await git.push("origin", "HEAD:main");
+  return {
+    origin,
+    clone,
+    cleanup: () => rm(dir, { recursive: true, force: true }),
+  };
+}
+
+describe("syncFromRemote", () => {
+  it("fast-forward returns changedPaths, not offline/conflict", async () => {
+    const { origin, clone, cleanup } = await setupOriginAndClone();
+    try {
+      // Make a second clone, commit, push.
+      const other = clone + "-other";
+      await simpleGit().env(scrubGitEnv()).clone(origin, other);
+      const og = simpleGit({ baseDir: other }).env(scrubGitEnv());
+      await og.addConfig("user.email", "t@x", false, "local");
+      await og.addConfig("user.name", "t", false, "local");
+      await writeFile(join(other, "added.md"), "new\n");
+      await og.add("added.md");
+      await og.commit("add file");
+      await og.push("origin", "HEAD:main");
+
+      const git = simpleGit({ baseDir: clone }).env(scrubGitEnv());
+      const result = await syncFromRemote({ git });
+      expect(result.offline).toBe(false);
+      expect(result.conflict).toBe(false);
+      expect(result.changedPaths).toContain("added.md");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("up-to-date returns empty changedPaths", async () => {
+    const { clone, cleanup } = await setupOriginAndClone();
+    try {
+      const git = simpleGit({ baseDir: clone }).env(scrubGitEnv());
+      const result = await syncFromRemote({ git });
+      expect(result.offline).toBe(false);
+      expect(result.conflict).toBe(false);
+      expect(result.changedPaths).toEqual([]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("rebase conflict → conflict=true, rebase aborted, working tree clean", async () => {
+    const { origin, clone, cleanup } = await setupOriginAndClone();
+    try {
+      // Remote commit modifies first.md.
+      const other = clone + "-other";
+      await simpleGit().env(scrubGitEnv()).clone(origin, other);
+      const og = simpleGit({ baseDir: other }).env(scrubGitEnv());
+      await og.addConfig("user.email", "t@x", false, "local");
+      await og.addConfig("user.name", "t", false, "local");
+      await writeFile(join(other, "first.md"), "remote-change\n");
+      await og.add("first.md");
+      await og.commit("remote");
+      await og.push("origin", "HEAD:main");
+
+      // Local conflicting commit on the same file.
+      const git = simpleGit({ baseDir: clone }).env(scrubGitEnv());
+      await writeFile(join(clone, "first.md"), "local-change\n");
+      await git.add("first.md");
+      await git.commit("local");
+
+      const result = await syncFromRemote({ git });
+      expect(result.conflict).toBe(true);
+      expect(result.offline).toBe(false);
+      const status = await git.status();
+      expect(status.files).toHaveLength(0); // clean working tree
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("network failure → offline=true, no throw", async () => {
+    const { clone, cleanup } = await setupOriginAndClone();
+    try {
+      const git = simpleGit({ baseDir: clone }).env(scrubGitEnv());
+      // Point origin at a bogus URL.
+      await git.remote(["set-url", "origin", "/tmp/does-not-exist-xyz"]);
+      const result = await syncFromRemote({ git });
+      expect(result.offline).toBe(true);
+      expect(result.conflict).toBe(false);
+      expect(result.changedPaths).toEqual([]);
+    } finally {
+      await cleanup();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+```
+npx vitest run tests/unit/backend/vault/git/pull.test.ts
+```
+
+Expected: FAIL (module missing).
+
+- [ ] **Step 3: Implement `syncFromRemote`**
+
+Create `src/backend/vault/git/pull.ts`:
+
+```ts
+import type { SimpleGit } from "simple-git";
+import { logger } from "../../../utils/logger.js";
+
+export interface SyncFromRemoteConfig {
+  git: SimpleGit;
+}
+
+export interface SyncResult {
+  offline: boolean;
+  conflict: boolean;
+  /** Paths changed by the pull (git-relative, forward-slash). */
+  changedPaths: string[];
+}
+
+/**
+ * Runs `git pull --rebase --autostash`. Classifies failures rather than
+ * throwing. Rebase conflicts abort via `git rebase --abort` so the working
+ * tree returns to the pre-pull HEAD. Network / auth failures surface as
+ * `offline: true`. Caller decides whether to serve local stale data.
+ */
+export async function syncFromRemote(
+  cfg: SyncFromRemoteConfig,
+): Promise<SyncResult> {
+  // Short-circuit when no origin is configured — pull would throw
+  // "no tracking information".
+  const remotes = await cfg.git.getRemotes(true);
+  if (!remotes.some((r) => r.name === "origin")) {
+    return { offline: false, conflict: false, changedPaths: [] };
+  }
+
+  const preHead = await resolveHead(cfg.git);
+
+  try {
+    await cfg.git.pull("origin", undefined, {
+      "--rebase": null,
+      "--autostash": null,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/CONFLICT|could not apply|Merge conflict|rebase.*conflict/i.test(msg)) {
+      try {
+        await cfg.git.raw(["rebase", "--abort"]);
+      } catch (abortErr) {
+        logger.error(
+          `vault: rebase --abort failed after conflict: ${abortErr instanceof Error ? abortErr.message : String(abortErr)}`,
+        );
+      }
+      return { offline: false, conflict: true, changedPaths: [] };
+    }
+    // Treat everything else as offline/transient — network, auth, no
+    // upstream, host unreachable, etc.
+    logger.warn(`vault: pull failed, serving local: ${msg}`);
+    return { offline: true, conflict: false, changedPaths: [] };
+  }
+
+  const postHead = await resolveHead(cfg.git);
+  if (!preHead || !postHead || preHead === postHead) {
+    return { offline: false, conflict: false, changedPaths: [] };
+  }
+  const diff = await cfg.git.raw([
+    "diff",
+    "--name-only",
+    `${preHead}..${postHead}`,
+  ]);
+  const changedPaths = diff
+    .split("\n")
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+  return { offline: false, conflict: false, changedPaths };
+}
+
+async function resolveHead(git: SimpleGit): Promise<string | null> {
+  try {
+    const sha = await git.raw(["rev-parse", "HEAD"]);
+    return sha.trim();
+  } catch {
+    return null;
+  }
+}
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```
+npx vitest run tests/unit/backend/vault/git/pull.test.ts
+```
+
+Expected: PASS (4/4). Note: if vitest complains about the `[2]` / `[0]` fake-clone tempdir, each test creates its own `mkdtemp`, so isolation holds.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/backend/vault/git/pull.ts tests/unit/backend/vault/git/pull.test.ts
+git commit -m "feat(vault-sync): syncFromRemote pull --rebase --autostash"
+```
+
+---
+
+## Task 8: `reconcileDirty` — post-crash recovery commit
+
+**Goal:** On backend startup, collapse any dirty tracked memory markdown files into a single `AB-Action: reconcile` commit before serving. Uses the same `GitOpsImpl.stageAndCommit` so we inherit the mutex + scoped-commit invariants.
+
+**Files:**
+
+- Create: `src/backend/vault/git/reconcile.ts`
+- Create: `tests/unit/backend/vault/git/reconcile.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/unit/backend/vault/git/reconcile.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { simpleGit } from "simple-git";
+import { scrubGitEnv } from "../../../../../src/backend/vault/git/env.js";
+import { GitOpsImpl } from "../../../../../src/backend/vault/git/git-ops.js";
+import { reconcileDirty } from "../../../../../src/backend/vault/git/reconcile.js";
+
+async function makeRepo(): Promise<{
+  root: string;
+  cleanup: () => Promise<void>;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "reconcile-test-"));
+  const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+  await git.init();
+  await git.addConfig("user.email", "t@x", false, "local");
+  await git.addConfig("user.name", "t", false, "local");
+  // Ignore a runtime subtree to prove reconcile skips gitignored files.
+  await writeFile(join(root, ".gitignore"), ".agent-brain/\n");
+  await git.add(".gitignore");
+  await git.commit("init");
+  return { root, cleanup: () => rm(root, { recursive: true, force: true }) };
+}
+
+describe("reconcileDirty", () => {
+  it("collapses dirty tracked memory markdown into one reconcile commit", async () => {
+    const { root, cleanup } = await makeRepo();
+    try {
+      const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+      const ops = new GitOpsImpl({ root });
+
+      // Create + commit two memory files so they're tracked.
+      await mkdir(join(root, "workspaces/ws1/memories"), { recursive: true });
+      await writeFile(join(root, "workspaces/ws1/memories/a.md"), "v1-a\n");
+      await writeFile(join(root, "workspaces/ws1/memories/b.md"), "v1-b\n");
+      await git.add([
+        "workspaces/ws1/memories/a.md",
+        "workspaces/ws1/memories/b.md",
+      ]);
+      await git.commit("seed");
+
+      // Now dirty them outside git — simulates post-crash state.
+      await writeFile(join(root, "workspaces/ws1/memories/a.md"), "v2-a\n");
+      await writeFile(join(root, "workspaces/ws1/memories/b.md"), "v2-b\n");
+
+      await reconcileDirty({ git, ops });
+
+      const log = await git.log();
+      expect(log.latest?.message).toMatch(/reconcile/i);
+      const showFiles = await git.raw([
+        "show",
+        "--name-only",
+        "--pretty=format:",
+        "HEAD",
+      ]);
+      const files = showFiles
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean);
+      expect(files).toEqual(
+        expect.arrayContaining([
+          "workspaces/ws1/memories/a.md",
+          "workspaces/ws1/memories/b.md",
+        ]),
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("no-op when tree clean", async () => {
+    const { root, cleanup } = await makeRepo();
+    try {
+      const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+      const ops = new GitOpsImpl({ root });
+      const before = (await git.log()).total;
+      await reconcileDirty({ git, ops });
+      const after = (await git.log()).total;
+      expect(after).toBe(before);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("ignores untracked files and gitignored dirty files", async () => {
+    const { root, cleanup } = await makeRepo();
+    try {
+      const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+      const ops = new GitOpsImpl({ root });
+
+      await mkdir(join(root, ".agent-brain"), { recursive: true });
+      await writeFile(join(root, ".agent-brain/state.json"), "{}");
+      await mkdir(join(root, "workspaces/ws1/memories"), { recursive: true });
+      await writeFile(
+        join(root, "workspaces/ws1/memories/new.md"),
+        "untracked\n",
+      );
+
+      const before = (await git.log()).total;
+      await reconcileDirty({ git, ops });
+      const after = (await git.log()).total;
+      expect(after).toBe(before);
+    } finally {
+      await cleanup();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+```
+npx vitest run tests/unit/backend/vault/git/reconcile.test.ts
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `reconcileDirty`**
+
+Create `src/backend/vault/git/reconcile.ts`:
+
+```ts
+import type { SimpleGit } from "simple-git";
+import { logger } from "../../../utils/logger.js";
+import type { GitOps } from "./types.js";
+
+export interface ReconcileConfig {
+  git: SimpleGit;
+  ops: GitOps;
+}
+
+const MEMORY_PATH_RE =
+  /^(workspaces\/[^/]+\/memories\/|project\/memories\/|users\/[^/]+\/memories\/).+\.md$/;
+
+/**
+ * Recovers from a crash between "markdown write succeeded" and "git commit
+ * landed" in Phase 4a. Collects dirty tracked memory markdown files and
+ * folds them into a single commit with trailer `AB-Action: reconcile`.
+ *
+ * Untracked files are ignored (requires validation; defer to Phase 5
+ * watcher). Non-memory dirty files are also ignored — operator edits to
+ * README etc. should not be auto-committed by agent-brain on startup.
+ */
+export async function reconcileDirty(cfg: ReconcileConfig): Promise<void> {
+  if (!cfg.ops.enabled) return;
+  const status = await cfg.git.status();
+  const candidates = [
+    ...status.modified,
+    ...status.not_added,
+    ...status.deleted,
+  ].filter((p) => MEMORY_PATH_RE.test(p));
+  if (candidates.length === 0) return;
+
+  try {
+    await cfg.ops.stageAndCommit(
+      candidates,
+      "[agent-brain] reconcile: post-crash recovery",
+      {
+        action: "reconcile",
+        actor: "agent-brain",
+        reason: "post-crash-recovery",
+      },
+    );
+  } catch (err) {
+    logger.error(
+      `vault reconcile commit failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Extend `CommitAction` to include `"reconcile"`**
+
+Edit `src/backend/vault/git/trailers.ts` (or wherever `CommitAction` is defined — check `types.ts` first):
+
+```ts
+export type CommitAction =
+  | "created"
+  | "updated"
+  | "archived"
+  | "verified"
+  | "commented"
+  | "flagged"
+  | "unflagged"
+  | "related"
+  | "unrelated"
+  | "workspace_upsert"
+  | "reconcile";
+```
+
+- [ ] **Step 5: Update trailer-formatter test if it enumerates actions**
+
+Check `tests/unit/backend/vault/git/trailers.test.ts` for an enumeration assertion and add `"reconcile"` if needed.
+
+- [ ] **Step 6: Run tests**
+
+```
+npx vitest run tests/unit/backend/vault/git/reconcile.test.ts tests/unit/backend/vault/git/trailers.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```
+git add src/backend/vault/git/reconcile.ts src/backend/vault/git/types.ts tests/unit/backend/vault/git/reconcile.test.ts tests/unit/backend/vault/git/trailers.test.ts
+git commit -m "feat(vault-sync): reconcileDirty post-crash recovery commit"
+```
+
+---
+
+## Task 9: `diffReindex` — refresh lance after pull
+
+**Goal:** Given a list of changed paths returned by `syncFromRemote`, parse each memory markdown file, compare `content_hash` against the Phase 3 lance row, and:
+
+- new hash → re-embed via the embedding provider + full upsert
+- same hash → metadata-only upsert (no re-embed)
+- parse failure → increment `parse_errors`, skip, continue
+
+The embedding call is injected so unit tests use a deterministic fake.
+
+**Files:**
+
+- Create: `src/backend/vault/session-start.ts` (holds `diffReindex` for now; `runSessionStart` added in Task 10)
+- Create: `tests/unit/backend/vault/session-start.test.ts`
+- Modify: `src/backend/vault/vector/lance-index.ts` — add `getContentHash(id)` lookup
+
+- [ ] **Step 1: Add `getContentHash` to vector index**
+
+Edit `src/backend/vault/vector/lance-index.ts`. Add method:
+
+```ts
+  async getContentHash(id: string): Promise<string | null> {
+    const rows = await this.table
+      .query()
+      .where(`id = '${id.replace(/'/g, "''")}'`)
+      .select(["content_hash"])
+      .limit(1)
+      .toArray();
+    if (rows.length === 0) return null;
+    return String(rows[0].content_hash);
+  }
+```
+
+Add unit coverage in `tests/unit/backend/vault/vector/lance-index.test.ts`:
+
+```ts
+it("getContentHash returns stored hash", async () => {
+  const { index, cleanup } = await makeIndex();
+  try {
+    await index.upsert([{ ...baseRow("m1"), content_hash: "h1" }]);
+    expect(await index.getContentHash("m1")).toBe("h1");
+    expect(await index.getContentHash("missing")).toBeNull();
+  } finally {
+    await cleanup();
+  }
+});
+```
+
+(Use the file's existing `makeIndex` / `baseRow` helpers; they already exist — check imports.)
+
+Run: `npx vitest run tests/unit/backend/vault/vector/lance-index.test.ts -t "getContentHash"` — PASS.
+
+- [ ] **Step 2: Write failing `diffReindex` tests**
+
+Create `tests/unit/backend/vault/session-start.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { VaultVectorIndex } from "../../../../src/backend/vault/vector/lance-index.js";
+import { diffReindex } from "../../../../src/backend/vault/session-start.js";
+import { serializeMemoryFile } from "../../../../src/backend/vault/parser/memory-parser.js";
+
+const DIMS = 768;
+
+async function setup(): Promise<{
+  root: string;
+  index: VaultVectorIndex;
+  cleanup: () => Promise<void>;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "reindex-test-"));
+  const index = await VaultVectorIndex.create({ root, dims: DIMS });
+  return {
+    root,
+    index,
+    cleanup: async () => {
+      await index.close();
+      await rm(root, { recursive: true, force: true });
+    },
+  };
+}
+
+function fakeMemoryMarkdown(id: string, body: string): string {
+  return serializeMemoryFile({
+    frontmatter: {
+      id,
+      title: `t-${id}`,
+      type: "fact",
+      scope: "workspace",
+      workspace_id: "ws1",
+      user_id: null,
+      project_id: "p1",
+      author: "a",
+      source: null,
+      tags: null,
+      version: 1,
+      created_at: "2026-04-22T00:00:00Z",
+      updated_at: "2026-04-22T00:00:00Z",
+      verified_at: null,
+      archived_at: null,
+      embedding_model: null,
+      embedding_dimensions: DIMS,
+      flags: [],
+    },
+    body,
+    comments: [],
+    relationships: [],
+  });
+}
+
+async function writeMemory(
+  root: string,
+  path: string,
+  id: string,
+  body: string,
+): Promise<void> {
+  const abs = join(root, path);
+  await mkdir(join(abs, ".."), { recursive: true });
+  await writeFile(abs, fakeMemoryMarkdown(id, body));
+}
+
+describe("diffReindex", () => {
+  it("re-embeds when content hash changed", async () => {
+    const { root, index, cleanup } = await setup();
+    try {
+      let calls = 0;
+      const embed = async (text: string) => {
+        calls += 1;
+        return new Array(DIMS).fill(text.length / 100);
+      };
+      await writeMemory(root, "workspaces/ws1/memories/m1.md", "m1", "body-v1");
+      const r1 = await diffReindex({
+        paths: ["workspaces/ws1/memories/m1.md"],
+        root,
+        vectorIndex: index,
+        embed,
+      });
+      expect(r1.parseErrors).toBe(0);
+      expect(calls).toBe(1);
+
+      await writeMemory(root, "workspaces/ws1/memories/m1.md", "m1", "body-v2");
+      const r2 = await diffReindex({
+        paths: ["workspaces/ws1/memories/m1.md"],
+        root,
+        vectorIndex: index,
+        embed,
+      });
+      expect(r2.parseErrors).toBe(0);
+      expect(calls).toBe(2);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("skips re-embed when content hash unchanged", async () => {
+    const { root, index, cleanup } = await setup();
+    try {
+      let calls = 0;
+      const embed = async (text: string) => {
+        calls += 1;
+        return new Array(DIMS).fill(text.length / 100);
+      };
+      await writeMemory(
+        root,
+        "workspaces/ws1/memories/m1.md",
+        "m1",
+        "body-stable",
+      );
+      await diffReindex({
+        paths: ["workspaces/ws1/memories/m1.md"],
+        root,
+        vectorIndex: index,
+        embed,
+      });
+      expect(calls).toBe(1);
+      await diffReindex({
+        paths: ["workspaces/ws1/memories/m1.md"],
+        root,
+        vectorIndex: index,
+        embed,
+      });
+      expect(calls).toBe(1); // skipped — same hash
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("counts parse errors without aborting", async () => {
+    const { root, index, cleanup } = await setup();
+    try {
+      const embed = async () => new Array(DIMS).fill(0.1);
+      await writeMemory(root, "workspaces/ws1/memories/good.md", "good", "ok");
+      await mkdir(join(root, "workspaces/ws1/memories"), { recursive: true });
+      await writeFile(
+        join(root, "workspaces/ws1/memories/bad.md"),
+        ":: not YAML ::\n",
+      );
+      const r = await diffReindex({
+        paths: [
+          "workspaces/ws1/memories/good.md",
+          "workspaces/ws1/memories/bad.md",
+        ],
+        root,
+        vectorIndex: index,
+        embed,
+      });
+      expect(r.parseErrors).toBe(1);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("skips non-memory paths", async () => {
+    const { root, index, cleanup } = await setup();
+    try {
+      let calls = 0;
+      const embed = async () => {
+        calls += 1;
+        return new Array(DIMS).fill(0.1);
+      };
+      const r = await diffReindex({
+        paths: [".gitignore", "README.md", "docs/x.md"],
+        root,
+        vectorIndex: index,
+        embed,
+      });
+      expect(r.parseErrors).toBe(0);
+      expect(calls).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+});
+```
+
+Adjust `serializeMemoryFile` import path if the parser exports differ — check `src/backend/vault/parser/memory-parser.ts` for the exact exported fn name (may be `serialize` / `serializeMemoryFile` / similar) and `MemoryFile` shape.
+
+- [ ] **Step 3: Run — expect fail**
+
+```
+npx vitest run tests/unit/backend/vault/session-start.test.ts
+```
+
+Expected: FAIL (module missing).
+
+- [ ] **Step 4: Implement `diffReindex`**
+
+Create `src/backend/vault/session-start.ts`:
+
+```ts
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+import { parseMemoryFile } from "./parser/memory-parser.js";
+import type { VaultVectorIndex, IndexRow } from "./vector/lance-index.js";
+import { logger } from "../../utils/logger.js";
+
+const MEMORY_PATH_RE =
+  /^(workspaces\/[^/]+\/memories\/|project\/memories\/|users\/[^/]+\/memories\/).+\.md$/;
+
+export type Embedder = (text: string) => Promise<number[]>;
+
+export interface DiffReindexConfig {
+  paths: string[];
+  root: string;
+  vectorIndex: VaultVectorIndex;
+  embed: Embedder;
+}
+
+export interface DiffReindexResult {
+  parseErrors: number;
+}
+
+export async function diffReindex(
+  cfg: DiffReindexConfig,
+): Promise<DiffReindexResult> {
+  let parseErrors = 0;
+  for (const rel of cfg.paths) {
+    if (!MEMORY_PATH_RE.test(rel)) continue;
+    const abs = join(cfg.root, rel);
+    let raw: string;
+    try {
+      raw = await readFile(abs, "utf8");
+    } catch (err) {
+      // File deleted by the pull (e.g. remote deleted a memory via merge).
+      // Skip silently — phase 4b does not handle remote deletions.
+      logger.debug(
+        `diffReindex: skip unreadable ${rel}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      continue;
+    }
+    let parsed;
+    try {
+      parsed = parseMemoryFile(raw);
+    } catch {
+      parseErrors += 1;
+      continue;
+    }
+    const fm = parsed.frontmatter;
+    const newHash = sha256(parsed.body);
+    const existingHash = await cfg.vectorIndex.getContentHash(fm.id);
+
+    if (existingHash === newHash) {
+      await cfg.vectorIndex.upsert([buildRow(fm, existingHash, undefined)]);
+      continue;
+    }
+    const embedding = await cfg.embed(parsed.body);
+    await cfg.vectorIndex.upsert([buildRow(fm, newHash, embedding)]);
+  }
+  return { parseErrors };
+}
+
+function sha256(s: string): string {
+  return createHash("sha256").update(s).digest("hex");
+}
+
+function buildRow(
+  fm: {
+    id: string;
+    project_id: string;
+    workspace_id: string | null;
+    scope: "workspace" | "user" | "project";
+    author: string;
+    title: string;
+    archived_at: string | null;
+  },
+  contentHash: string,
+  embedding: number[] | undefined,
+): IndexRow {
+  return {
+    id: fm.id,
+    project_id: fm.project_id,
+    workspace_id: fm.workspace_id,
+    scope: fm.scope,
+    author: fm.author,
+    title: fm.title,
+    archived: fm.archived_at !== null,
+    content_hash: contentHash,
+    vector: embedding ?? [],
+  };
+}
+```
+
+**Note:** `vector: []` path relies on `VaultVectorIndex.upsert` accepting a meta-only update. If Phase 3 requires non-empty vectors in `upsert`, the unchanged-hash branch must call `upsertMetaOnly` instead — check the existing lance-index API. If `upsertMetaOnly` is a distinct method, swap the unchanged-hash line for:
+
+```ts
+await cfg.vectorIndex.upsertMetaOnly(fm);
+continue;
+```
+
+- [ ] **Step 5: Fix parser types as needed**
+
+Adjust `parseMemoryFile` call signature to match the Phase 1 parser. If the parser returns `{ frontmatter, body, comments, relationships }` with different field names, update `diffReindex` accordingly. Check `src/backend/vault/parser/memory-parser.ts` for the canonical export.
+
+- [ ] **Step 6: Run — expect pass**
+
+```
+npx vitest run tests/unit/backend/vault/session-start.test.ts tests/unit/backend/vault/vector/lance-index.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```
+git add src/backend/vault/session-start.ts src/backend/vault/vector/lance-index.ts tests/unit/backend/vault/session-start.test.ts tests/unit/backend/vault/vector/lance-index.test.ts
+git commit -m "feat(vault-sync): diffReindex + VaultVectorIndex.getContentHash"
+```
+
+---
+
+## Task 10: `runSessionStart` orchestrator + `VaultBackend.sessionStart`
+
+**Goal:** Tie `syncFromRemote`, `diffReindex`, and `pushQueue` together. Return `BackendSessionStartMeta`.
+
+**Files:**
+
+- Modify: `src/backend/vault/session-start.ts` (add orchestrator)
+- Modify: `src/backend/vault/index.ts` (wire + real `sessionStart`)
+- Modify: `tests/unit/backend/vault/session-start.test.ts` (add orchestrator tests)
+
+- [ ] **Step 1: Write failing orchestrator test**
+
+Append to `tests/unit/backend/vault/session-start.test.ts`:
+
+```ts
+import { runSessionStart } from "../../../../src/backend/vault/session-start.js";
+
+function fakeSync(result: {
+  offline?: boolean;
+  conflict?: boolean;
+  changedPaths?: string[];
+}) {
+  return async () => ({
+    offline: result.offline ?? false,
+    conflict: result.conflict ?? false,
+    changedPaths: result.changedPaths ?? [],
+  });
+}
+
+function fakePushQueue(unpushed: number | (() => Promise<number>)) {
+  return {
+    unpushedCommits: async () =>
+      typeof unpushed === "number" ? unpushed : await unpushed(),
+    request: () => {},
+  };
+}
+
+describe("runSessionStart", () => {
+  it("all-happy returns empty meta", async () => {
+    const { root, index, cleanup } = await setup();
+    try {
+      const meta = await runSessionStart({
+        root,
+        vectorIndex: index,
+        embed: async () => new Array(DIMS).fill(0.1),
+        syncFromRemote: fakeSync({}),
+        pushQueue: fakePushQueue(0),
+      });
+      expect(meta).toEqual({});
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("offline surfaces in meta", async () => {
+    const { root, index, cleanup } = await setup();
+    try {
+      const meta = await runSessionStart({
+        root,
+        vectorIndex: index,
+        embed: async () => new Array(DIMS).fill(0.1),
+        syncFromRemote: fakeSync({ offline: true }),
+        pushQueue: fakePushQueue(0),
+      });
+      expect(meta.offline).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("conflict surfaces in meta", async () => {
+    const { root, index, cleanup } = await setup();
+    try {
+      const meta = await runSessionStart({
+        root,
+        vectorIndex: index,
+        embed: async () => new Array(DIMS).fill(0.1),
+        syncFromRemote: fakeSync({ conflict: true }),
+        pushQueue: fakePushQueue(0),
+      });
+      expect(meta.pull_conflict).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("unpushed > 0 surfaces", async () => {
+    const { root, index, cleanup } = await setup();
+    try {
+      const meta = await runSessionStart({
+        root,
+        vectorIndex: index,
+        embed: async () => new Array(DIMS).fill(0.1),
+        syncFromRemote: fakeSync({}),
+        pushQueue: fakePushQueue(3),
+      });
+      expect(meta.unpushed_commits).toBe(3);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("parse errors propagate from diffReindex", async () => {
+    const { root, index, cleanup } = await setup();
+    try {
+      await mkdir(join(root, "workspaces/ws1/memories"), { recursive: true });
+      await writeFile(
+        join(root, "workspaces/ws1/memories/bad.md"),
+        ":: not YAML ::\n",
+      );
+      const meta = await runSessionStart({
+        root,
+        vectorIndex: index,
+        embed: async () => new Array(DIMS).fill(0.1),
+        syncFromRemote: fakeSync({
+          changedPaths: ["workspaces/ws1/memories/bad.md"],
+        }),
+        pushQueue: fakePushQueue(0),
+      });
+      expect(meta.parse_errors).toBe(1);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("kicks pushQueue.request() after collecting meta", async () => {
+    const { root, index, cleanup } = await setup();
+    try {
+      let kicked = 0;
+      const meta = await runSessionStart({
+        root,
+        vectorIndex: index,
+        embed: async () => new Array(DIMS).fill(0.1),
+        syncFromRemote: fakeSync({}),
+        pushQueue: {
+          unpushedCommits: async () => 2,
+          request: () => {
+            kicked += 1;
+          },
+        },
+      });
+      expect(kicked).toBe(1);
+      expect(meta.unpushed_commits).toBe(2);
+    } finally {
+      await cleanup();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+```
+npx vitest run tests/unit/backend/vault/session-start.test.ts -t "runSessionStart"
+```
+
+Expected: FAIL.
+
+- [ ] **Step 3: Implement orchestrator**
+
+Append to `src/backend/vault/session-start.ts`:
+
+```ts
+import type { BackendSessionStartMeta } from "../types.js";
+import type { SyncResult } from "./git/pull.js";
+
+export interface PushQueueHandle {
+  unpushedCommits(): Promise<number>;
+  request(): void;
+}
+
+export interface RunSessionStartConfig {
+  root: string;
+  vectorIndex: VaultVectorIndex;
+  embed: Embedder;
+  syncFromRemote: () => Promise<SyncResult>;
+  pushQueue: PushQueueHandle;
+}
+
+export async function runSessionStart(
+  cfg: RunSessionStartConfig,
+): Promise<BackendSessionStartMeta> {
+  const meta: BackendSessionStartMeta = {};
+  const pull = await cfg.syncFromRemote();
+  if (pull.offline) meta.offline = true;
+  if (pull.conflict) meta.pull_conflict = true;
+
+  let parseErrors = 0;
+  if (pull.changedPaths.length > 0) {
+    const result = await diffReindex({
+      paths: pull.changedPaths,
+      root: cfg.root,
+      vectorIndex: cfg.vectorIndex,
+      embed: cfg.embed,
+    });
+    parseErrors = result.parseErrors;
+  }
+  if (parseErrors > 0) meta.parse_errors = parseErrors;
+
+  const unpushed = await cfg.pushQueue.unpushedCommits();
+  if (unpushed > 0) meta.unpushed_commits = unpushed;
+  cfg.pushQueue.request(); // kick drain
+
+  return meta;
+}
+```
+
+- [ ] **Step 4: Run**
+
+```
+npx vitest run tests/unit/backend/vault/session-start.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/backend/vault/session-start.ts tests/unit/backend/vault/session-start.test.ts
+git commit -m "feat(vault-sync): runSessionStart orchestrator"
+```
+
+---
+
+## Task 11: Wire PushQueue + reconcile + sessionStart into `VaultBackend`
+
+**Goal:** Replace the Task-1 stub `sessionStart` with the real orchestrator. Add config fields for `remoteUrl`, `pushDebounceMs`, `pushBackoffMs`. Construct `PushQueue`, hook `afterCommit`, run `ensureRemote` and `reconcileDirty` at backend create. Extend `close()` to drain the queue.
+
+**Files:**
+
+- Modify: `src/backend/vault/index.ts`
+- Modify: `src/backend/factory.ts`
+- Test: `tests/integration/vault/two-clone-sync.test.ts` comes in Task 13; this task verified via existing contract/unit suites.
+
+- [ ] **Step 1: Extend `VaultBackendConfig`**
+
+In `src/backend/vault/index.ts`:
+
+```ts
+export interface VaultBackendConfig {
+  root: string;
+  embeddingDimensions: number;
+  trackUsersInGit?: boolean;
+  remoteUrl?: string;
+  pushDebounceMs?: number;
+  pushBackoffMs?: readonly number[];
+  /**
+   * Dependency-injected embedder used for diffReindex on pull.
+   * Defaults to a runtime provider-based embedder; tests inject a fake.
+   */
+  embed?: Embedder;
+}
+```
+
+Add `Embedder` import from `./session-start.js`.
+
+- [ ] **Step 2: Wire primitives in `VaultBackend.create`**
+
+Replace the body of `VaultBackend.create`:
+
+```ts
+  static async create(cfg: VaultBackendConfig): Promise<VaultBackend> {
+    await mkdir(cfg.root, { recursive: true });
+    const trackUsersInGit = cfg.trackUsersInGit ?? false;
+    await ensureVaultGit({
+      root: cfg.root,
+      trackUsers: trackUsersInGit,
+    });
+    const git = simpleGit({ baseDir: cfg.root }).env(scrubGitEnv());
+    await ensureRemote({ git, remoteUrl: cfg.remoteUrl });
+
+    const gitOps: GitOps = new GitOpsImpl({ root: cfg.root });
+    await reconcileDirty({ git, ops: gitOps });
+
+    const vectorIndex = await VaultVectorIndex.create({
+      root: cfg.root,
+      dims: cfg.embeddingDimensions,
+    });
+
+    const debounceMs = cfg.pushDebounceMs ?? 5000;
+    const backoffMs = cfg.pushBackoffMs ?? [5000, 30000, 300000, 1800000];
+    const pushQueue = new PushQueue({
+      debounceMs,
+      backoffMs,
+      push: async () => {
+        await git.push("origin", "HEAD:main");
+      },
+      countUnpushed: async () => {
+        try {
+          const out = await git.raw([
+            "rev-list",
+            "--count",
+            "@{u}..HEAD",
+          ]);
+          return Number(out.trim()) || 0;
+        } catch {
+          return 0;
+        }
+      },
+    });
+    // Fire push attempt after every successful commit.
+    if (gitOps.enabled) {
+      gitOps.afterCommit = () => pushQueue.request();
+    }
+
+    const memoryRepo = await VaultMemoryRepository.create({
+      root: cfg.root,
+      index: vectorIndex,
+      gitOps,
+      trackUsersInGit,
+    });
+
+    const embed = cfg.embed ?? defaultEmbedder(cfg.embeddingDimensions);
+
+    return new VaultBackend(
+      memoryRepo,
+      vectorIndex,
+      cfg.root,
+      gitOps,
+      trackUsersInGit,
+      git,
+      pushQueue,
+      embed,
+    );
+  }
+```
+
+Update imports (`simpleGit`, `scrubGitEnv`, `ensureRemote`, `reconcileDirty`, `PushQueue`, `GitOpsImpl`).
+
+Add `defaultEmbedder` helper in the same file:
+
+```ts
+import { getEmbeddingProvider } from "../../providers/embedding/index.js";
+
+function defaultEmbedder(dims: number): Embedder {
+  const provider = getEmbeddingProvider();
+  return async (text: string) => {
+    const vec = await provider.embed(text);
+    if (vec.length !== dims) {
+      throw new Error(
+        `vault embed: provider returned ${vec.length} dims, expected ${dims}`,
+      );
+    }
+    return vec;
+  };
+}
+```
+
+If `getEmbeddingProvider` is not already the canonical factory, inspect `src/providers/embedding/index.ts` and use the correct function. Pick the existing startup-time provider resolution used by `MemoryService` to keep parity.
+
+- [ ] **Step 3: Extend constructor to store new deps**
+
+```ts
+  private constructor(
+    memoryRepo: MemoryRepository,
+    private readonly vectorIndex: VaultVectorIndex,
+    private readonly root: string,
+    gitOps: GitOps,
+    trackUsersInGit: boolean,
+    private readonly git: SimpleGit,
+    private readonly pushQueue: PushQueue,
+    private readonly embed: Embedder,
+  ) {
+    // existing body unchanged
+  }
+```
+
+Add `SimpleGit` + `PushQueue` imports.
+
+- [ ] **Step 4: Replace `sessionStart` stub with real orchestrator**
+
+```ts
+  async sessionStart(): Promise<BackendSessionStartMeta> {
+    return runSessionStart({
+      root: this.root,
+      vectorIndex: this.vectorIndex,
+      embed: this.embed,
+      syncFromRemote: () => syncFromRemote({ git: this.git }),
+      pushQueue: {
+        unpushedCommits: () => this.pushQueue.unpushedCommits(),
+        request: () => this.pushQueue.request(),
+      },
+    });
+  }
+```
+
+- [ ] **Step 5: Extend `close()`**
+
+```ts
+  async close(): Promise<void> {
+    await this.pushQueue.close();
+    await this.vectorIndex.close();
+  }
+```
+
+- [ ] **Step 6: Plumb env var through factory**
+
+Edit `src/backend/factory.ts`. Where `VaultBackend.create` is called, pass:
+
+```ts
+return VaultBackend.create({
+  root: vaultRoot,
+  embeddingDimensions: cfg.embeddingDimensions,
+  trackUsersInGit: cfg.trackUsersInGit,
+  remoteUrl: process.env.AGENT_BRAIN_VAULT_REMOTE_URL,
+});
+```
+
+Preserve existing fields; only add `remoteUrl`.
+
+- [ ] **Step 7: Run full unit + contract suites**
+
+```
+npm run test:unit
+```
+
+Expected: PASS. Debug any regression in `tests/contract/repositories/*-git.test.ts` — most likely culprit is a test that doesn't pass `remoteUrl` (fine — env var absent, no push queue activity because no remote).
+
+- [ ] **Step 8: Commit**
+
+```
+git add src/backend/vault/index.ts src/backend/factory.ts
+git commit -m "feat(vault-sync): wire PushQueue, ensureRemote, reconcileDirty, sessionStart"
+```
+
+---
+
+## Task 12: Service + tool — merge backend meta into envelope
+
+**Goal:** `MemoryService.sessionStart` awaits `backend.sessionStart()` once and merges fields into `result.meta`. No changes needed in the MCP tool (envelope passes through untouched).
+
+**Files:**
+
+- Modify: `src/services/memory-service.ts`
+- Test: `tests/integration/session-start.test.ts` (add assertions)
+
+- [ ] **Step 1: Add `StorageBackend` dependency to MemoryService if not already injected**
+
+Inspect the `MemoryService` constructor / factory. If it already receives the backend, skip. If it only receives individual repos, add a `backend: StorageBackend` param (propagate via `src/server.ts` / `MemoryService.create`).
+
+- [ ] **Step 2: Add failing test**
+
+In `tests/integration/session-start.test.ts`, add:
+
+```ts
+it("envelope meta includes backend fields (vault, offline=true simulated)", async () => {
+  // Uses a fake backend that returns { offline: true, unpushed_commits: 2 }.
+  const backend = makeFakeBackend({ offline: true, unpushed_commits: 2 });
+  const service = new MemoryService(/* deps + */ backend);
+  const envelope = await service.sessionStart("ws1", "alice");
+  expect(envelope.meta.offline).toBe(true);
+  expect(envelope.meta.unpushed_commits).toBe(2);
+});
+```
+
+Add `makeFakeBackend` helper (inline or in `tests/helpers.ts`) that wraps the existing pg test backend with an override for `sessionStart`.
+
+Run: `npx vitest run tests/integration/session-start.test.ts -t "backend fields"` — FAIL.
+
+- [ ] **Step 3: Wire merge in `MemoryService.sessionStart`**
+
+Near the top of `sessionStart`, after workspace findOrCreate:
+
+```ts
+const backendMeta = await this.backend.sessionStart();
+```
+
+At the end, before return:
+
+```ts
+if (backendMeta.offline) result.meta.offline = true;
+if (backendMeta.pull_conflict) result.meta.pull_conflict = true;
+if (
+  typeof backendMeta.unpushed_commits === "number" &&
+  backendMeta.unpushed_commits > 0
+) {
+  result.meta.unpushed_commits = backendMeta.unpushed_commits;
+}
+if (
+  typeof backendMeta.parse_errors === "number" &&
+  backendMeta.parse_errors > 0
+) {
+  result.meta.parse_errors = backendMeta.parse_errors;
+}
+```
+
+Extend the `result.meta` TypeScript type to accept these fields (find the existing `Envelope<MemorySummaryWithRelevance[]>` shape and widen the meta to include optional `offline`, `pull_conflict`, `unpushed_commits`, `parse_errors`).
+
+- [ ] **Step 4: Run — PASS**
+
+```
+npx vitest run tests/integration/session-start.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Full suite**
+
+```
+npm run test:unit
+```
+
+- [ ] **Step 6: Commit**
+
+```
+git add src/services/memory-service.ts tests/integration/session-start.test.ts tests/helpers.ts
+git commit -m "feat(vault-sync): merge backend sessionStart meta into envelope"
+```
+
+---
+
+## Task 13: Server-boot smoke — vault backend with remote URL
+
+**Goal:** Catch ESM/CJS interop on the new deps by booting the real server under `AGENT_BRAIN_BACKEND=vault` with a bare-repo remote.
+
+**Files:**
+
+- Modify: `tests/unit/server-boot.test.ts`
+
+- [ ] **Step 1: Extend test**
+
+Find the existing server-boot test. Add a case (inside the same `describe`):
+
+```ts
+it("boots under AGENT_BRAIN_BACKEND=vault with AGENT_BRAIN_VAULT_REMOTE_URL", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "server-boot-vault-"));
+  const bare = join(dir, "origin.git");
+  await mkdir(bare, { recursive: true });
+  await simpleGit().env(scrubGitEnv()).cwd(bare).init(true);
+  const vault = join(dir, "vault");
+  try {
+    const { stderr, exitCode } = await spawnServerWithEnv({
+      AGENT_BRAIN_BACKEND: "vault",
+      AGENT_BRAIN_VAULT_ROOT: vault,
+      AGENT_BRAIN_VAULT_REMOTE_URL: bare,
+    });
+    expect(exitCode).toBe(0);
+    // No error-level logs from push queue on boot.
+    expect(stderr).not.toMatch(/vault push failed/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+```
+
+Use the existing `spawnServerWithEnv` helper if present; otherwise model it on the current server-boot spawn pattern (look up how the existing test uses `node --import tsx`).
+
+Env var name for vault root: verify against `src/backend/factory.ts` — may be `AGENT_BRAIN_VAULT_ROOT` or similar.
+
+- [ ] **Step 2: Run**
+
+```
+npx vitest run tests/unit/server-boot.test.ts
+```
+
+Expected: PASS. Note: this test exercises the full ESM import chain including `@lancedb/lancedb`.
+
+- [ ] **Step 3: Commit**
+
+```
+git add tests/unit/server-boot.test.ts
+git commit -m "test(vault-sync): server-boot smoke under vault backend + remote URL"
+```
+
+---
+
+## Task 14: Two-clone integration test
+
+**Goal:** End-to-end: two `VaultBackend` instances + bare origin. Cases: happy sync, non-conflicting concurrent writes, conflict envelope, offline mode.
+
+**Files:**
+
+- Create: `tests/integration/vault/two-clone-sync.test.ts`
+- Modify: `tests/contract/repositories/_git-helpers.ts` — add shared `setupBareAndClones` helper
+
+- [ ] **Step 1: Add helper**
+
+In `tests/contract/repositories/_git-helpers.ts`:
+
+```ts
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { simpleGit } from "simple-git";
+
+export async function setupBareAndTwoVaults(): Promise<{
+  dir: string;
+  bare: string;
+  vaultA: string;
+  vaultB: string;
+  cleanup: () => Promise<void>;
+}> {
+  const dir = await mkdtemp(join(tmpdir(), "two-clone-"));
+  const bare = join(dir, "origin.git");
+  await mkdir(bare, { recursive: true });
+  await simpleGit().env(scrubGitEnv()).cwd(bare).init(true);
+  const vaultA = join(dir, "a");
+  const vaultB = join(dir, "b");
+  return {
+    dir,
+    bare,
+    vaultA,
+    vaultB,
+    cleanup: () => rm(dir, { recursive: true, force: true }),
+  };
+}
+```
+
+- [ ] **Step 2: Write integration test**
+
+Create `tests/integration/vault/two-clone-sync.test.ts`:
+
+```ts
+import { describe, expect, it, vi } from "vitest";
+import { setupBareAndTwoVaults } from "../../contract/repositories/_git-helpers.js";
+import { VaultBackend } from "../../../src/backend/vault/index.js";
+
+const DIMS = 768;
+
+function fakeEmbed(): (text: string) => Promise<number[]> {
+  return async () => new Array(DIMS).fill(0.01);
+}
+
+async function createBackend(
+  root: string,
+  remoteUrl: string,
+): Promise<VaultBackend> {
+  return VaultBackend.create({
+    root,
+    embeddingDimensions: DIMS,
+    remoteUrl,
+    pushDebounceMs: 10, // speed up tests
+    pushBackoffMs: [50, 200],
+    embed: fakeEmbed(),
+  });
+}
+
+async function waitForUnpushedZero(backend: VaultBackend): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    const meta = await backend.sessionStart();
+    if (!meta.unpushed_commits || meta.unpushed_commits === 0) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error("timed out waiting for unpushed_commits=0");
+}
+
+describe("vault two-clone sync", () => {
+  it("write on A is visible on B after A pushes and B session-starts", async () => {
+    const { bare, vaultA, vaultB, cleanup } = await setupBareAndTwoVaults();
+    try {
+      const a = await createBackend(vaultA, bare);
+      // A must seed a first commit so origin has `main` branch.
+      await a.memoryRepo.create(makeMemoryInput("m1"));
+      await waitForUnpushedZero(a);
+
+      const b = await createBackend(vaultB, bare);
+      const meta = await b.sessionStart();
+      expect(meta.pull_conflict).toBeUndefined();
+      expect(meta.offline).toBeUndefined();
+
+      const found = await b.memoryRepo.findById("m1");
+      expect(found?.title).toBe("t-m1");
+
+      await a.close();
+      await b.close();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("non-conflicting concurrent writes merge cleanly", async () => {
+    const { bare, vaultA, vaultB, cleanup } = await setupBareAndTwoVaults();
+    try {
+      const a = await createBackend(vaultA, bare);
+      await a.memoryRepo.create(makeMemoryInput("seed"));
+      await waitForUnpushedZero(a);
+
+      const b = await createBackend(vaultB, bare);
+      await b.sessionStart();
+
+      await a.memoryRepo.create(makeMemoryInput("from-a"));
+      await b.memoryRepo.create(makeMemoryInput("from-b"));
+      await waitForUnpushedZero(a);
+
+      const bMeta = await b.sessionStart();
+      expect(bMeta.pull_conflict).toBeUndefined();
+      await waitForUnpushedZero(b);
+
+      const aMeta = await a.sessionStart();
+      expect(aMeta.pull_conflict).toBeUndefined();
+
+      expect(await a.memoryRepo.findById("from-b")).not.toBeNull();
+      expect(await b.memoryRepo.findById("from-a")).not.toBeNull();
+
+      await a.close();
+      await b.close();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("conflicting writes on same file surface pull_conflict", async () => {
+    const { bare, vaultA, vaultB, cleanup } = await setupBareAndTwoVaults();
+    try {
+      const a = await createBackend(vaultA, bare);
+      await a.memoryRepo.create(makeMemoryInput("shared"));
+      await waitForUnpushedZero(a);
+
+      const b = await createBackend(vaultB, bare);
+      await b.sessionStart();
+
+      // Both mutate the SAME memory's title (frontmatter collision).
+      await a.memoryRepo.update("shared", { title: "a-title" });
+      await b.memoryRepo.update("shared", { title: "b-title" });
+      await waitForUnpushedZero(a);
+
+      const bMeta = await b.sessionStart();
+      expect(bMeta.pull_conflict).toBe(true);
+
+      await a.close();
+      await b.close();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("offline mode: origin unreachable → meta.offline=true, writes still commit", async () => {
+    const { bare, vaultA, cleanup } = await setupBareAndTwoVaults();
+    try {
+      const a = await createBackend(vaultA, bare);
+      await a.memoryRepo.create(makeMemoryInput("seed"));
+      await waitForUnpushedZero(a);
+      // Break origin.
+      await rm(bare, { recursive: true, force: true });
+
+      await a.memoryRepo.create(makeMemoryInput("offline-write"));
+      const meta = await a.sessionStart();
+      expect(meta.offline).toBe(true);
+      expect(meta.unpushed_commits ?? 0).toBeGreaterThan(0);
+
+      await a.close();
+    } finally {
+      await cleanup();
+    }
+  });
+});
+
+function makeMemoryInput(id: string) {
+  return {
+    id,
+    title: `t-${id}`,
+    body: `body-${id}`,
+    type: "fact" as const,
+    scope: "workspace" as const,
+    workspace_id: "ws1",
+    user_id: null,
+    project_id: "p1",
+    author: "alice",
+    embedding: new Array(DIMS).fill(0.1),
+    // add any other required fields based on actual MemoryRepository.create signature
+  };
+}
+```
+
+Adjust `makeMemoryInput` to exactly match `VaultMemoryRepository.create` input. Inspect `src/backend/vault/repositories/memory-repository.ts` for the method signature — it is likely `CreateMemoryInput` with a specific shape. Replace `makeMemoryInput` body accordingly.
+
+- [ ] **Step 3: Run**
+
+```
+npx vitest run tests/integration/vault/two-clone-sync.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: If flaky on timing, tune**
+
+The 10ms debounce + 50ms/200ms backoff is aggressive. If the test flakes in CI, raise to 100/500/2000. Single-flight + `waitForUnpushedZero` polling should absorb remaining jitter.
+
+- [ ] **Step 5: Commit**
+
+```
+git add tests/integration/vault/two-clone-sync.test.ts tests/contract/repositories/_git-helpers.ts
+git commit -m "test(vault-sync): two-clone integration coverage"
+```
+
+---
+
+## Task 15: Docs + snippet alignment
+
+**Goal:** Mark Phase 4 done on the design doc. No snippet changes required — `memory_session_start` tool signature unchanged; envelope `meta` is additive. Spec snippet refs to `meta.offline`/`meta.unpushed_commits` are informational, optional.
+
+**Files:**
+
+- Modify: `docs/superpowers/specs/2026-04-21-vault-backend-design.md`
+
+- [ ] **Step 1: Tick phase 4 row**
+
+Edit the "Phased rollout" table row for Phase 4 to reference the Phase 4a + 4b plans and note status:
+
+```
+| 4     | Git sync layer. Commit-on-write, pull-on-session_start, conflict handling. Two-clone integration test. **Done — 4a (#34), 4b (this PR).** |
+```
+
+- [ ] **Step 2: Commit**
+
+```
+git add docs/superpowers/specs/2026-04-21-vault-backend-design.md
+git commit -m "docs(vault): mark Phase 4 git sync complete"
+```
+
+---
+
+## Final verification
+
+- [ ] **Typecheck**
+
+```
+npm run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Full unit + integration**
+
+```
+npm run test:unit
+```
+
+Expected: PASS.
+
+- [ ] **Lint + format**
+
+```
+npm run lint && npm run format
+```
+
+Expected: PASS.
+
+- [ ] **Diff review**
+
+```
+git log --oneline main..HEAD
+git diff main..HEAD --stat
+```
+
+Confirm every task produced its commit.
+
+- [ ] **PR body**
+
+Create PR titled `feat(vault): Phase 4b — git sync (push queue + pull on session_start)`. Body references spec `docs/superpowers/specs/2026-04-22-vault-backend-phase-4b-git-sync-design.md` and the Phase 4a handoff. Test plan lists all unit + integration suites added.
+
+---
+
+## Handoff notes
+
+- The `content_hash` column on lance rows was seeded in Phase 3. The branch that skips re-embedding on hash-match relies on this; if a row predates the column (migration not run), the branch falls through to a full re-embed. Expected/safe.
+- `gitOps.afterCommit` is opt-in per `GitOps` instance. Unit tests that construct `GitOpsImpl` directly without wiring `afterCommit` remain valid (hook is undefined, nothing fires).
+- The push queue is a process-local, best-effort primitive. If the process is SIGKILLed between commit and push, reconciliation on next startup recovers _dirty working tree_ state only — committed-but-unpushed commits remain and get drained on the next `sessionStart`'s `pushQueue.request()` kick, per Task 11's wiring.
+- Frontmatter-level merge conflicts are deferred to Phase 4c's smart merge driver. Phase 4b only surfaces the condition; users resolve manually (Obsidian edit + commit, or `git rebase --continue` from CLI).

--- a/docs/superpowers/specs/2026-04-21-vault-backend-design.md
+++ b/docs/superpowers/specs/2026-04-21-vault-backend-design.md
@@ -364,23 +364,23 @@ chokidar event → watcher.ts
 
 ### Failure modes
 
-| Failure                                             | Detection                   | Response                                                                                                                                          |
-| --------------------------------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Atomic rename mid-write                             | `.tmp` left behind          | Sweep on startup; caller sees error and retries                                                                                                   |
-| LanceDB upsert fails after successful fs write      | `lance.upsert` throws       | Log + enqueue repair; background reindex picks it up. Caller sees success (vault = source of truth)                                               |
-| `git commit` fails after fs + lance succeed         | non-zero exit               | Repair queue retries on next write or session_start. Caller sees success                                                                          |
-| `git push` fails                                    | non-zero exit               | push-queue marks dirty and retries (5s → 30s → 5m → 30m backoff). Writes never block. `meta.unpushed_commits` exposed on `session_start` envelope |
-| Pull conflict (auto-resolvable)                     | merge=union on markdown     | Logged and merged                                                                                                                                 |
-| Pull conflict (unresolvable)                        | post-rebase `git status`    | `git rebase --abort`; serve stale; create `verify` flag on affected memories; `meta.pull_conflict = true`                                         |
-| Offline on pull                                     | network error               | Serve local; `meta.offline = true`; writes queue for push                                                                                         |
-| Parse error (invalid frontmatter after manual edit) | `parser.parse` throws       | Skip file; `meta.parse_errors` includes path; previous index entry still served                                                                   |
-| LanceDB corruption / schema mismatch                | startup check               | Full reindex from vault; blocks startup until complete; vault is source of truth so no data loss                                                  |
-| Vault missing or not a git repo                     | startup validation          | Hard fail with remediation text; no silent recovery                                                                                               |
-| Disk full                                           | fs write error              | Propagate as tool error; no partial index update                                                                                                  |
-| Concurrent writes to same memory                    | per-file lock               | Second write waits up to 5s then throws; tool retries or surfaces timeout                                                                         |
-| Race: external edit + tool write                    | lock + watcher queue        | Tool holds lock during its path; watcher reindex queues after lock release                                                                        |
-| Optimistic version mismatch                         | parsed `version` ≠ expected | Existing `OptimisticLockError` contract — unchanged                                                                                               |
-| Malformed commit trailers on migration              | audit-log parser            | Skip for audit purposes, treat as external commit                                                                                                 |
+| Failure                                             | Detection                   | Response                                                                                                                                                            |
+| --------------------------------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Atomic rename mid-write                             | `.tmp` left behind          | Sweep on startup; caller sees error and retries                                                                                                                     |
+| LanceDB upsert fails after successful fs write      | `lance.upsert` throws       | Log + enqueue repair; background reindex picks it up. Caller sees success (vault = source of truth)                                                                 |
+| `git commit` fails after fs + lance succeed         | non-zero exit               | Repair queue retries on next write or session_start. Caller sees success                                                                                            |
+| `git push` fails                                    | non-zero exit               | push-queue marks dirty and retries (5s → 30s → 5m → 30m backoff). Writes never block. `meta.unpushed_commits` exposed on `session_start` envelope                   |
+| Pull conflict (auto-resolvable)                     | merge=union on markdown     | YAML frontmatter silently union-merged; invalid YAML surfaces as `parse_errors` on next read. Other conflicts (content, only/delete) surface `pull_conflict: true`. |
+| Pull conflict (unresolvable)                        | post-rebase `git status`    | `git rebase --abort`; serve stale; create `verify` flag on affected memories; `meta.pull_conflict = true`                                                           |
+| Offline on pull                                     | network error               | Serve local; `meta.offline = true`; writes queue for push                                                                                                           |
+| Parse error (invalid frontmatter after manual edit) | `parser.parse` throws       | Skip file; `meta.parse_errors` includes path; previous index entry still served                                                                                     |
+| LanceDB corruption / schema mismatch                | startup check               | Full reindex from vault; blocks startup until complete; vault is source of truth so no data loss                                                                    |
+| Vault missing or not a git repo                     | startup validation          | Hard fail with remediation text; no silent recovery                                                                                                                 |
+| Disk full                                           | fs write error              | Propagate as tool error; no partial index update                                                                                                                    |
+| Concurrent writes to same memory                    | per-file lock               | Second write waits up to 5s then throws; tool retries or surfaces timeout                                                                                           |
+| Race: external edit + tool write                    | lock + watcher queue        | Tool holds lock during its path; watcher reindex queues after lock release                                                                                          |
+| Optimistic version mismatch                         | parsed `version` ≠ expected | Existing `OptimisticLockError` contract — unchanged                                                                                                                 |
+| Malformed commit trailers on migration              | audit-log parser            | Skip for audit purposes, treat as external commit                                                                                                                   |
 
 ### Invariants
 
@@ -445,16 +445,16 @@ Forces behavioral parity; divergence = test failure.
 
 ## Phased rollout
 
-| Phase | Deliverable                                                                                                                     |
-| ----- | ------------------------------------------------------------------------------------------------------------------------------- |
-| 0     | `StorageBackend` interface extraction. Move existing drizzle repos behind factory. No behavior change. Green tests.             |
-| 1     | Vault parser + serializer (pure). Roundtrip property tests for all entity types.                                                |
-| 2     | Vault repositories against a local directory (no git, no vector). Parameterized repo contract tests pass against both backends. |
-| 3     | LanceDB index integration. Vector parity tests.                                                                                 |
-| 4     | Git sync layer. Commit-on-write, pull-on-session_start, conflict handling. Two-clone integration test.                          |
-| 5     | Chokidar watcher. External edit E2E.                                                                                            |
-| 6     | Migration CLI + reverse migration.                                                                                              |
-| 7     | Docs, recommended Obsidian vault template (Dataview, Tasks plugins), README updates.                                            |
+| Phase | Deliverable                                                                                                                               |
+| ----- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| 0     | `StorageBackend` interface extraction. Move existing drizzle repos behind factory. No behavior change. Green tests.                       |
+| 1     | Vault parser + serializer (pure). Roundtrip property tests for all entity types.                                                          |
+| 2     | Vault repositories against a local directory (no git, no vector). Parameterized repo contract tests pass against both backends.           |
+| 3     | LanceDB index integration. Vector parity tests.                                                                                           |
+| 4     | Git sync layer. Commit-on-write, pull-on-session_start, conflict handling. Two-clone integration test. **Done — 4a (#34), 4b (this PR).** |
+| 5     | Chokidar watcher. External edit E2E.                                                                                                      |
+| 6     | Migration CLI + reverse migration.                                                                                                        |
+| 7     | Docs, recommended Obsidian vault template (Dataview, Tasks plugins), README updates.                                                      |
 
 ## Open questions
 

--- a/docs/superpowers/specs/2026-04-22-vault-backend-phase-4b-git-sync-design.md
+++ b/docs/superpowers/specs/2026-04-22-vault-backend-phase-4b-git-sync-design.md
@@ -1,0 +1,328 @@
+# Vault Backend Phase 4b — Git Sync (Push Queue + Pull on Session Start) Design
+
+## Context
+
+Phase 4a (merged as `4198fac`) wired `git commit` into every `Vault*Repository` mutation with `AB-*` trailers, bootstrapped `.gitignore` / `.gitattributes`, and enforced a `users/`-gitignored privacy invariant. Push and pull were explicitly deferred to Phase 4b. This spec closes that gap so a vault-backed agent-brain can round-trip writes between clones over a git remote with bounded staleness.
+
+Phase 4b is the last sync-layer phase before Phase 5 (chokidar watcher). Phase 4c reimplements `VaultAuditRepository` on `git log --follow`.
+
+## Goals
+
+1. Every successful write produces a commit (Phase 4a) **and** a debounced asynchronous push to `origin`.
+2. `memory_session_start` performs `pull --rebase --autostash` before serving, with a diff-driven LanceDB reindex of files the pull changed.
+3. Crash-recoverable: a vault left in a dirty state by a post-fs-write commit failure (Phase 4a log-and-continue branch) is reconciled into a single recovery commit on next backend startup.
+4. Offline / conflict / auth failures never block writes and surface to the caller through `memory_session_start` envelope `meta`.
+5. Writes on one clone appear on another clone within seconds (debounce + push + pull on next `memory_session_start`).
+
+## Non-Goals (Phase 4c / 5)
+
+- `VaultAuditRepository` on `git log` (Phase 4c).
+- Smart YAML-frontmatter merge driver (Phase 4c). Phase 4b relies on the `*.md merge=union` driver already set by Phase 4a; YAML-collision rebase conflicts abort the rebase and surface `pull_conflict: true`, and the user resolves manually (Obsidian, CLI, or next session).
+- Chokidar watcher for external edits (Phase 5).
+- Surfacing parse errors as per-memory flags — Phase 4b only counts them in the envelope.
+
+## Decisions
+
+| Area                                 | Decision                                                                                                                                                                                      |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Remote URL source                    | Single env var `AGENT_BRAIN_VAULT_REMOTE_URL`. No new config-file field.                                                                                                                      |
+| Origin add policy                    | `ensureRemote` adds `origin` on fresh init when env var set; existing non-matching `origin` URL is left alone + warn-log (user intent wins).                                                  |
+| Push cadence                         | Debounced 5s coalesce, single-flight one subprocess at a time. Retry backoff `[5s, 30s, 5m, 30m]`, then stay at 30m. New commits during backoff bump debounce but do not reset backoff timer. |
+| Pull cadence                         | Once per `memory_session_start`. No background pull.                                                                                                                                          |
+| Pull strategy                        | `pull --rebase --autostash`. Rebase conflict → `rebase --abort` + `pull_conflict: true` in meta; serve local (stale).                                                                         |
+| Offline detection                    | Push/pull subprocess network-class failure flips `offline: true` for that envelope. Next successful push/pull clears the flag.                                                                |
+| Reconciliation                       | `VaultBackend.create`, after `ensureVaultGit` and before serving, runs `git status --porcelain` and commits any dirty tracked `*.md` paths in one commit with trailer `AB-Action: reconcile`. |
+| Diff reindex scope                   | Only memory markdown paths (`workspaces/**/memories/*.md`, `project/memories/*.md`, `users/**/memories/*.md`). Other changed paths (`.gitignore`, `.gitattributes`) ignored by reindex.       |
+| Hash reuse                           | Phase 3 `content_hash` on lance row is the reindex short-circuit: unchanged hash → skip re-embed, mirror metadata only.                                                                       |
+| Privacy invariant                    | Unchanged from Phase 4a — `assertUsersIgnored` still runs at every mutation; push queue simply pushes whatever Phase 4a committed.                                                            |
+| Scope of `VaultBackend.sessionStart` | New backend method invoked by the `memory_session_start` MCP tool; not an MCP tool itself. Pg backend no-ops.                                                                                 |
+
+## Architecture
+
+### New files
+
+```
+src/backend/vault/git/
+├── push-queue.ts          # PushQueue: debounce, single-flight, backoff
+├── remote.ts              # ensureRemote({git, remoteUrl})
+├── pull.ts                # syncFromRemote({git})
+└── reconcile.ts           # reconcileDirty({git, root})
+
+src/backend/vault/
+└── session-start.ts       # VaultBackend.sessionStart orchestrator + diff reindex
+```
+
+Wiring in `src/backend/vault/index.ts` (`VaultBackend.create`):
+
+```
+VaultBackend.create(root, dims, { trackUsersInGit?, pushDebounceMs?, pushBackoffMs? })
+  ├─ ensureVaultGit({ root, trackUsers })
+  ├─ ensureRemote({ git, remoteUrl: env.AGENT_BRAIN_VAULT_REMOTE_URL })
+  ├─ reconcileDirty({ git, root })                # post-crash recovery
+  ├─ vectorIndex = VaultVectorIndex.create(...)
+  ├─ gitOps = new GitOpsImpl({ root })
+  ├─ pushQueue = new PushQueue({ git, debounceMs, backoffMs })
+  ├─ gitOps.afterCommit = () => pushQueue.request()    # hook, not an event-bus
+  ├─ repos = { memory, workspace, comment, flag, relationship, ... }
+  └─ return VaultBackend { ...repos, sessionStart(), shutdown() }
+```
+
+### Write pipeline delta
+
+Phase 4a ended inside the per-file lock with `gitOps.stageAndCommit(...)`. Phase 4b adds one non-blocking call after lock release:
+
+```
+acquire per-file lock
+  ├─ [phase 2a-4a unchanged]
+  └─ gitOps.stageAndCommit(paths, subject, trailers)
+release lock
+→ gitOps.afterCommit?.()                         # fire-and-forget
+```
+
+The `afterCommit` hook defaults to `undefined`; `VaultBackend.create` sets it to `pushQueue.request`. Keeping the hook on `GitOpsImpl` (rather than letting every repo know about the push queue) preserves the Phase 4a repo → `GitOps` seam.
+
+### PushQueue state machine
+
+```
+            request()                request()
+              │                        │
+              ▼                        ▼
+        ┌─────────┐   debounce    ┌───────────┐
+        │  idle   │──────────────▶│ scheduled │
+        └─────────┘               └───────────┘
+              ▲                        │ timer
+              │                        ▼
+     success  │                  ┌───────────┐
+       ┌──────┤                  │ in-flight │
+       │      │                  └───────────┘
+       │      │ retry backoff        │
+       │      │                      ├─ success ─┐
+       │      │                      └─ failure  │
+       │      │                                  │
+       │   ┌──┴──────┐                           │
+       │   │ backoff │◀──────────────────────────┘
+       │   └─────────┘
+       └───── timer fires ────────▶ in-flight
+```
+
+- `idle`: no pending work.
+- `scheduled`: debounce timer running. `request()` bumps its deadline.
+- `in-flight`: one `git push` subprocess active. New `request()` calls queue a follow-up and drain on completion.
+- `backoff`: last push failed. Backoff timer fires a single retry. New `request()` calls do NOT shorten the timer (avoids hammering dead remote) but mark that drain is still needed.
+
+Shutdown: `PushQueue.close()` cancels pending timers, awaits in-flight, returns. `VaultBackend.shutdown()` calls it.
+
+### Session start flow
+
+`VaultBackend.sessionStart()` returns envelope meta and drives pull + reindex:
+
+```
+async sessionStart(): Promise<VaultSessionStartMeta> {
+  const pull = await syncFromRemote({ git });          // pull --rebase --autostash
+  let parseErrors = 0;
+  if (pull.changedPaths.length) {
+    parseErrors = await diffReindex({
+      paths: pull.changedPaths,
+      root, vectorIndex
+    });
+  }
+  const unpushed = await pushQueue.unpushedCommits();
+  pushQueue.request();                                 // kick drain if behind
+  return {
+    offline: pull.offline,
+    pull_conflict: pull.conflict,
+    unpushed_commits: unpushed > 0 ? unpushed : undefined,
+    parse_errors: parseErrors > 0 ? parseErrors : undefined,
+  };
+}
+```
+
+`memory_session_start` MCP tool merges the returned `meta` fields into its existing envelope `meta`. Pg backend implements a no-op `sessionStart()` that returns `{}`.
+
+### Diff-driven reindex
+
+Input: `changedPaths: string[]` from `syncFromRemote` (`git diff --name-only <prev-HEAD>..HEAD`).
+
+```
+for path in changedPaths:
+    if not matches(workspaces/**/memories/*.md | project/memories/*.md | users/**/memories/*.md):
+        continue
+    try:
+        parsed = parseMemoryFile(path)
+    except ParseError:
+        parseErrors += 1
+        continue
+    newHash = sha256(parsed.body)
+    existingHash = vectorIndex.getContentHash(parsed.frontmatter.id)
+    if existingHash === newHash:
+        vectorIndex.upsertMetaOnly(parsed.frontmatter)   # no re-embed
+    else:
+        # re-embed via existing embedding pipeline
+        embedding = await embed(parsed.body)
+        vectorIndex.upsert({ ...parsed.frontmatter, embedding, content_hash: newHash })
+```
+
+`parseMemoryFile` failure classes (YAML broken by union merge, unknown type, missing required field) all increment `parse_errors`. The file stays on disk — next human edit or next commit's post-hook validation (Phase 4c / 5) handles surfacing.
+
+### Reconciliation on backend startup
+
+Runs after `ensureVaultGit`, before `VaultBackend` returns:
+
+```
+reconcileDirty({ git, root }):
+    status = await git.status()
+    dirtyMarkdown = status.modified + status.not_added
+        filter paths that are *.md AND are inside a memory path
+    if dirtyMarkdown is empty: return
+    await git.add(dirtyMarkdown)
+    await git.commit(
+        "[agent-brain] reconcile: post-crash recovery",
+        dirtyMarkdown,
+        trailers: [
+            AB-Action: reconcile,
+            AB-Actor: agent-brain,
+            AB-Reason: post-crash-recovery
+        ]
+    )
+```
+
+Uses the same `GitOpsImpl` mutex (Phase 4a memory `UKNx4APvbydG4ukOWmo6L` gotcha #1) and scoped-commit path contract so a concurrent first write cannot cross-attribute. Runs once per backend create.
+
+Untracked markdown files (e.g. user manually dropped a file in `memories/`) are NOT reconciled — out of scope for a crash-recovery path and would require validation. Phase 5 watcher handles that flow.
+
+### Remote URL plumbing
+
+`ensureRemote` reads `process.env.AGENT_BRAIN_VAULT_REMOTE_URL`:
+
+| Current state of `.git/config` | Env var set? | Action                                                                         |
+| ------------------------------ | ------------ | ------------------------------------------------------------------------------ |
+| No `origin`                    | Yes          | `git remote add origin <url>`                                                  |
+| No `origin`                    | No           | No-op. Push queue still runs but all push attempts no-op with `offline: true`. |
+| `origin` matches env           | Yes          | No-op.                                                                         |
+| `origin` differs from env      | Yes          | Warn-log, leave existing. User wins.                                           |
+| `origin` set                   | No           | No-op.                                                                         |
+
+When no remote is configured at all, push attempts short-circuit before invoking `git push`: `PushQueue.request()` checks `git.getRemotes(true)` once at start and caches "no remote" → push becomes a no-op until backend restart. (Refreshing a remote addition at runtime is out of scope; `VaultBackend` restart is the seam.)
+
+## Error handling matrix
+
+| Failure                          | Source                | Behavior                                                                | Envelope meta                   |
+| -------------------------------- | --------------------- | ----------------------------------------------------------------------- | ------------------------------- |
+| Push network failure             | PushQueue             | Backoff; next attempt per schedule                                      | `offline: true` until recovered |
+| Push auth / permission failure   | PushQueue             | Backoff + `error`-level log; user must repair                           | `offline: true`                 |
+| Push non-fast-forward (diverged) | PushQueue             | Next `memory_session_start` pull will rebase + retry; do not force-push | `unpushed_commits: N`           |
+| Pull network failure             | `syncFromRemote`      | Serve local                                                             | `offline: true`                 |
+| Pull rebase conflict             | `syncFromRemote`      | `rebase --abort`; serve local (pre-pull state)                          | `pull_conflict: true`           |
+| Pull auth failure                | `syncFromRemote`      | Serve local                                                             | `offline: true`                 |
+| Reconcile commit fails           | `VaultBackend.create` | `error`-level log; continue startup. Next successful write re-stages.   | n/a                             |
+| Diff reindex parse error         | `diffReindex`         | Count + skip the file                                                   | `parse_errors: N`               |
+| Repo corrupt / missing `HEAD`    | `syncFromRemote`      | Throw `VaultGitCorruptError` — fatal, backend create rejects            | n/a (startup fails)             |
+
+## Config surface
+
+### Env vars
+
+| Name                           | Required | Purpose                                     |
+| ------------------------------ | -------- | ------------------------------------------- |
+| `AGENT_BRAIN_VAULT_REMOTE_URL` | No       | Remote URL for `ensureRemote` on fresh init |
+
+### `VaultBackendConfig` additions
+
+```ts
+interface VaultBackendConfig {
+  // existing fields...
+  remoteUrl?: string; // explicit override of env var (tests)
+  pushDebounceMs?: number; // default 5000
+  pushBackoffMs?: readonly number[]; // default [5000, 30000, 300000, 1800000]
+}
+```
+
+Explicit config wins over env var. Env wins over nothing.
+
+## Envelope meta schema
+
+`memory_session_start` envelope gains (merged onto existing `meta` object):
+
+```ts
+interface VaultSessionStartMeta {
+  offline?: true;
+  unpushed_commits?: number; // omitted when 0
+  pull_conflict?: true;
+  parse_errors?: number; // omitted when 0
+}
+```
+
+All fields optional; absent = healthy. Pg backend contributes `{}`.
+
+## Testing
+
+### Unit tests
+
+1. **`push-queue.test.ts`**
+   - Debounce coalesces N rapid `request()` calls into one push.
+   - Single-flight: second push does not start until first completes.
+   - Backoff schedule `[5s, 30s, 5m, 30m]` with injected clock.
+   - Successful push after backoff resets schedule.
+   - `close()` cancels pending timers, awaits in-flight, is idempotent.
+   - `request()` during backoff queues drain without shortening timer.
+2. **`remote.test.ts`**
+   - No origin + env set → `git remote add origin`.
+   - Existing matching origin + env set → no-op.
+   - Existing non-matching origin + env set → no-op + warn-log.
+   - No origin + no env → no-op.
+3. **`pull.test.ts`**
+   - Clean fast-forward → `changedPaths` populated, no conflict/offline.
+   - Up-to-date → empty `changedPaths`.
+   - Rebase conflict → `conflict: true`, `git rebase --abort` invoked, working tree clean.
+   - Network failure → `offline: true`, no throw.
+4. **`reconcile.test.ts`**
+   - Dirty markdown on startup → one commit with `AB-Action: reconcile`.
+   - Clean startup → no commit.
+   - Untracked markdown → not reconciled.
+   - Dirty gitignored file → not reconciled.
+5. **`session-start.test.ts`**
+   - All-happy path → `meta = {}`.
+   - Offline pull → `meta.offline = true`.
+   - Conflict → `meta.pull_conflict = true`.
+   - Unpushed commits → `meta.unpushed_commits = N`.
+   - Parse error in a changed file → `meta.parse_errors = 1`.
+6. **`diff-reindex.test.ts`**
+   - Unchanged `content_hash` → `upsertMetaOnly` path.
+   - Changed body → full upsert with new embedding.
+   - Parse error → counted, does not abort.
+   - Non-memory path → skipped.
+
+### Integration
+
+7. **`tests/integration/vault/two-clone-sync.test.ts`**
+   - Bare repo + two `VaultBackend` instances in same process in distinct temp dirs, both with `AGENT_BRAIN_VAULT_REMOTE_URL` pointing at bare repo.
+   - Cases:
+     - Happy: A `memory_create` → A push → B `sessionStart` → B sees memory via search.
+     - Concurrent non-conflicting writes on different files → both pushed, both pulled, merge-free.
+     - Concurrent writes on same file with diverging frontmatter → B pulls, rebase conflict, `meta.pull_conflict=true`, B retains local.
+     - Offline: bare repo removed mid-run → A write still commits, push fails, `meta.offline=true`.
+8. **`tests/unit/server-boot.test.ts` extension**
+   - Spawn under `AGENT_BRAIN_BACKEND=vault` + `AGENT_BRAIN_VAULT_REMOTE_URL=<bare-repo>` and assert boot succeeds and no `error`-level logs from push queue (push coalesce + no commits yet).
+
+### CI
+
+No new CI layers. Integration tests run under the existing PR-time integration job. Benchmarks out of scope for 4b; pushed to 4c or perf phase.
+
+## Phased rollout inside 4b
+
+1. Primitives: `push-queue.ts`, `remote.ts`, `pull.ts`, `reconcile.ts` with unit tests.
+2. `VaultBackend` wiring: `sessionStart`, reconciliation on create, `afterCommit` hook plumbed into `GitOpsImpl`.
+3. `memory_session_start` MCP tool merges backend `sessionStart` meta into envelope.
+4. Two-clone integration test + server-boot extension.
+5. Docs: update `docs/superpowers/specs/2026-04-21-vault-backend-design.md` status section to mark Phase 4b done; add envelope meta reference to copilot + claude snippets if they reference `memory_session_start` output shape.
+
+## Open questions
+
+None. All decisions locked above. Implementation-time choices (exact error class names, exact subprocess invocation flags) are plan-time details for `writing-plans`.
+
+## Handoff to Phase 4c
+
+- `VaultAuditRepository` reimplemented over `git log --follow` + trailer parser. Deletion of `_audit/` JSONL storage.
+- Smart YAML frontmatter merge driver (replaces `merge=union` for memory markdown).
+- Surfacing `parse_errors` as per-memory flags (consolidation producer).
+- Performance budget verification on the full write path (commit + push under load).

--- a/src/backend/factory.ts
+++ b/src/backend/factory.ts
@@ -27,6 +27,7 @@ export async function createBackend(
         root: config.vaultRoot,
         embeddingDimensions: config.embeddingDimensions,
         trackUsersInGit: config.vaultTrackUsersInGit ?? false,
+        remoteUrl: process.env.AGENT_BRAIN_VAULT_REMOTE_URL,
       });
     default: {
       // Exhaustiveness + runtime guard for an env-var typo that slipped past zod.

--- a/src/backend/postgres/index.ts
+++ b/src/backend/postgres/index.ts
@@ -12,7 +12,11 @@ import { DrizzleAuditRepository } from "../../repositories/audit-repository.js";
 import { DrizzleFlagRepository } from "../../repositories/flag-repository.js";
 import { DrizzleRelationshipRepository } from "../../repositories/relationship-repository.js";
 import { DrizzleSchedulerStateRepository } from "../../repositories/scheduler-state-repository.js";
-import type { StorageBackend, BackendName } from "../types.js";
+import type {
+  StorageBackend,
+  BackendName,
+  BackendSessionStartMeta,
+} from "../types.js";
 import type {
   MemoryRepository,
   WorkspaceRepository,
@@ -65,5 +69,9 @@ export class PostgresBackend implements StorageBackend {
 
   async close(): Promise<void> {
     await this.db.$client.end();
+  }
+
+  async sessionStart(): Promise<BackendSessionStartMeta> {
+    return {};
   }
 }

--- a/src/backend/types.ts
+++ b/src/backend/types.ts
@@ -14,6 +14,19 @@ import type {
 export type BackendName = "postgres" | "vault";
 
 /**
+ * Envelope meta fields contributed by the backend at memory_session_start.
+ * All fields optional — absent means healthy. Merged into the MemoryService
+ * session-start envelope meta. The pg backend always returns {}; vault
+ * populates based on pull + push-queue state.
+ */
+export interface BackendSessionStartMeta {
+  offline?: true;
+  unpushed_commits?: number;
+  pull_conflict?: true;
+  parse_errors?: number;
+}
+
+/**
  * Storage backend abstraction. Bundles the eight repository interfaces
  * plus a lifecycle hook. `server.ts` constructs one of these via
  * `createBackend()` and passes the individual repos to services.
@@ -33,4 +46,10 @@ export interface StorageBackend {
   readonly relationshipRepo: RelationshipRepository;
   readonly schedulerStateRepo: SchedulerStateRepository;
   close(): Promise<void>;
+  /**
+   * Called by MemoryService.sessionStart before composing the response.
+   * Backend-specific sync/reconciliation. Returned fields merge into
+   * envelope meta.
+   */
+  sessionStart(): Promise<BackendSessionStartMeta>;
 }

--- a/src/backend/types.ts
+++ b/src/backend/types.ts
@@ -13,29 +13,26 @@ import type {
 
 export type BackendName = "postgres" | "vault";
 
-/**
- * Envelope meta fields contributed by the backend at memory_session_start.
- * All fields optional — absent means healthy. Merged into the MemoryService
- * session-start envelope meta. The pg backend always returns {}; vault
- * populates based on pull + push-queue state.
- */
+// Absent field = healthy. Zero/false values are stripped before merging
+// into envelope meta so clients treat absence as the healthy state.
 export interface BackendSessionStartMeta {
-  /** Literal `true` — presence means offline; `false` is not a valid state. */
   offline?: true;
   unpushed_commits?: number;
-  /** Literal `true` — presence means a rebase conflict was detected. */
   pull_conflict?: true;
   parse_errors?: number;
+  // Last push failure message; set while push-queue is in backoff so
+  // users can tell "not pushed yet" from "broken auth / bad remote".
+  last_push_error?: string;
+  // Dirty-tree reconcile commit on boot failed; next write will try again.
+  reconcile_failed?: true;
+  // `rebase --abort` itself failed after a conflict; working tree may be
+  // wedged mid-rebase. Signals the operator to inspect manually.
+  rebase_wedged?: true;
+  // `AGENT_BRAIN_VAULT_REMOTE_URL` disagrees with configured `origin`;
+  // operator intent wins but surface it so the mismatch is visible.
+  remote_mismatch?: { configured: string; actual: string };
 }
 
-/**
- * Storage backend abstraction. Bundles the eight repository interfaces
- * plus a lifecycle hook. `server.ts` constructs one of these via
- * `createBackend()` and passes the individual repos to services.
- *
- * New backends (e.g. vault) implement this interface without touching
- * service or tool code.
- */
 export interface StorageBackend {
   readonly name: BackendName;
   readonly memoryRepo: MemoryRepository;
@@ -48,10 +45,5 @@ export interface StorageBackend {
   readonly relationshipRepo: RelationshipRepository;
   readonly schedulerStateRepo: SchedulerStateRepository;
   close(): Promise<void>;
-  /**
-   * Called by MemoryService.sessionStart before composing the response.
-   * Backend-specific sync/reconciliation. Returned fields merge into
-   * envelope meta.
-   */
   sessionStart(): Promise<BackendSessionStartMeta>;
 }

--- a/src/backend/types.ts
+++ b/src/backend/types.ts
@@ -20,8 +20,10 @@ export type BackendName = "postgres" | "vault";
  * populates based on pull + push-queue state.
  */
 export interface BackendSessionStartMeta {
+  /** Literal `true` — presence means offline; `false` is not a valid state. */
   offline?: true;
   unpushed_commits?: number;
+  /** Literal `true` — presence means a rebase conflict was detected. */
   pull_conflict?: true;
   parse_errors?: number;
 }

--- a/src/backend/vault/git/align.ts
+++ b/src/backend/vault/git/align.ts
@@ -1,0 +1,113 @@
+import type { SimpleGit } from "simple-git";
+import { logger } from "../../../utils/logger.js";
+
+/**
+ * Aligns the local repo with origin/main when local is behind remote or
+ * the two histories are unrelated. Called once during VaultBackend
+ * creation, before any push/pull logic runs.
+ *
+ * Ancestry is computed via `rev-list --count` (numeric) rather than
+ * `merge-base --is-ancestor`, so transient git errors do not silently
+ * classify as "not an ancestor" and trigger a destructive reset.
+ *
+ * Behaviour by case:
+ *
+ * 1. No `origin` remote configured → no-op (local-only vault).
+ * 2. Origin unreachable (fetch throws) → no-op; offline handling
+ *    deferred to the PushQueue / syncFromRemote path.
+ * 3. origin/main does not yet exist (empty bare repo) → no-op; the
+ *    first push from this vault will create it.
+ * 4. No local commits yet → checks out a new `main` branch tracking
+ *    `origin/main` directly.
+ * 5. Local is up-to-date with or ahead of origin/main → no-op.
+ * 6. Local is strictly behind remote → fast-forward:
+ *    `reset --hard <remoteHead>` then
+ *    `branch --set-upstream-to=origin/main main`.
+ * 7. Histories have diverged AND share a common ancestor → throw. This
+ *    is not a bootstrap scenario; destroying local work is unsafe.
+ * 8. Histories have diverged AND share NO common ancestor (unrelated)
+ *    → `reset --hard <remoteHead>` then set upstream. This is the
+ *    fresh second-vault bootstrap case where both clones produced their
+ *    own initial commits. Safe only at init time.
+ *
+ * Note: this function does NOT produce a merge commit. In case 6 and 8
+ * it performs a hard reset to `origin/main` and sets the upstream
+ * tracking branch.
+ */
+export async function alignWithRemote(git: SimpleGit): Promise<void> {
+  const remotes = await git.getRemotes(true);
+  if (!remotes.some((r) => r.name === "origin")) return;
+
+  try {
+    await git.fetch("origin");
+  } catch {
+    // Origin unreachable (offline); skip — pull will classify as offline.
+    return;
+  }
+
+  let remoteHead: string;
+  try {
+    remoteHead = (await git.raw(["rev-parse", "origin/main"])).trim();
+  } catch {
+    // origin/main not found — bare repo is empty; nothing to align with.
+    return;
+  }
+
+  let localHead: string | null;
+  try {
+    localHead = (await git.raw(["rev-parse", "HEAD"])).trim();
+  } catch {
+    // No local commits yet — track origin/main directly.
+    await git.raw(["checkout", "-b", "main", "--track", "origin/main"]);
+    return;
+  }
+
+  const ahead = await revListCount(git, `${remoteHead}..${localHead}`);
+  const behind = await revListCount(git, `${localHead}..${remoteHead}`);
+
+  if (behind === 0) return;
+  if (ahead === 0) {
+    await git.raw(["reset", "--hard", remoteHead]);
+    await git.raw(["branch", "--set-upstream-to=origin/main", "main"]);
+    return;
+  }
+
+  // Diverged — distinguish true unrelated histories (no common ancestor,
+  // bootstrap case) from a shared-ancestor divergence (real local work).
+  const mergeBase = await tryMergeBase(git, localHead, remoteHead);
+  if (mergeBase !== null) {
+    throw new Error(
+      `vault: local HEAD ${localHead} has diverged from origin/main ${remoteHead} (ahead=${ahead}, behind=${behind}) with shared ancestor ${mergeBase}. Refusing destructive reset; resolve manually or reconfigure AGENT_BRAIN_VAULT_REMOTE_URL.`,
+    );
+  }
+
+  logger.error(
+    `vault: unrelated-history reset — local HEAD ${localHead} has no common ancestor with origin/main ${remoteHead}; discarding local history. This is safe only for fresh-clone bootstrap; if you have local work, abort and investigate AGENT_BRAIN_VAULT_REMOTE_URL.`,
+  );
+  await git.raw(["reset", "--hard", remoteHead]);
+  await git.raw(["branch", "--set-upstream-to=origin/main", "main"]);
+}
+
+async function revListCount(git: SimpleGit, range: string): Promise<number> {
+  const out = await git.raw(["rev-list", "--count", range]);
+  const n = Number(out.trim());
+  if (!Number.isFinite(n)) {
+    throw new Error(`vault: rev-list --count ${range} returned ${out.trim()}`);
+  }
+  return n;
+}
+
+/** Returns the merge-base SHA, or null when no common ancestor exists. */
+async function tryMergeBase(
+  git: SimpleGit,
+  a: string,
+  b: string,
+): Promise<string | null> {
+  try {
+    const out = (await git.raw(["merge-base", a, b])).trim();
+    return out === "" ? null : out;
+  } catch {
+    // `git merge-base` exits non-zero when there is no common ancestor.
+    return null;
+  }
+}

--- a/src/backend/vault/git/align.ts
+++ b/src/backend/vault/git/align.ts
@@ -1,63 +1,44 @@
 import type { SimpleGit } from "simple-git";
 import { logger } from "../../../utils/logger.js";
+import { OFFLINE_RE } from "./pull.js";
 
-/**
- * Aligns the local repo with origin/main when local is behind remote or
- * the two histories are unrelated. Called once during VaultBackend
- * creation, before any push/pull logic runs.
- *
- * Ancestry is computed via `rev-list --count` (numeric) rather than
- * `merge-base --is-ancestor`, so transient git errors do not silently
- * classify as "not an ancestor" and trigger a destructive reset.
- *
- * Behaviour by case:
- *
- * 1. No `origin` remote configured → no-op (local-only vault).
- * 2. Origin unreachable (fetch throws) → no-op; offline handling
- *    deferred to the PushQueue / syncFromRemote path.
- * 3. origin/main does not yet exist (empty bare repo) → no-op; the
- *    first push from this vault will create it.
- * 4. No local commits yet → checks out a new `main` branch tracking
- *    `origin/main` directly.
- * 5. Local is up-to-date with or ahead of origin/main → no-op.
- * 6. Local is strictly behind remote → fast-forward:
- *    `reset --hard <remoteHead>` then
- *    `branch --set-upstream-to=origin/main main`.
- * 7. Histories have diverged AND share a common ancestor → throw. This
- *    is not a bootstrap scenario; destroying local work is unsafe.
- * 8. Histories have diverged AND share NO common ancestor (unrelated)
- *    → `reset --hard <remoteHead>` then set upstream. This is the
- *    fresh second-vault bootstrap case where both clones produced their
- *    own initial commits. Safe only at init time.
- *
- * Note: this function does NOT produce a merge commit. In case 6 and 8
- * it performs a hard reset to `origin/main` and sets the upstream
- * tracking branch.
- */
+const UNBORN_HEAD_RE =
+  /unknown revision|bad revision|does not have any commits yet/i;
+const UNKNOWN_REV_RE =
+  /unknown revision|bad revision|ambiguous argument|Not a valid object name/i;
+
+// Uses numeric `rev-list --count` rather than `merge-base --is-ancestor`
+// so a transient git error cannot silently classify as "not ancestor"
+// and trigger a destructive reset.
 export async function alignWithRemote(git: SimpleGit): Promise<void> {
   const remotes = await git.getRemotes(true);
   if (!remotes.some((r) => r.name === "origin")) return;
 
   try {
     await git.fetch("origin");
-  } catch {
-    // Origin unreachable (offline); skip — pull will classify as offline.
-    return;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (OFFLINE_RE.test(msg)) return;
+    logger.error(`vault align: fetch failed with unexpected error: ${msg}`);
+    throw err;
   }
 
   let remoteHead: string;
   try {
     remoteHead = (await git.raw(["rev-parse", "origin/main"])).trim();
-  } catch {
-    // origin/main not found — bare repo is empty; nothing to align with.
-    return;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (UNKNOWN_REV_RE.test(msg)) return; // bare repo empty
+    throw err;
   }
 
   let localHead: string | null;
   try {
     localHead = (await git.raw(["rev-parse", "HEAD"])).trim();
-  } catch {
-    // No local commits yet — track origin/main directly.
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!UNBORN_HEAD_RE.test(msg)) throw err;
+    logger.info(`vault align: checkout main tracking origin/main`);
     await git.raw(["checkout", "-b", "main", "--track", "origin/main"]);
     return;
   }
@@ -72,8 +53,6 @@ export async function alignWithRemote(git: SimpleGit): Promise<void> {
     return;
   }
 
-  // Diverged — distinguish true unrelated histories (no common ancestor,
-  // bootstrap case) from a shared-ancestor divergence (real local work).
   const mergeBase = await tryMergeBase(git, localHead, remoteHead);
   if (mergeBase !== null) {
     throw new Error(
@@ -97,7 +76,10 @@ async function revListCount(git: SimpleGit, range: string): Promise<number> {
   return n;
 }
 
-/** Returns the merge-base SHA, or null when no common ancestor exists. */
+// Returns the merge-base SHA, or null when no common ancestor exists.
+// Narrows the catch to exit-code 1 / empty stdout — corrupt-repo errors
+// would otherwise silently route to the destructive unrelated-history
+// branch.
 async function tryMergeBase(
   git: SimpleGit,
   a: string,
@@ -106,8 +88,11 @@ async function tryMergeBase(
   try {
     const out = (await git.raw(["merge-base", a, b])).trim();
     return out === "" ? null : out;
-  } catch {
-    // `git merge-base` exits non-zero when there is no common ancestor.
-    return null;
+  } catch (err) {
+    const exit = (err as { exitCode?: number } | undefined)?.exitCode;
+    if (exit === 1) return null;
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error(`vault align: merge-base failed unexpectedly: ${msg}`);
+    throw err;
   }
 }

--- a/src/backend/vault/git/git-ops.ts
+++ b/src/backend/vault/git/git-ops.ts
@@ -1,6 +1,7 @@
 import { simpleGit, type SimpleGit } from "simple-git";
 import { formatTrailers } from "./trailers.js";
 import { scrubGitEnv } from "./env.js";
+import { logger } from "../../../utils/logger.js";
 import {
   VaultGitNothingToCommitError,
   type CommitTrailer,
@@ -60,13 +61,13 @@ export class GitOpsImpl implements GitOps {
       // land its file under our trailer.
       await this.git.commit(`${subject}\n\n${body}`, paths);
     });
-    // Fire hook after the serialized block resolves so a callback that
-    // itself calls into git cannot deadlock on the mutex. Swallow hook
-    // errors — this is fire-and-forget.
+    // Fire outside serialize so a hook that calls into git can't deadlock on the mutex.
     try {
       this.afterCommit?.();
-    } catch {
-      // ignored
+    } catch (err) {
+      logger.error(
+        `vault: afterCommit hook threw; push may not be scheduled: ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 

--- a/src/backend/vault/git/git-ops.ts
+++ b/src/backend/vault/git/git-ops.ts
@@ -13,6 +13,7 @@ export interface GitOpsConfig {
 
 export class GitOpsImpl implements GitOps {
   readonly enabled = true;
+  afterCommit?: () => void;
   private readonly git: SimpleGit;
   // Process-wide serialization of git index operations. Two writers
   // on different markdown files share one .git/index; without a
@@ -47,7 +48,7 @@ export class GitOpsImpl implements GitOps {
     if (paths.length === 0) {
       throw new Error("stageAndCommit: paths must be non-empty");
     }
-    return this.#serialize(async () => {
+    await this.#serialize(async () => {
       await this.git.add(paths);
       const status = await this.git.status();
       if (status.staged.length === 0 && status.created.length === 0) {
@@ -59,6 +60,14 @@ export class GitOpsImpl implements GitOps {
       // land its file under our trailer.
       await this.git.commit(`${subject}\n\n${body}`, paths);
     });
+    // Fire hook after the serialized block resolves so a callback that
+    // itself calls into git cannot deadlock on the mutex. Swallow hook
+    // errors — this is fire-and-forget.
+    try {
+      this.afterCommit?.();
+    } catch {
+      // ignored
+    }
   }
 
   async status(): Promise<{ clean: boolean }> {

--- a/src/backend/vault/git/pull.ts
+++ b/src/backend/vault/git/pull.ts
@@ -31,7 +31,7 @@ export async function syncFromRemote(
   const preHead = await resolveHead(cfg.git);
 
   try {
-    await cfg.git.pull("origin", undefined, {
+    await cfg.git.pull("origin", "main", {
       "--rebase": null,
       "--autostash": null,
     });

--- a/src/backend/vault/git/pull.ts
+++ b/src/backend/vault/git/pull.ts
@@ -12,11 +12,21 @@ export interface SyncResult {
   changedPaths: string[];
 }
 
+const CONFLICT_RE = /CONFLICT|could not apply|Merge conflict|rebase.*conflict/i;
+
+// Patterns that classify as `offline: true` — we keep serving local data.
+// Anything not matched here (corrupt refs, disk-full, gpg failures,
+// unrelated histories, programmer errors) is rethrown so operators notice.
+const OFFLINE_RE =
+  /Could not resolve host|Could not read from remote repository|Connection (?:refused|timed out|reset)|Operation timed out|Network is unreachable|authentication failed|Permission denied \(publickey|unable to access|no tracking information|couldn't find remote ref|repository .* not found|does not appear to be a git repository/i;
+
 /**
  * Runs `git pull --rebase --autostash`. Classifies failures rather than
- * throwing. Rebase conflicts abort via `git rebase --abort` so the working
- * tree returns to the pre-pull HEAD. Network / auth failures surface as
- * `offline: true`. Caller decides whether to serve local stale data.
+ * throwing on the expected network/auth path. Rebase conflicts abort via
+ * `git rebase --abort` so the working tree returns to the pre-pull HEAD.
+ * Known network / auth / missing-upstream errors surface as
+ * `offline: true`. All other errors are rethrown — treating them as offline
+ * masks real failures (corrupt refs, disk-full, gpg, unrelated histories).
  */
 export async function syncFromRemote(
   cfg: SyncFromRemoteConfig,
@@ -37,7 +47,7 @@ export async function syncFromRemote(
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    if (/CONFLICT|could not apply|Merge conflict|rebase.*conflict/i.test(msg)) {
+    if (CONFLICT_RE.test(msg)) {
       try {
         await cfg.git.raw(["rebase", "--abort"]);
       } catch (abortErr) {
@@ -47,10 +57,12 @@ export async function syncFromRemote(
       }
       return { offline: false, conflict: true, changedPaths: [] };
     }
-    // Treat everything else as offline/transient — network, auth, no
-    // upstream, host unreachable, etc.
-    logger.warn(`vault: pull failed, serving local: ${msg}`);
-    return { offline: true, conflict: false, changedPaths: [] };
+    if (OFFLINE_RE.test(msg)) {
+      logger.warn(`vault: pull failed, serving local: ${msg}`);
+      return { offline: true, conflict: false, changedPaths: [] };
+    }
+    logger.error(`vault: pull failed with unexpected error: ${msg}`);
+    throw err;
   }
 
   const postHead = await resolveHead(cfg.git);

--- a/src/backend/vault/git/pull.ts
+++ b/src/backend/vault/git/pull.ts
@@ -5,19 +5,22 @@ export interface SyncFromRemoteConfig {
   git: SimpleGit;
 }
 
-export interface SyncResult {
-  offline: boolean;
-  conflict: boolean;
-  /** Paths changed by the pull (git-relative, forward-slash). */
-  changedPaths: string[];
-}
+// Discriminated union: callers switch on `kind` rather than checking
+// independent booleans whose combinations are logically impossible.
+export type SyncResult =
+  | { kind: "offline" }
+  | { kind: "conflict"; rebaseWedged?: true }
+  | { kind: "ok"; changedPaths: string[] };
 
 const CONFLICT_RE = /CONFLICT|could not apply|Merge conflict|rebase.*conflict/i;
 
 // Patterns that classify as `offline: true` — we keep serving local data.
+// Auth failures bucket with offline (both mean "can't reach remote; keep
+// serving local"); distinguishing them would complicate client UX without
+// an actionable difference.
 // Anything not matched here (corrupt refs, disk-full, gpg failures,
 // unrelated histories, programmer errors) is rethrown so operators notice.
-const OFFLINE_RE =
+export const OFFLINE_RE =
   /Could not resolve host|Could not read from remote repository|Connection (?:refused|timed out|reset)|Operation timed out|Network is unreachable|authentication failed|Permission denied \(publickey|unable to access|no tracking information|couldn't find remote ref|repository .* not found|does not appear to be a git repository/i;
 
 /**
@@ -35,12 +38,14 @@ export async function syncFromRemote(
   // "no tracking information".
   const remotes = await cfg.git.getRemotes(true);
   if (!remotes.some((r) => r.name === "origin")) {
-    return { offline: false, conflict: false, changedPaths: [] };
+    return { kind: "ok", changedPaths: [] };
   }
 
   const preHead = await resolveHead(cfg.git);
 
   try {
+    // --autostash handles a dirty tree from a crashed write between
+    // markdown-emit and commit; without it the rebase aborts.
     await cfg.git.pull("origin", "main", {
       "--rebase": null,
       "--autostash": null,
@@ -48,26 +53,33 @@ export async function syncFromRemote(
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     if (CONFLICT_RE.test(msg)) {
+      let wedged = false;
       try {
         await cfg.git.raw(["rebase", "--abort"]);
       } catch (abortErr) {
+        wedged = true;
         logger.error(
           `vault: rebase --abort failed after conflict: ${abortErr instanceof Error ? abortErr.message : String(abortErr)}`,
         );
       }
-      return { offline: false, conflict: true, changedPaths: [] };
+      // Drop any autostash entry restored by abort — we don't want it
+      // accumulating on subsequent pulls, and we never pop it back.
+      await cfg.git.raw(["stash", "drop"]).catch(() => undefined);
+      return wedged
+        ? { kind: "conflict", rebaseWedged: true }
+        : { kind: "conflict" };
     }
     if (OFFLINE_RE.test(msg)) {
       logger.warn(`vault: pull failed, serving local: ${msg}`);
-      return { offline: true, conflict: false, changedPaths: [] };
+      return { kind: "offline" };
     }
     logger.error(`vault: pull failed with unexpected error: ${msg}`);
     throw err;
   }
 
   const postHead = await resolveHead(cfg.git);
-  if (!preHead || !postHead || preHead === postHead) {
-    return { offline: false, conflict: false, changedPaths: [] };
+  if (preHead === null || postHead === null || preHead === postHead) {
+    return { kind: "ok", changedPaths: [] };
   }
   const diff = await cfg.git.raw([
     "diff",
@@ -78,14 +90,24 @@ export async function syncFromRemote(
     .split("\n")
     .map((p) => p.trim())
     .filter((p) => p.length > 0);
-  return { offline: false, conflict: false, changedPaths };
+  return { kind: "ok", changedPaths };
 }
 
+// Returns null for the unborn-HEAD case (fresh init, no commits yet).
+// Other failures (corrupt refs, permission denied) surface — silently
+// returning null would hide pull-produced changes.
 async function resolveHead(git: SimpleGit): Promise<string | null> {
   try {
     const sha = await git.raw(["rev-parse", "HEAD"]);
     return sha.trim();
-  } catch {
-    return null;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (
+      /unknown revision|bad revision|does not have any commits yet/i.test(msg)
+    ) {
+      return null;
+    }
+    logger.error(`vault: rev-parse HEAD failed: ${msg}`);
+    throw err;
   }
 }

--- a/src/backend/vault/git/pull.ts
+++ b/src/backend/vault/git/pull.ts
@@ -1,0 +1,79 @@
+import type { SimpleGit } from "simple-git";
+import { logger } from "../../../utils/logger.js";
+
+export interface SyncFromRemoteConfig {
+  git: SimpleGit;
+}
+
+export interface SyncResult {
+  offline: boolean;
+  conflict: boolean;
+  /** Paths changed by the pull (git-relative, forward-slash). */
+  changedPaths: string[];
+}
+
+/**
+ * Runs `git pull --rebase --autostash`. Classifies failures rather than
+ * throwing. Rebase conflicts abort via `git rebase --abort` so the working
+ * tree returns to the pre-pull HEAD. Network / auth failures surface as
+ * `offline: true`. Caller decides whether to serve local stale data.
+ */
+export async function syncFromRemote(
+  cfg: SyncFromRemoteConfig,
+): Promise<SyncResult> {
+  // Short-circuit when no origin is configured — pull would throw
+  // "no tracking information".
+  const remotes = await cfg.git.getRemotes(true);
+  if (!remotes.some((r) => r.name === "origin")) {
+    return { offline: false, conflict: false, changedPaths: [] };
+  }
+
+  const preHead = await resolveHead(cfg.git);
+
+  try {
+    await cfg.git.pull("origin", undefined, {
+      "--rebase": null,
+      "--autostash": null,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/CONFLICT|could not apply|Merge conflict|rebase.*conflict/i.test(msg)) {
+      try {
+        await cfg.git.raw(["rebase", "--abort"]);
+      } catch (abortErr) {
+        logger.error(
+          `vault: rebase --abort failed after conflict: ${abortErr instanceof Error ? abortErr.message : String(abortErr)}`,
+        );
+      }
+      return { offline: false, conflict: true, changedPaths: [] };
+    }
+    // Treat everything else as offline/transient — network, auth, no
+    // upstream, host unreachable, etc.
+    logger.warn(`vault: pull failed, serving local: ${msg}`);
+    return { offline: true, conflict: false, changedPaths: [] };
+  }
+
+  const postHead = await resolveHead(cfg.git);
+  if (!preHead || !postHead || preHead === postHead) {
+    return { offline: false, conflict: false, changedPaths: [] };
+  }
+  const diff = await cfg.git.raw([
+    "diff",
+    "--name-only",
+    `${preHead}..${postHead}`,
+  ]);
+  const changedPaths = diff
+    .split("\n")
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+  return { offline: false, conflict: false, changedPaths };
+}
+
+async function resolveHead(git: SimpleGit): Promise<string | null> {
+  try {
+    const sha = await git.raw(["rev-parse", "HEAD"]);
+    return sha.trim();
+  } catch {
+    return null;
+  }
+}

--- a/src/backend/vault/git/push-queue.ts
+++ b/src/backend/vault/git/push-queue.ts
@@ -8,6 +8,13 @@ export interface PushQueueConfig {
    * scheduling is handled by the backoff logic (Task 5).
    */
   push: () => Promise<void>;
+  /**
+   * Returns the count of commits between @{u} (upstream) and HEAD.
+   * Injected for testability; in the real backend (Task 11), this
+   * shells to `git rev-list --count @{u}..HEAD`. If absent or throws,
+   * unpushedCommits() returns 0.
+   */
+  countUnpushed?: () => Promise<number>;
   debounceMs: number;
   backoffMs: readonly number[];
 }
@@ -63,6 +70,15 @@ export class PushQueue {
     }
     if (this.inFlightPromise) {
       await this.inFlightPromise;
+    }
+  }
+
+  async unpushedCommits(): Promise<number> {
+    if (!this.cfg.countUnpushed) return 0;
+    try {
+      return await this.cfg.countUnpushed();
+    } catch {
+      return 0;
     }
   }
 

--- a/src/backend/vault/git/push-queue.ts
+++ b/src/backend/vault/git/push-queue.ts
@@ -2,17 +2,13 @@ import { logger } from "../../../utils/logger.js";
 
 export interface PushQueueConfig {
   /**
-   * Performs the actual push. Injected so unit tests can use a fake
-   * and the real backend wires a simple-git wrapper in Task 11.
-   * Throwing any error keeps the queue in pending state; retry
-   * scheduling is handled by the backoff logic (Task 5).
+   * Performs the actual push. Throwing keeps the queue pending; the
+   * queue handles backoff scheduling.
    */
   push: () => Promise<void>;
   /**
    * Returns the count of commits between @{u} (upstream) and HEAD.
-   * Injected for testability; in the real backend (Task 11), this
-   * shells to `git rev-list --count @{u}..HEAD`. If absent or throws,
-   * unpushedCommits() returns 0.
+   * If absent or throws, unpushedCommits() returns 0.
    */
   countUnpushed?: () => Promise<number>;
   debounceMs: number;
@@ -77,7 +73,10 @@ export class PushQueue {
     if (!this.cfg.countUnpushed) return 0;
     try {
       return await this.cfg.countUnpushed();
-    } catch {
+    } catch (err) {
+      logger.warn(
+        `vault: unpushedCommits failed, reporting 0: ${err instanceof Error ? err.message : String(err)}`,
+      );
       return 0;
     }
   }

--- a/src/backend/vault/git/push-queue.ts
+++ b/src/backend/vault/git/push-queue.ts
@@ -74,25 +74,28 @@ export class PushQueue {
 
   async #runPush(): Promise<void> {
     this.state = { kind: "in-flight", follow: false };
-    const promise = this.cfg.push().then(
-      () => {
-        // Success path: drain follow-up if queued.
-        const follow = this.state.kind === "in-flight" && this.state.follow;
-        this.state = { kind: "idle" };
+    const promise = this.cfg
+      .push()
+      .then(
+        () => {
+          // Success path: drain follow-up if queued.
+          const follow = this.state.kind === "in-flight" && this.state.follow;
+          this.state = { kind: "idle" };
+          if (follow && !this.closing) {
+            this.#schedule();
+          }
+        },
+        (err: unknown) => {
+          // Backoff path — implemented in Task 5. For now just log + idle.
+          logger.warn(
+            `vault push failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          this.state = { kind: "idle" };
+        },
+      )
+      .finally(() => {
         this.inFlightPromise = null;
-        if (follow && !this.closing) {
-          this.#schedule();
-        }
-      },
-      (err: unknown) => {
-        // Backoff path — implemented in Task 5. For now just log + idle.
-        logger.warn(
-          `vault push failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-        this.state = { kind: "idle" };
-        this.inFlightPromise = null;
-      },
-    );
+      });
     this.inFlightPromise = promise;
     await promise;
   }

--- a/src/backend/vault/git/push-queue.ts
+++ b/src/backend/vault/git/push-queue.ts
@@ -27,6 +27,7 @@ export class PushQueue {
   private state: State = { kind: "idle" };
   private closing = false;
   private inFlightPromise: Promise<void> | null = null;
+  private attempt = 0;
 
   constructor(private readonly cfg: PushQueueConfig) {}
 
@@ -81,16 +82,26 @@ export class PushQueue {
           // Success path: drain follow-up if queued.
           const follow = this.state.kind === "in-flight" && this.state.follow;
           this.state = { kind: "idle" };
+          this.attempt = 0;
           if (follow && !this.closing) {
             this.#schedule();
           }
         },
         (err: unknown) => {
-          // Backoff path — implemented in Task 5. For now just log + idle.
+          // Backoff path: schedule a retry after the appropriate delay.
           logger.warn(
-            `vault push failed: ${err instanceof Error ? err.message : String(err)}`,
+            `vault push failed (attempt ${this.attempt + 1}): ${err instanceof Error ? err.message : String(err)}`,
           );
-          this.state = { kind: "idle" };
+          if (this.closing) {
+            this.state = { kind: "idle" };
+            return;
+          }
+          const ms = this.#backoffMs();
+          this.attempt += 1;
+          const timer = setTimeout(() => {
+            void this.#runPush();
+          }, ms);
+          this.state = { kind: "backoff", timer, attempt: this.attempt };
         },
       )
       .finally(() => {
@@ -98,5 +109,11 @@ export class PushQueue {
       });
     this.inFlightPromise = promise;
     await promise;
+  }
+
+  #backoffMs(): number {
+    if (this.cfg.backoffMs.length === 0) return 0;
+    const idx = Math.min(this.attempt, this.cfg.backoffMs.length - 1);
+    return this.cfg.backoffMs[idx];
   }
 }

--- a/src/backend/vault/git/push-queue.ts
+++ b/src/backend/vault/git/push-queue.ts
@@ -1,0 +1,99 @@
+import { logger } from "../../../utils/logger.js";
+
+export interface PushQueueConfig {
+  /**
+   * Performs the actual push. Injected so unit tests can use a fake
+   * and the real backend wires a simple-git wrapper in Task 11.
+   * Throwing any error keeps the queue in pending state; retry
+   * scheduling is handled by the backoff logic (Task 5).
+   */
+  push: () => Promise<void>;
+  debounceMs: number;
+  backoffMs: readonly number[];
+}
+
+type State =
+  | { kind: "idle" }
+  | { kind: "scheduled"; timer: NodeJS.Timeout }
+  | { kind: "in-flight"; follow: boolean }
+  | { kind: "backoff"; timer: NodeJS.Timeout; attempt: number };
+
+/**
+ * Debounced, single-flight push queue. `request()` bumps a debounce
+ * timer; when it fires, one push runs. Concurrent requests during an
+ * in-flight push queue exactly one follow-up on completion.
+ */
+export class PushQueue {
+  private state: State = { kind: "idle" };
+  private closing = false;
+  private inFlightPromise: Promise<void> | null = null;
+
+  constructor(private readonly cfg: PushQueueConfig) {}
+
+  request(): void {
+    if (this.closing) return;
+    switch (this.state.kind) {
+      case "idle":
+        this.#schedule();
+        return;
+      case "scheduled":
+        clearTimeout(this.state.timer);
+        this.#schedule();
+        return;
+      case "in-flight":
+        this.state = { kind: "in-flight", follow: true };
+        return;
+      case "backoff":
+        // Do not shorten backoff — just mark that we still need to push.
+        // The backoff timer already owns the next attempt.
+        return;
+    }
+  }
+
+  async close(): Promise<void> {
+    this.closing = true;
+    if (this.state.kind === "scheduled") {
+      clearTimeout(this.state.timer);
+      this.state = { kind: "idle" };
+    }
+    if (this.state.kind === "backoff") {
+      clearTimeout(this.state.timer);
+      this.state = { kind: "idle" };
+    }
+    if (this.inFlightPromise) {
+      await this.inFlightPromise;
+    }
+  }
+
+  #schedule(): void {
+    const timer = setTimeout(() => {
+      void this.#runPush();
+    }, this.cfg.debounceMs);
+    this.state = { kind: "scheduled", timer };
+  }
+
+  async #runPush(): Promise<void> {
+    this.state = { kind: "in-flight", follow: false };
+    const promise = this.cfg.push().then(
+      () => {
+        // Success path: drain follow-up if queued.
+        const follow = this.state.kind === "in-flight" && this.state.follow;
+        this.state = { kind: "idle" };
+        this.inFlightPromise = null;
+        if (follow && !this.closing) {
+          this.#schedule();
+        }
+      },
+      (err: unknown) => {
+        // Backoff path — implemented in Task 5. For now just log + idle.
+        logger.warn(
+          `vault push failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        this.state = { kind: "idle" };
+        this.inFlightPromise = null;
+      },
+    );
+    this.inFlightPromise = promise;
+    await promise;
+  }
+}

--- a/src/backend/vault/git/push-queue.ts
+++ b/src/backend/vault/git/push-queue.ts
@@ -1,17 +1,12 @@
 import { logger } from "../../../utils/logger.js";
 
 export interface PushQueueConfig {
-  /**
-   * Performs the actual push. Throwing keeps the queue pending; the
-   * queue handles backoff scheduling.
-   */
+  // Throws → queue retains pending state and schedules backoff.
   push: () => Promise<void>;
-  /**
-   * Returns the count of commits between @{u} (upstream) and HEAD.
-   * If absent or throws, unpushedCommits() returns 0.
-   */
   countUnpushed?: () => Promise<number>;
   debounceMs: number;
+  // Backoff: fast first retry for transient blips, then exponential to a
+  // long cap so we don't tight-loop against a broken remote.
   backoffMs: readonly number[];
 }
 
@@ -21,16 +16,12 @@ type State =
   | { kind: "in-flight"; follow: boolean }
   | { kind: "backoff"; timer: NodeJS.Timeout; attempt: number };
 
-/**
- * Debounced, single-flight push queue. `request()` bumps a debounce
- * timer; when it fires, one push runs. Concurrent requests during an
- * in-flight push queue exactly one follow-up on completion.
- */
 export class PushQueue {
   private state: State = { kind: "idle" };
   private closing = false;
   private inFlightPromise: Promise<void> | null = null;
   private attempt = 0;
+  private lastError: string | null = null;
 
   constructor(private readonly cfg: PushQueueConfig) {}
 
@@ -74,11 +65,23 @@ export class PushQueue {
     try {
       return await this.cfg.countUnpushed();
     } catch (err) {
-      logger.warn(
-        `vault: unpushedCommits failed, reporting 0: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      const msg = err instanceof Error ? err.message : String(err);
+      // No upstream yet (pre-first-push) is expected — debug only.
+      if (
+        /no upstream|unknown revision @\{u\}|ambiguous argument '@\{u\}'/i.test(
+          msg,
+        )
+      ) {
+        logger.debug(`vault: unpushedCommits — no upstream yet: ${msg}`);
+        return 0;
+      }
+      logger.warn(`vault: unpushedCommits failed, reporting 0: ${msg}`);
       return 0;
     }
+  }
+
+  lastPushError(): string | null {
+    return this.lastError;
   }
 
   #schedule(): void {
@@ -94,25 +97,35 @@ export class PushQueue {
       .push()
       .then(
         () => {
-          // Success path: drain follow-up if queued.
           const follow = this.state.kind === "in-flight" && this.state.follow;
           this.state = { kind: "idle" };
           this.attempt = 0;
+          this.lastError = null;
           if (follow && !this.closing) {
             this.#schedule();
           }
         },
         (err: unknown) => {
-          // Backoff path: schedule a retry after the appropriate delay.
-          logger.warn(
-            `vault push failed (attempt ${this.attempt + 1}): ${err instanceof Error ? err.message : String(err)}`,
-          );
+          const msg = err instanceof Error ? err.message : String(err);
+          this.lastError = msg;
+          const attemptNum = this.attempt + 1;
+          // Escalate to error once we've exhausted the backoff curve —
+          // operators need a louder signal when retries keep failing.
+          const exhausted = attemptNum >= this.cfg.backoffMs.length;
+          if (exhausted) {
+            logger.error(
+              `vault push failed (attempt ${attemptNum}, exhausted backoff): ${msg}`,
+            );
+          } else {
+            logger.warn(`vault push failed (attempt ${attemptNum}): ${msg}`);
+          }
           if (this.closing) {
+            this.attempt = 0;
             this.state = { kind: "idle" };
             return;
           }
           const ms = this.#backoffMs();
-          this.attempt += 1;
+          this.attempt = attemptNum;
           const timer = setTimeout(() => {
             void this.#runPush();
           }, ms);

--- a/src/backend/vault/git/reconcile.ts
+++ b/src/backend/vault/git/reconcile.ts
@@ -12,13 +12,13 @@ const MEMORY_PATH_RE =
 
 /**
  * Recovers from a crash between "markdown write succeeded" and "git commit
- * landed" in Phase 4a. Collects dirty tracked memory markdown files and
- * folds them into a single commit with trailer `AB-Action: reconcile`.
+ * landed". Collects dirty tracked memory markdown files and folds them
+ * into a single commit with trailer `AB-Action: reconcile`.
  *
- * Only modified and deleted tracked files are included. Untracked files are
- * ignored (requires validation; defer to Phase 5 watcher). Non-memory dirty
- * files are also ignored — operator edits to README etc. should not be
- * auto-committed by agent-brain on startup.
+ * Only modified and deleted tracked files are included. Untracked files
+ * are skipped — auto-committing unreviewed markdown on startup is unsafe.
+ * Non-memory dirty files are also ignored so operator edits to README
+ * etc. are never swept up by agent-brain.
  */
 export async function reconcileDirty(cfg: ReconcileConfig): Promise<void> {
   if (!cfg.ops.enabled) return;

--- a/src/backend/vault/git/reconcile.ts
+++ b/src/backend/vault/git/reconcile.ts
@@ -1,0 +1,48 @@
+import type { SimpleGit } from "simple-git";
+import { logger } from "../../../utils/logger.js";
+import type { GitOps } from "./types.js";
+
+export interface ReconcileConfig {
+  git: SimpleGit;
+  ops: GitOps;
+}
+
+const MEMORY_PATH_RE =
+  /^(workspaces\/[^/]+\/memories\/|project\/memories\/|users\/[^/]+\/memories\/).+\.md$/;
+
+/**
+ * Recovers from a crash between "markdown write succeeded" and "git commit
+ * landed" in Phase 4a. Collects dirty tracked memory markdown files and
+ * folds them into a single commit with trailer `AB-Action: reconcile`.
+ *
+ * Only modified and deleted tracked files are included. Untracked files are
+ * ignored (requires validation; defer to Phase 5 watcher). Non-memory dirty
+ * files are also ignored — operator edits to README etc. should not be
+ * auto-committed by agent-brain on startup.
+ */
+export async function reconcileDirty(cfg: ReconcileConfig): Promise<void> {
+  if (!cfg.ops.enabled) return;
+  const status = await cfg.git.status();
+  // Use only modified and deleted — not_added is untracked and must be
+  // skipped (untracked markdown requires validation before auto-commit).
+  const candidates = [...status.modified, ...status.deleted].filter((p) =>
+    MEMORY_PATH_RE.test(p),
+  );
+  if (candidates.length === 0) return;
+
+  try {
+    await cfg.ops.stageAndCommit(
+      candidates,
+      "[agent-brain] reconcile: post-crash recovery",
+      {
+        action: "reconcile",
+        actor: "agent-brain",
+        reason: "post-crash-recovery",
+      },
+    );
+  } catch (err) {
+    logger.error(
+      `vault reconcile commit failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/src/backend/vault/git/reconcile.ts
+++ b/src/backend/vault/git/reconcile.ts
@@ -1,5 +1,6 @@
 import type { SimpleGit } from "simple-git";
 import { logger } from "../../../utils/logger.js";
+import { inferScopeFromPath } from "../io/paths.js";
 import type { GitOps } from "./types.js";
 
 export interface ReconcileConfig {
@@ -7,28 +8,25 @@ export interface ReconcileConfig {
   ops: GitOps;
 }
 
-const MEMORY_PATH_RE =
-  /^(workspaces\/[^/]+\/memories\/|project\/memories\/|users\/[^/]+\/memories\/).+\.md$/;
+export interface ReconcileResult {
+  failed: boolean;
+}
 
 /**
  * Recovers from a crash between "markdown write succeeded" and "git commit
- * landed". Collects dirty tracked memory markdown files and folds them
- * into a single commit with trailer `AB-Action: reconcile`.
- *
- * Only modified and deleted tracked files are included. Untracked files
- * are skipped — auto-committing unreviewed markdown on startup is unsafe.
- * Non-memory dirty files are also ignored so operator edits to README
- * etc. are never swept up by agent-brain.
+ * landed". Folds dirty tracked memory markdown into one `AB-Action: reconcile`
+ * commit. Skips untracked files — auto-committing unreviewed markdown is
+ * unsafe.
  */
-export async function reconcileDirty(cfg: ReconcileConfig): Promise<void> {
-  if (!cfg.ops.enabled) return;
+export async function reconcileDirty(
+  cfg: ReconcileConfig,
+): Promise<ReconcileResult> {
+  if (!cfg.ops.enabled) return { failed: false };
   const status = await cfg.git.status();
-  // Use only modified and deleted — not_added is untracked and must be
-  // skipped (untracked markdown requires validation before auto-commit).
-  const candidates = [...status.modified, ...status.deleted].filter((p) =>
-    MEMORY_PATH_RE.test(p),
+  const candidates = [...status.modified, ...status.deleted].filter(
+    (p) => inferScopeFromPath(p) !== null,
   );
-  if (candidates.length === 0) return;
+  if (candidates.length === 0) return { failed: false };
 
   try {
     await cfg.ops.stageAndCommit(
@@ -40,9 +38,11 @@ export async function reconcileDirty(cfg: ReconcileConfig): Promise<void> {
         reason: "post-crash-recovery",
       },
     );
+    return { failed: false };
   } catch (err) {
     logger.error(
       `vault reconcile commit failed: ${err instanceof Error ? err.message : String(err)}`,
     );
+    return { failed: true };
   }
 }

--- a/src/backend/vault/git/remote.ts
+++ b/src/backend/vault/git/remote.ts
@@ -6,13 +6,16 @@ export interface EnsureRemoteConfig {
   remoteUrl?: string;
 }
 
-/**
- * Adds `origin` to the vault repo when absent and `remoteUrl` is provided.
- * Leaves any existing `origin` alone — users may have configured the
- * remote manually and that intent wins. Mismatches are warn-logged.
- * Idempotent.
- */
-export async function ensureRemote(cfg: EnsureRemoteConfig): Promise<void> {
+export interface EnsureRemoteResult {
+  mismatch?: { configured: string; actual: string };
+}
+
+// Leave existing origin in place — operator intent wins; mismatch is
+// surfaced via boot meta so the operator sees it without digging through
+// logs.
+export async function ensureRemote(
+  cfg: EnsureRemoteConfig,
+): Promise<EnsureRemoteResult> {
   const remotes = await cfg.git.getRemotes(true);
   const origin = remotes.find((r) => r.name === "origin");
   if (origin) {
@@ -20,9 +23,13 @@ export async function ensureRemote(cfg: EnsureRemoteConfig): Promise<void> {
       logger.warn(
         `vault: configured remoteUrl (${cfg.remoteUrl}) differs from existing origin (${origin.refs.fetch}); leaving existing`,
       );
+      return {
+        mismatch: { configured: cfg.remoteUrl, actual: origin.refs.fetch },
+      };
     }
-    return;
+    return {};
   }
-  if (!cfg.remoteUrl) return;
+  if (!cfg.remoteUrl) return {};
   await cfg.git.addRemote("origin", cfg.remoteUrl);
+  return {};
 }

--- a/src/backend/vault/git/remote.ts
+++ b/src/backend/vault/git/remote.ts
@@ -1,0 +1,28 @@
+import type { SimpleGit } from "simple-git";
+import { logger } from "../../../utils/logger.js";
+
+export interface EnsureRemoteConfig {
+  git: SimpleGit;
+  remoteUrl: string | undefined;
+}
+
+/**
+ * Adds `origin` to the vault repo when absent and `remoteUrl` is provided.
+ * Leaves any existing `origin` alone — users may have configured the
+ * remote manually and that intent wins. Mismatches are warn-logged.
+ * Idempotent.
+ */
+export async function ensureRemote(cfg: EnsureRemoteConfig): Promise<void> {
+  const remotes = await cfg.git.getRemotes(true);
+  const origin = remotes.find((r) => r.name === "origin");
+  if (origin) {
+    if (cfg.remoteUrl && origin.refs.fetch !== cfg.remoteUrl) {
+      logger.warn(
+        `vault: AGENT_BRAIN_VAULT_REMOTE_URL (${cfg.remoteUrl}) differs from existing origin (${origin.refs.fetch}); leaving existing`,
+      );
+    }
+    return;
+  }
+  if (!cfg.remoteUrl) return;
+  await cfg.git.addRemote("origin", cfg.remoteUrl);
+}

--- a/src/backend/vault/git/remote.ts
+++ b/src/backend/vault/git/remote.ts
@@ -3,7 +3,7 @@ import { logger } from "../../../utils/logger.js";
 
 export interface EnsureRemoteConfig {
   git: SimpleGit;
-  remoteUrl: string | undefined;
+  remoteUrl?: string;
 }
 
 /**
@@ -18,7 +18,7 @@ export async function ensureRemote(cfg: EnsureRemoteConfig): Promise<void> {
   if (origin) {
     if (cfg.remoteUrl && origin.refs.fetch !== cfg.remoteUrl) {
       logger.warn(
-        `vault: AGENT_BRAIN_VAULT_REMOTE_URL (${cfg.remoteUrl}) differs from existing origin (${origin.refs.fetch}); leaving existing`,
+        `vault: configured remoteUrl (${cfg.remoteUrl}) differs from existing origin (${origin.refs.fetch}); leaving existing`,
       );
     }
     return;

--- a/src/backend/vault/git/trailers.ts
+++ b/src/backend/vault/git/trailers.ts
@@ -11,6 +11,8 @@ export function formatTrailers(trailer: CommitTrailer): string {
       throw new Error("workspaceId required for workspace_upsert");
     }
     lines.push(`AB-Workspace: ${trailer.workspaceId}`);
+  } else if (trailer.action === "reconcile") {
+    // Bulk recovery commit — no single memoryId or workspaceId to attach.
   } else {
     if (!trailer.memoryId) {
       throw new Error(`memoryId required for action ${trailer.action}`);

--- a/src/backend/vault/git/trailers.ts
+++ b/src/backend/vault/git/trailers.ts
@@ -1,22 +1,12 @@
 import type { CommitTrailer } from "./types.js";
 
-// Maps a CommitTrailer into git-interpret-trailers-compatible lines.
-// Newlines inside free-form fields (reason) are escaped as `\\n` so
-// the trailer block stays a single logical paragraph — downstream
-// parsers split on LF and rely on one-line-per-trailer.
+// Escape LF in free-form fields — parsers split trailers on LF.
+// Non-free-form values (ids, actions) are validated upstream so no escape needed.
 export function formatTrailers(trailer: CommitTrailer): string {
   const lines: string[] = [`AB-Action: ${trailer.action}`];
   if (trailer.action === "workspace_upsert") {
-    if (!trailer.workspaceId) {
-      throw new Error("workspaceId required for workspace_upsert");
-    }
     lines.push(`AB-Workspace: ${trailer.workspaceId}`);
-  } else if (trailer.action === "reconcile") {
-    // Bulk recovery commit — no single memoryId or workspaceId to attach.
-  } else {
-    if (!trailer.memoryId) {
-      throw new Error(`memoryId required for action ${trailer.action}`);
-    }
+  } else if (trailer.action !== "reconcile") {
     lines.push(`AB-Memory: ${trailer.memoryId}`);
   }
   lines.push(`AB-Actor: ${trailer.actor}`);

--- a/src/backend/vault/git/trailers.ts
+++ b/src/backend/vault/git/trailers.ts
@@ -2,8 +2,8 @@ import type { CommitTrailer } from "./types.js";
 
 // Maps a CommitTrailer into git-interpret-trailers-compatible lines.
 // Newlines inside free-form fields (reason) are escaped as `\\n` so
-// the trailer block stays a single logical paragraph — git log parsers
-// in Phase 4c split on LF and rely on that.
+// the trailer block stays a single logical paragraph — downstream
+// parsers split on LF and rely on one-line-per-trailer.
 export function formatTrailers(trailer: CommitTrailer): string {
   const lines: string[] = [`AB-Action: ${trailer.action}`];
   if (trailer.action === "workspace_upsert") {

--- a/src/backend/vault/git/types.ts
+++ b/src/backend/vault/git/types.ts
@@ -10,7 +10,8 @@ export type CommitAction =
   | "unflagged"
   | "related"
   | "unrelated"
-  | "workspace_upsert";
+  | "workspace_upsert"
+  | "reconcile";
 
 export interface CommitTrailer {
   action: CommitAction;

--- a/src/backend/vault/git/types.ts
+++ b/src/backend/vault/git/types.ts
@@ -13,13 +13,29 @@ export type CommitAction =
   | "workspace_upsert"
   | "reconcile";
 
-export interface CommitTrailer {
-  action: CommitAction;
-  memoryId?: string;
-  workspaceId?: string;
-  actor: string;
-  reason?: string | null;
-}
+type MemoryAction = Exclude<CommitAction, "workspace_upsert" | "reconcile">;
+
+// Discriminated union — makes illegal (action, required-id) combinations
+// unrepresentable at compile time, so trailers.ts doesn't need runtime
+// guards.
+export type CommitTrailer =
+  | {
+      action: MemoryAction;
+      memoryId: string;
+      actor: string;
+      reason?: string | null;
+    }
+  | {
+      action: "workspace_upsert";
+      workspaceId: string;
+      actor: string;
+      reason?: string | null;
+    }
+  | {
+      action: "reconcile";
+      actor: string;
+      reason?: string | null;
+    };
 
 export interface GitOps {
   // False for the no-op implementation used by test backends that

--- a/src/backend/vault/git/types.ts
+++ b/src/backend/vault/git/types.ts
@@ -33,6 +33,13 @@ export interface GitOps {
     trailer: CommitTrailer,
   ): Promise<void>;
   status(): Promise<{ clean: boolean }>;
+  /**
+   * Optional callback invoked after every successful stageAndCommit.
+   * Fires outside the #serialize mutex but within the same async flow —
+   * callers get a synchronous "commit landed" signal. Failures in the
+   * callback are not propagated (fire-and-forget).
+   */
+  afterCommit?: () => void;
 }
 
 // Thrown by stageAndCommit when `git add` staged nothing (file unchanged
@@ -50,6 +57,7 @@ export class VaultGitNothingToCommitError extends DomainError {
 
 export class NoopGitOps implements GitOps {
   readonly enabled = false;
+  afterCommit?: () => void;
   async isRepo(): Promise<boolean> {
     return false;
   }

--- a/src/backend/vault/index.ts
+++ b/src/backend/vault/index.ts
@@ -194,21 +194,34 @@ export class VaultBackend implements StorageBackend {
 }
 
 /**
- * When origin/main exists and the local repo has a divergent bootstrap
- * commit (i.e. the local main and origin/main have no common ancestor),
- * replace the local history with the remote's so push / pull work.
+ * Aligns the local repo with origin/main when they have diverged or
+ * when local is simply behind remote. Called once during VaultBackend
+ * creation, before any push/pull logic runs.
  *
- * This handles the "second vault initializing against an existing bare
- * repo" case: ensureVaultGit ran `git init` + committed bootstrap files,
- * but the bare already has a `main` branch from the first vault. A plain
- * `git pull --rebase` would fail with "refusing to merge unrelated
- * histories". Instead we fetch, then point main at origin/main, then
- * re-apply the bootstrap files (if they differ) as a merge commit so the
- * local .gitignore/.gitattributes invariants are satisfied without
- * diverging the graph.
+ * Behaviour by case:
  *
- * Safe to call on a repo that is already aligned — the early-return after
- * merge-base check makes it a no-op in that case.
+ * 1. No `origin` remote configured → no-op (local-only vault).
+ * 2. Origin unreachable (fetch throws) → no-op; offline handling
+ *    deferred to the PushQueue / syncFromRemote path.
+ * 3. origin/main does not yet exist (empty bare repo) → no-op; the
+ *    first push from this vault will create it.
+ * 4. No local commits yet → checks out a new `main` branch tracking
+ *    `origin/main` directly.
+ * 5. origin/main is an ancestor of local HEAD (local is ahead or equal)
+ *    → already aligned; no-op.
+ * 6. local HEAD is an ancestor of origin/main (local is behind) →
+ *    fast-forward: `reset --hard <remoteHead>` then
+ *    `branch --set-upstream-to=origin/main main`.
+ * 7. Unrelated histories (fresh second-vault bootstrap produced a
+ *    divergent root commit) → same as case 6: `reset --hard <remoteHead>`
+ *    then set upstream. The bootstrap files (.gitignore, .gitattributes)
+ *    are already present in origin because the first vault committed them,
+ *    so no re-commit is needed. This is safe only at init time (before
+ *    any user data has been written to the local repo).
+ *
+ * Note: this function does NOT produce a merge commit. In all write cases
+ * it performs a hard reset to `origin/main` and sets the upstream
+ * tracking branch.
  */
 async function alignWithRemote(git: SimpleGit): Promise<void> {
   const remotes = await git.getRemotes(true);

--- a/src/backend/vault/index.ts
+++ b/src/backend/vault/index.ts
@@ -21,6 +21,7 @@ import type { GitOps } from "./git/types.js";
 import { runSessionStart } from "./session-start.js";
 import type { Embedder } from "./session-start.js";
 import { createEmbeddingProvider } from "../../providers/embedding/index.js";
+import { logger } from "../../utils/logger.js";
 import type {
   BackendName,
   StorageBackend,
@@ -273,6 +274,9 @@ async function alignWithRemote(git: SimpleGit): Promise<void> {
     // bootstrap files (.gitignore, .gitattributes) are already
     // present in origin because the first vault committed them, so no
     // re-commit is needed.
+    logger.error(
+      `vault: unrelated-history reset — local HEAD ${localHead} has no common ancestor with origin/main ${remoteHead}; discarding local history. This is safe only for fresh-clone bootstrap; if you have local work, abort and investigate AGENT_BRAIN_VAULT_REMOTE_URL.`,
+    );
     await git.raw(["reset", "--hard", remoteHead]);
     await git.raw(["branch", "--set-upstream-to=origin/main", "main"]);
   }

--- a/src/backend/vault/index.ts
+++ b/src/backend/vault/index.ts
@@ -67,8 +67,7 @@ export class VaultBackend implements StorageBackend {
   readonly flagRepo: FlagRepository;
   readonly relationshipRepo: RelationshipRepository;
   readonly schedulerStateRepo: SchedulerStateRepository;
-  // Retain the concrete type so sessionStart can call syncPaths()
-  // after a pull without a type cast.
+  // Concrete type needed — syncPaths isn't on MemoryRepository.
   private readonly vaultMemoryRepo: VaultMemoryRepository;
 
   private constructor(
@@ -80,6 +79,7 @@ export class VaultBackend implements StorageBackend {
     private readonly git: SimpleGit,
     private readonly pushQueue: PushQueue,
     private readonly embed: Embedder,
+    private readonly bootMeta: Partial<BackendSessionStartMeta>,
   ) {
     this.memoryRepo = memoryRepo;
     this.vaultMemoryRepo = memoryRepo;
@@ -113,11 +113,17 @@ export class VaultBackend implements StorageBackend {
       trackUsers: trackUsersInGit,
     });
     const git = simpleGit({ baseDir: cfg.root }).env(scrubGitEnv());
-    await ensureRemote({ git, remoteUrl: cfg.remoteUrl });
-    await alignWithRemote(git);
+    const bootMeta: Partial<BackendSessionStartMeta> = {};
+    const remoteResult = await ensureRemote({ git, remoteUrl: cfg.remoteUrl });
+    if (remoteResult.mismatch) bootMeta.remote_mismatch = remoteResult.mismatch;
 
     const gitOps: GitOps = new GitOpsImpl({ root: cfg.root });
-    await reconcileDirty({ git, ops: gitOps });
+    // Reconcile BEFORE align: a post-crash dirty tree must land as a
+    // commit first, otherwise align's `reset --hard` on the
+    // unrelated-history bootstrap path silently discards it.
+    const reconcile = await reconcileDirty({ git, ops: gitOps });
+    if (reconcile.failed) bootMeta.reconcile_failed = true;
+    await alignWithRemote(git);
 
     const vectorIndex = await VaultVectorIndex.create({
       root: cfg.root,
@@ -125,21 +131,25 @@ export class VaultBackend implements StorageBackend {
     });
 
     const debounceMs = cfg.pushDebounceMs ?? 5000;
+    // Backoff: fast first retry for transient blips, then exponential to
+    // a 30-min cap so we don't tight-loop against a broken remote.
     const backoffMs = cfg.pushBackoffMs ?? [5000, 30000, 300000, 1800000];
     const pushQueue = new PushQueue({
       debounceMs,
       backoffMs,
       push: async () => {
-        // --set-upstream ensures @{u} resolves on subsequent calls so
-        // `git rev-list --count @{u}..HEAD` works after the first push.
+        // --set-upstream so @{u} resolves on subsequent calls and the
+        // unpushed-count query works post-first-push.
         await git.raw(["push", "--set-upstream", "origin", "HEAD:main"]);
       },
       countUnpushed: async () => {
-        // Throws when @{u} is not yet configured (pre-first-push). The
-        // PushQueue.unpushedCommits() wrapper logs and returns 0 for that
-        // and any other failure.
+        // Throws pre-first-push when @{u} is unset — caller classifies.
         const out = await git.raw(["rev-list", "--count", "@{u}..HEAD"]);
-        return Number(out.trim()) || 0;
+        const n = Number.parseInt(out.trim(), 10);
+        if (!Number.isFinite(n)) {
+          throw new Error(`rev-list --count returned ${out.trim()}`);
+        }
+        return n;
       },
     });
 
@@ -165,6 +175,7 @@ export class VaultBackend implements StorageBackend {
       git,
       pushQueue,
       embed,
+      bootMeta,
     );
   }
 
@@ -174,22 +185,28 @@ export class VaultBackend implements StorageBackend {
   }
 
   async sessionStart(): Promise<BackendSessionStartMeta> {
-    return runSessionStart({
+    const meta = await runSessionStart({
       root: this.root,
       vectorIndex: this.vectorIndex,
       embed: this.embed,
       syncFromRemote: () => syncFromRemote({ git: this.git }),
       pushQueue: {
         unpushedCommits: () => this.pushQueue.unpushedCommits(),
+        lastPushError: () => this.pushQueue.lastPushError(),
         request: () => this.pushQueue.request(),
       },
       onChangedPaths: (paths) => {
-        // Keep the memory repo's in-memory path index in sync with
-        // files that arrived via git pull so findById works immediately
-        // after sessionStart without a full process restart.
+        // Pulled files need path-index refresh or findById misses until restart.
         this.vaultMemoryRepo.syncPaths(paths);
       },
     });
+    // Boot-time meta (remote_mismatch, reconcile_failed) is sticky for
+    // the life of the backend — clients should see it on every session
+    // start until the process is restarted with a fixed config.
+    if (this.bootMeta.remote_mismatch)
+      meta.remote_mismatch = this.bootMeta.remote_mismatch;
+    if (this.bootMeta.reconcile_failed) meta.reconcile_failed = true;
+    return meta;
   }
 }
 

--- a/src/backend/vault/index.ts
+++ b/src/backend/vault/index.ts
@@ -1,4 +1,5 @@
 import { mkdir } from "node:fs/promises";
+import { simpleGit, type SimpleGit } from "simple-git";
 import { VaultAuditRepository } from "./repositories/audit-repository.js";
 import { VaultCommentRepository } from "./repositories/comment-repository.js";
 import { VaultFlagRepository } from "./repositories/flag-repository.js";
@@ -11,7 +12,15 @@ import { VaultWorkspaceRepository } from "./repositories/workspace-repository.js
 import { VaultVectorIndex } from "./vector/lance-index.js";
 import { ensureVaultGit } from "./git/bootstrap.js";
 import { GitOpsImpl } from "./git/git-ops.js";
+import { scrubGitEnv } from "./git/env.js";
+import { ensureRemote } from "./git/remote.js";
+import { reconcileDirty } from "./git/reconcile.js";
+import { syncFromRemote } from "./git/pull.js";
+import { PushQueue } from "./git/push-queue.js";
 import type { GitOps } from "./git/types.js";
+import { runSessionStart } from "./session-start.js";
+import type { Embedder } from "./session-start.js";
+import { createEmbeddingProvider } from "../../providers/embedding/index.js";
 import type {
   BackendName,
   StorageBackend,
@@ -36,6 +45,10 @@ export interface VaultBackendConfig {
   // workspace/project ones. Default false — `users/` stays gitignored
   // and its writes skip the commit step (privacy-first).
   trackUsersInGit?: boolean;
+  remoteUrl?: string;
+  pushDebounceMs?: number;
+  pushBackoffMs?: readonly number[];
+  embed?: Embedder;
 }
 
 // Markdown-vault backend. Composes the nine Vault* repositories backed
@@ -57,9 +70,12 @@ export class VaultBackend implements StorageBackend {
   private constructor(
     memoryRepo: MemoryRepository,
     private readonly vectorIndex: VaultVectorIndex,
-    root: string,
+    private readonly root: string,
     gitOps: GitOps,
     trackUsersInGit: boolean,
+    private readonly git: SimpleGit,
+    private readonly pushQueue: PushQueue,
+    private readonly embed: Embedder,
   ) {
     this.memoryRepo = memoryRepo;
     this.workspaceRepo = new VaultWorkspaceRepository({ root, gitOps });
@@ -91,31 +107,88 @@ export class VaultBackend implements StorageBackend {
       root: cfg.root,
       trackUsers: trackUsersInGit,
     });
+    const git = simpleGit({ baseDir: cfg.root }).env(scrubGitEnv());
+    await ensureRemote({ git, remoteUrl: cfg.remoteUrl });
+
     const gitOps: GitOps = new GitOpsImpl({ root: cfg.root });
+    await reconcileDirty({ git, ops: gitOps });
+
     const vectorIndex = await VaultVectorIndex.create({
       root: cfg.root,
       dims: cfg.embeddingDimensions,
     });
+
+    const debounceMs = cfg.pushDebounceMs ?? 5000;
+    const backoffMs = cfg.pushBackoffMs ?? [5000, 30000, 300000, 1800000];
+    const pushQueue = new PushQueue({
+      debounceMs,
+      backoffMs,
+      push: async () => {
+        await git.push("origin", "HEAD:main");
+      },
+      countUnpushed: async () => {
+        try {
+          const out = await git.raw(["rev-list", "--count", "@{u}..HEAD"]);
+          return Number(out.trim()) || 0;
+        } catch {
+          return 0;
+        }
+      },
+    });
+
+    if (gitOps.enabled) {
+      gitOps.afterCommit = () => pushQueue.request();
+    }
+
     const memoryRepo = await VaultMemoryRepository.create({
       root: cfg.root,
       index: vectorIndex,
       gitOps,
       trackUsersInGit,
     });
+
+    const embed = cfg.embed ?? defaultEmbedder(cfg.embeddingDimensions);
+
     return new VaultBackend(
       memoryRepo,
       vectorIndex,
       cfg.root,
       gitOps,
       trackUsersInGit,
+      git,
+      pushQueue,
+      embed,
     );
   }
 
   async close(): Promise<void> {
+    await this.pushQueue.close();
     await this.vectorIndex.close();
   }
 
   async sessionStart(): Promise<BackendSessionStartMeta> {
-    return {};
+    return runSessionStart({
+      root: this.root,
+      vectorIndex: this.vectorIndex,
+      embed: this.embed,
+      syncFromRemote: () => syncFromRemote({ git: this.git }),
+      pushQueue: {
+        unpushedCommits: () => this.pushQueue.unpushedCommits(),
+        request: () => this.pushQueue.request(),
+      },
+    });
   }
+}
+
+function defaultEmbedder(dims: number): Embedder {
+  const provider = createEmbeddingProvider();
+  return async (text: string) => {
+    const vec = await provider.embed(text);
+    if (vec.length !== dims) {
+      throw new Error(
+        `vault embed: provider returned ${vec.length} dims, expected ${dims}`,
+      );
+    }
+    return vec;
+  };
 }

--- a/src/backend/vault/index.ts
+++ b/src/backend/vault/index.ts
@@ -66,9 +66,12 @@ export class VaultBackend implements StorageBackend {
   readonly flagRepo: FlagRepository;
   readonly relationshipRepo: RelationshipRepository;
   readonly schedulerStateRepo: SchedulerStateRepository;
+  // Retain the concrete type so sessionStart can call syncPaths()
+  // after a pull without a type cast.
+  private readonly vaultMemoryRepo: VaultMemoryRepository;
 
   private constructor(
-    memoryRepo: MemoryRepository,
+    memoryRepo: VaultMemoryRepository,
     private readonly vectorIndex: VaultVectorIndex,
     private readonly root: string,
     gitOps: GitOps,
@@ -78,6 +81,7 @@ export class VaultBackend implements StorageBackend {
     private readonly embed: Embedder,
   ) {
     this.memoryRepo = memoryRepo;
+    this.vaultMemoryRepo = memoryRepo;
     this.workspaceRepo = new VaultWorkspaceRepository({ root, gitOps });
     this.commentRepo = new VaultCommentRepository({
       root,
@@ -109,6 +113,7 @@ export class VaultBackend implements StorageBackend {
     });
     const git = simpleGit({ baseDir: cfg.root }).env(scrubGitEnv());
     await ensureRemote({ git, remoteUrl: cfg.remoteUrl });
+    await alignWithRemote(git);
 
     const gitOps: GitOps = new GitOpsImpl({ root: cfg.root });
     await reconcileDirty({ git, ops: gitOps });
@@ -124,7 +129,9 @@ export class VaultBackend implements StorageBackend {
       debounceMs,
       backoffMs,
       push: async () => {
-        await git.push("origin", "HEAD:main");
+        // --set-upstream ensures @{u} resolves on subsequent calls so
+        // `git rev-list --count @{u}..HEAD` works after the first push.
+        await git.raw(["push", "--set-upstream", "origin", "HEAD:main"]);
       },
       countUnpushed: async () => {
         try {
@@ -176,7 +183,85 @@ export class VaultBackend implements StorageBackend {
         unpushedCommits: () => this.pushQueue.unpushedCommits(),
         request: () => this.pushQueue.request(),
       },
+      onChangedPaths: (paths) => {
+        // Keep the memory repo's in-memory path index in sync with
+        // files that arrived via git pull so findById works immediately
+        // after sessionStart without a full process restart.
+        this.vaultMemoryRepo.syncPaths(paths);
+      },
     });
+  }
+}
+
+/**
+ * When origin/main exists and the local repo has a divergent bootstrap
+ * commit (i.e. the local main and origin/main have no common ancestor),
+ * replace the local history with the remote's so push / pull work.
+ *
+ * This handles the "second vault initializing against an existing bare
+ * repo" case: ensureVaultGit ran `git init` + committed bootstrap files,
+ * but the bare already has a `main` branch from the first vault. A plain
+ * `git pull --rebase` would fail with "refusing to merge unrelated
+ * histories". Instead we fetch, then point main at origin/main, then
+ * re-apply the bootstrap files (if they differ) as a merge commit so the
+ * local .gitignore/.gitattributes invariants are satisfied without
+ * diverging the graph.
+ *
+ * Safe to call on a repo that is already aligned — the early-return after
+ * merge-base check makes it a no-op in that case.
+ */
+async function alignWithRemote(git: SimpleGit): Promise<void> {
+  const remotes = await git.getRemotes(true);
+  if (!remotes.some((r) => r.name === "origin")) return;
+
+  try {
+    await git.fetch("origin");
+  } catch {
+    // Origin unreachable (offline); skip — pull will classify as offline.
+    return;
+  }
+
+  // Check whether origin/main exists.
+  let remoteHead: string;
+  try {
+    remoteHead = (await git.raw(["rev-parse", "origin/main"])).trim();
+  } catch {
+    // origin/main not found — bare repo is empty; nothing to align with.
+    return;
+  }
+
+  // Check whether the local HEAD and origin/main share a common ancestor.
+  let localHead: string | null;
+  try {
+    localHead = (await git.raw(["rev-parse", "HEAD"])).trim();
+  } catch {
+    // No local commits yet — reset directly to remote.
+    await git.raw(["checkout", "-b", "main", "--track", "origin/main"]);
+    return;
+  }
+
+  try {
+    await git.raw(["merge-base", "--is-ancestor", remoteHead, localHead]);
+    // remote is an ancestor of local — already aligned or local is ahead.
+    return;
+  } catch {
+    // Not an ancestor — check the other direction.
+  }
+
+  try {
+    await git.raw(["merge-base", "--is-ancestor", localHead, remoteHead]);
+    // local is behind remote — fast-forward.
+    await git.raw(["reset", "--hard", remoteHead]);
+    await git.raw(["branch", "--set-upstream-to=origin/main", "main"]);
+    return;
+  } catch {
+    // Neither is an ancestor of the other — unrelated histories.
+    // Reset local to remote HEAD so the histories are unified. The
+    // bootstrap files (.gitignore, .gitattributes) are already
+    // present in origin because the first vault committed them, so no
+    // re-commit is needed.
+    await git.raw(["reset", "--hard", remoteHead]);
+    await git.raw(["branch", "--set-upstream-to=origin/main", "main"]);
   }
 }
 

--- a/src/backend/vault/index.ts
+++ b/src/backend/vault/index.ts
@@ -12,7 +12,11 @@ import { VaultVectorIndex } from "./vector/lance-index.js";
 import { ensureVaultGit } from "./git/bootstrap.js";
 import { GitOpsImpl } from "./git/git-ops.js";
 import type { GitOps } from "./git/types.js";
-import type { BackendName, StorageBackend } from "../types.js";
+import type {
+  BackendName,
+  StorageBackend,
+  BackendSessionStartMeta,
+} from "../types.js";
 import type {
   AuditRepository,
   CommentRepository,
@@ -109,5 +113,9 @@ export class VaultBackend implements StorageBackend {
 
   async close(): Promise<void> {
     await this.vectorIndex.close();
+  }
+
+  async sessionStart(): Promise<BackendSessionStartMeta> {
+    return {};
   }
 }

--- a/src/backend/vault/index.ts
+++ b/src/backend/vault/index.ts
@@ -17,11 +17,11 @@ import { ensureRemote } from "./git/remote.js";
 import { reconcileDirty } from "./git/reconcile.js";
 import { syncFromRemote } from "./git/pull.js";
 import { PushQueue } from "./git/push-queue.js";
+import { alignWithRemote } from "./git/align.js";
 import type { GitOps } from "./git/types.js";
 import { runSessionStart } from "./session-start.js";
 import type { Embedder } from "./session-start.js";
 import { createEmbeddingProvider } from "../../providers/embedding/index.js";
-import { logger } from "../../utils/logger.js";
 import type {
   BackendName,
   StorageBackend,
@@ -135,12 +135,11 @@ export class VaultBackend implements StorageBackend {
         await git.raw(["push", "--set-upstream", "origin", "HEAD:main"]);
       },
       countUnpushed: async () => {
-        try {
-          const out = await git.raw(["rev-list", "--count", "@{u}..HEAD"]);
-          return Number(out.trim()) || 0;
-        } catch {
-          return 0;
-        }
+        // Throws when @{u} is not yet configured (pre-first-push). The
+        // PushQueue.unpushedCommits() wrapper logs and returns 0 for that
+        // and any other failure.
+        const out = await git.raw(["rev-list", "--count", "@{u}..HEAD"]);
+        return Number(out.trim()) || 0;
       },
     });
 
@@ -191,94 +190,6 @@ export class VaultBackend implements StorageBackend {
         this.vaultMemoryRepo.syncPaths(paths);
       },
     });
-  }
-}
-
-/**
- * Aligns the local repo with origin/main when they have diverged or
- * when local is simply behind remote. Called once during VaultBackend
- * creation, before any push/pull logic runs.
- *
- * Behaviour by case:
- *
- * 1. No `origin` remote configured → no-op (local-only vault).
- * 2. Origin unreachable (fetch throws) → no-op; offline handling
- *    deferred to the PushQueue / syncFromRemote path.
- * 3. origin/main does not yet exist (empty bare repo) → no-op; the
- *    first push from this vault will create it.
- * 4. No local commits yet → checks out a new `main` branch tracking
- *    `origin/main` directly.
- * 5. origin/main is an ancestor of local HEAD (local is ahead or equal)
- *    → already aligned; no-op.
- * 6. local HEAD is an ancestor of origin/main (local is behind) →
- *    fast-forward: `reset --hard <remoteHead>` then
- *    `branch --set-upstream-to=origin/main main`.
- * 7. Unrelated histories (fresh second-vault bootstrap produced a
- *    divergent root commit) → same as case 6: `reset --hard <remoteHead>`
- *    then set upstream. The bootstrap files (.gitignore, .gitattributes)
- *    are already present in origin because the first vault committed them,
- *    so no re-commit is needed. This is safe only at init time (before
- *    any user data has been written to the local repo).
- *
- * Note: this function does NOT produce a merge commit. In all write cases
- * it performs a hard reset to `origin/main` and sets the upstream
- * tracking branch.
- */
-async function alignWithRemote(git: SimpleGit): Promise<void> {
-  const remotes = await git.getRemotes(true);
-  if (!remotes.some((r) => r.name === "origin")) return;
-
-  try {
-    await git.fetch("origin");
-  } catch {
-    // Origin unreachable (offline); skip — pull will classify as offline.
-    return;
-  }
-
-  // Check whether origin/main exists.
-  let remoteHead: string;
-  try {
-    remoteHead = (await git.raw(["rev-parse", "origin/main"])).trim();
-  } catch {
-    // origin/main not found — bare repo is empty; nothing to align with.
-    return;
-  }
-
-  // Check whether the local HEAD and origin/main share a common ancestor.
-  let localHead: string | null;
-  try {
-    localHead = (await git.raw(["rev-parse", "HEAD"])).trim();
-  } catch {
-    // No local commits yet — reset directly to remote.
-    await git.raw(["checkout", "-b", "main", "--track", "origin/main"]);
-    return;
-  }
-
-  try {
-    await git.raw(["merge-base", "--is-ancestor", remoteHead, localHead]);
-    // remote is an ancestor of local — already aligned or local is ahead.
-    return;
-  } catch {
-    // Not an ancestor — check the other direction.
-  }
-
-  try {
-    await git.raw(["merge-base", "--is-ancestor", localHead, remoteHead]);
-    // local is behind remote — fast-forward.
-    await git.raw(["reset", "--hard", remoteHead]);
-    await git.raw(["branch", "--set-upstream-to=origin/main", "main"]);
-    return;
-  } catch {
-    // Neither is an ancestor of the other — unrelated histories.
-    // Reset local to remote HEAD so the histories are unified. The
-    // bootstrap files (.gitignore, .gitattributes) are already
-    // present in origin because the first vault committed them, so no
-    // re-commit is needed.
-    logger.error(
-      `vault: unrelated-history reset — local HEAD ${localHead} has no common ancestor with origin/main ${remoteHead}; discarding local history. This is safe only for fresh-clone bootstrap; if you have local work, abort and investigate AGENT_BRAIN_VAULT_REMOTE_URL.`,
-    );
-    await git.raw(["reset", "--hard", remoteHead]);
-    await git.raw(["branch", "--set-upstream-to=origin/main", "main"]);
   }
 }
 

--- a/src/backend/vault/repositories/memory-repository.ts
+++ b/src/backend/vault/repositories/memory-repository.ts
@@ -188,6 +188,28 @@ export class VaultMemoryRepository implements MemoryRepository {
     return saved.memory;
   }
 
+  /**
+   * Ingests a list of git-relative paths that arrived on disk via an
+   * external mutation (e.g. `git pull`). Entries matching the three
+   * memory directory layouts are added or updated in the in-memory
+   * index so subsequent `findById` calls resolve correctly without a
+   * full process restart.
+   *
+   * Non-memory paths are silently skipped.
+   */
+  syncPaths(paths: string[]): void {
+    for (const rel of paths) {
+      const loc = inferScopeFromPath(rel);
+      if (loc === null) continue;
+      this.index.set(loc.id, {
+        path: rel,
+        scope: loc.scope,
+        workspaceId: loc.workspaceId,
+        userId: loc.userId,
+      });
+    }
+  }
+
   async findById(id: string): Promise<Memory | null> {
     const entry = this.index.get(id);
     if (!entry) return null;

--- a/src/backend/vault/repositories/memory-repository.ts
+++ b/src/backend/vault/repositories/memory-repository.ts
@@ -1,5 +1,6 @@
 import { dirname, join } from "node:path";
 import { mkdir, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import type {
   Memory,
   MemoryScope,
@@ -188,25 +189,25 @@ export class VaultMemoryRepository implements MemoryRepository {
     return saved.memory;
   }
 
-  /**
-   * Ingests a list of git-relative paths that arrived on disk via an
-   * external mutation (e.g. `git pull`). Entries matching the three
-   * memory directory layouts are added or updated in the in-memory
-   * index so subsequent `findById` calls resolve correctly without a
-   * full process restart.
-   *
-   * Non-memory paths are silently skipped.
-   */
+  // Reconciles the in-memory index with paths that changed on disk via
+  // `git pull`. Adds/updates entries that exist on disk; removes entries
+  // whose file has been deleted — otherwise a stale index entry makes
+  // findById() throw ENOENT on read instead of returning null.
   syncPaths(paths: string[]): void {
     for (const rel of paths) {
       const loc = inferScopeFromPath(rel);
       if (loc === null) continue;
-      this.index.set(loc.id, {
-        path: rel,
-        scope: loc.scope,
-        workspaceId: loc.workspaceId,
-        userId: loc.userId,
-      });
+      const abs = join(this.cfg.root, rel);
+      if (existsSync(abs)) {
+        this.index.set(loc.id, {
+          path: rel,
+          scope: loc.scope,
+          workspaceId: loc.workspaceId,
+          userId: loc.userId,
+        });
+      } else {
+        this.index.delete(loc.id);
+      }
     }
   }
 

--- a/src/backend/vault/session-start.ts
+++ b/src/backend/vault/session-start.ts
@@ -1,0 +1,98 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+import { parseMemoryFile } from "./parser/memory-parser.js";
+import type { VaultVectorIndex, IndexRow } from "./vector/lance-index.js";
+import { logger } from "../../utils/logger.js";
+
+const MEMORY_PATH_RE =
+  /^(workspaces\/[^/]+\/memories\/|project\/memories\/|users\/[^/]+\/memories\/).+\.md$/;
+
+export type Embedder = (text: string) => Promise<number[]>;
+
+export interface DiffReindexConfig {
+  paths: string[];
+  root: string;
+  vectorIndex: VaultVectorIndex;
+  embed: Embedder;
+}
+
+export interface DiffReindexResult {
+  parseErrors: number;
+}
+
+export async function diffReindex(
+  cfg: DiffReindexConfig,
+): Promise<DiffReindexResult> {
+  let parseErrors = 0;
+  for (const rel of cfg.paths) {
+    if (!MEMORY_PATH_RE.test(rel)) continue;
+    const abs = join(cfg.root, rel);
+    let raw: string;
+    try {
+      raw = await readFile(abs, "utf8");
+    } catch (err) {
+      logger.debug(
+        `diffReindex: skip unreadable ${rel}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      continue;
+    }
+    let parsed: ReturnType<typeof parseMemoryFile>;
+    try {
+      parsed = parseMemoryFile(raw);
+    } catch {
+      parseErrors += 1;
+      continue;
+    }
+    const { memory } = parsed;
+    const newHash = sha256(memory.content);
+    const existingHash = await cfg.vectorIndex.getContentHash(memory.id);
+
+    if (existingHash === newHash) {
+      // Metadata-only refresh: preserve the existing vector.
+      await cfg.vectorIndex.upsertMetaOnly({
+        id: memory.id,
+        project_id: memory.project_id,
+        workspace_id: memory.workspace_id,
+        scope: memory.scope,
+        author: memory.author,
+        title: memory.title,
+        archived: memory.archived_at !== null,
+      });
+      continue;
+    }
+    const embedding = await cfg.embed(memory.content);
+    await cfg.vectorIndex.upsert([buildRow(memory, newHash, embedding)]);
+  }
+  return { parseErrors };
+}
+
+function sha256(s: string): string {
+  return createHash("sha256").update(s).digest("hex");
+}
+
+function buildRow(
+  memory: {
+    id: string;
+    project_id: string;
+    workspace_id: string | null;
+    scope: "workspace" | "user" | "project";
+    author: string;
+    title: string;
+    archived_at: Date | null;
+  },
+  contentHash: string,
+  embedding: number[],
+): IndexRow {
+  return {
+    id: memory.id,
+    project_id: memory.project_id,
+    workspace_id: memory.workspace_id,
+    scope: memory.scope,
+    author: memory.author,
+    title: memory.title,
+    archived: memory.archived_at !== null,
+    content_hash: contentHash,
+    vector: embedding,
+  };
+}

--- a/src/backend/vault/session-start.ts
+++ b/src/backend/vault/session-start.ts
@@ -3,6 +3,8 @@ import { join } from "node:path";
 import { createHash } from "node:crypto";
 import { parseMemoryFile } from "./parser/memory-parser.js";
 import type { VaultVectorIndex, IndexRow } from "./vector/lance-index.js";
+import type { BackendSessionStartMeta } from "../types.js";
+import type { SyncResult } from "./git/pull.js";
 import { logger } from "../../utils/logger.js";
 
 const MEMORY_PATH_RE =
@@ -95,4 +97,44 @@ function buildRow(
     content_hash: contentHash,
     vector: embedding,
   };
+}
+
+export interface PushQueueHandle {
+  unpushedCommits(): Promise<number>;
+  request(): void;
+}
+
+export interface RunSessionStartConfig {
+  root: string;
+  vectorIndex: VaultVectorIndex;
+  embed: Embedder;
+  syncFromRemote: () => Promise<SyncResult>;
+  pushQueue: PushQueueHandle;
+}
+
+export async function runSessionStart(
+  cfg: RunSessionStartConfig,
+): Promise<BackendSessionStartMeta> {
+  const meta: BackendSessionStartMeta = {};
+  const pull = await cfg.syncFromRemote();
+  if (pull.offline) meta.offline = true;
+  if (pull.conflict) meta.pull_conflict = true;
+
+  let parseErrors = 0;
+  if (pull.changedPaths.length > 0) {
+    const result = await diffReindex({
+      paths: pull.changedPaths,
+      root: cfg.root,
+      vectorIndex: cfg.vectorIndex,
+      embed: cfg.embed,
+    });
+    parseErrors = result.parseErrors;
+  }
+  if (parseErrors > 0) meta.parse_errors = parseErrors;
+
+  const unpushed = await cfg.pushQueue.unpushedCommits();
+  if (unpushed > 0) meta.unpushed_commits = unpushed;
+  cfg.pushQueue.request(); // kick drain
+
+  return meta;
 }

--- a/src/backend/vault/session-start.ts
+++ b/src/backend/vault/session-start.ts
@@ -110,6 +110,13 @@ export interface RunSessionStartConfig {
   embed: Embedder;
   syncFromRemote: () => Promise<SyncResult>;
   pushQueue: PushQueueHandle;
+  /**
+   * Called with the list of git-relative paths that changed during a
+   * pull. Allows callers (e.g. VaultBackend) to refresh derived in-
+   * memory indexes (e.g. VaultMemoryRepository path map) so lookups
+   * that run after sessionStart see the newly-pulled files.
+   */
+  onChangedPaths?: (paths: string[]) => void;
 }
 
 export async function runSessionStart(
@@ -122,6 +129,9 @@ export async function runSessionStart(
 
   let parseErrors = 0;
   if (pull.changedPaths.length > 0) {
+    // Refresh the caller's in-memory path map before reindexing so
+    // that findById calls issued after sessionStart resolve correctly.
+    cfg.onChangedPaths?.(pull.changedPaths);
     const result = await diffReindex({
       paths: pull.changedPaths,
       root: cfg.root,

--- a/src/backend/vault/session-start.ts
+++ b/src/backend/vault/session-start.ts
@@ -2,13 +2,11 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
 import { parseMemoryFile } from "./parser/memory-parser.js";
+import { inferScopeFromPath } from "./io/paths.js";
 import type { VaultVectorIndex, IndexRow } from "./vector/lance-index.js";
 import type { BackendSessionStartMeta } from "../types.js";
 import type { SyncResult } from "./git/pull.js";
 import { logger } from "../../utils/logger.js";
-
-const MEMORY_PATH_RE =
-  /^(workspaces\/[^/]+\/memories\/|project\/memories\/|users\/[^/]+\/memories\/).+\.md$/;
 
 export type Embedder = (text: string) => Promise<number[]>;
 
@@ -28,21 +26,28 @@ export async function diffReindex(
 ): Promise<DiffReindexResult> {
   let parseErrors = 0;
   for (const rel of cfg.paths) {
-    if (!MEMORY_PATH_RE.test(rel)) continue;
+    if (inferScopeFromPath(rel) === null) continue;
     const abs = join(cfg.root, rel);
     let raw: string;
     try {
       raw = await readFile(abs, "utf8");
     } catch (err) {
-      logger.debug(
-        `diffReindex: skip unreadable ${rel}: ${err instanceof Error ? err.message : String(err)}`,
-      );
+      const msg = err instanceof Error ? err.message : String(err);
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      if (code === "ENOENT") {
+        logger.debug(`diffReindex: skip missing ${rel}: ${msg}`);
+      } else {
+        logger.warn(`diffReindex: unreadable ${rel}: ${msg}`);
+      }
       continue;
     }
     let parsed: ReturnType<typeof parseMemoryFile>;
     try {
       parsed = parseMemoryFile(raw);
-    } catch {
+    } catch (err) {
+      logger.warn(
+        `diffReindex: parse failed for ${rel}: ${err instanceof Error ? err.message : String(err)}`,
+      );
       parseErrors += 1;
       continue;
     }
@@ -101,6 +106,7 @@ function buildRow(
 
 export interface PushQueueHandle {
   unpushedCommits(): Promise<number>;
+  lastPushError?(): string | null;
   request(): void;
 }
 
@@ -110,12 +116,7 @@ export interface RunSessionStartConfig {
   embed: Embedder;
   syncFromRemote: () => Promise<SyncResult>;
   pushQueue: PushQueueHandle;
-  /**
-   * Called with the list of git-relative paths that changed during a
-   * pull. Allows callers (e.g. VaultBackend) to refresh derived in-
-   * memory indexes (e.g. VaultMemoryRepository path map) so lookups
-   * that run after sessionStart see the newly-pulled files.
-   */
+  // Ordering matters: callback runs before reindex so findById resolves.
   onChangedPaths?: (paths: string[]) => void;
 }
 
@@ -124,26 +125,37 @@ export async function runSessionStart(
 ): Promise<BackendSessionStartMeta> {
   const meta: BackendSessionStartMeta = {};
   const pull = await cfg.syncFromRemote();
-  if (pull.offline) meta.offline = true;
-  if (pull.conflict) meta.pull_conflict = true;
 
   let parseErrors = 0;
-  if (pull.changedPaths.length > 0) {
-    // Refresh the caller's in-memory path map before reindexing so
-    // that findById calls issued after sessionStart resolve correctly.
-    cfg.onChangedPaths?.(pull.changedPaths);
-    const result = await diffReindex({
-      paths: pull.changedPaths,
-      root: cfg.root,
-      vectorIndex: cfg.vectorIndex,
-      embed: cfg.embed,
-    });
-    parseErrors = result.parseErrors;
+  switch (pull.kind) {
+    case "offline":
+      meta.offline = true;
+      break;
+    case "conflict":
+      meta.pull_conflict = true;
+      if (pull.rebaseWedged) meta.rebase_wedged = true;
+      break;
+    case "ok":
+      if (pull.changedPaths.length > 0) {
+        cfg.onChangedPaths?.(pull.changedPaths);
+        const result = await diffReindex({
+          paths: pull.changedPaths,
+          root: cfg.root,
+          vectorIndex: cfg.vectorIndex,
+          embed: cfg.embed,
+        });
+        parseErrors = result.parseErrors;
+      }
+      break;
   }
   if (parseErrors > 0) meta.parse_errors = parseErrors;
 
   const unpushed = await cfg.pushQueue.unpushedCommits();
   if (unpushed > 0) meta.unpushed_commits = unpushed;
+  if (unpushed > 0) {
+    const lastErr = cfg.pushQueue.lastPushError?.();
+    if (lastErr) meta.last_push_error = lastErr;
+  }
   cfg.pushQueue.request(); // kick drain
 
   return meta;

--- a/src/backend/vault/vector/lance-index.ts
+++ b/src/backend/vault/vector/lance-index.ts
@@ -195,6 +195,17 @@ export class VaultVectorIndex {
     return res.rowsUpdated;
   }
 
+  async getContentHash(id: string): Promise<string | null> {
+    const rows = (await this.table
+      .query()
+      .where(`id = ${sqlStr(id)}`)
+      .select(["content_hash"])
+      .limit(1)
+      .toArray()) as Array<Record<string, unknown>>;
+    if (rows.length === 0) return null;
+    return String(rows[0].content_hash);
+  }
+
   async upsertMetaOnly(
     meta: Omit<IndexRow, "content_hash" | "vector">,
   ): Promise<number> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -108,6 +108,7 @@ async function main() {
     flagService,
     config.consolidationMaxFlagsPerSession,
     relationshipService,
+    backend,
   );
 
   // Always create ConsolidationService (used by both scheduler and MCP tool)

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -861,7 +861,7 @@ export class MemoryService {
     // D-34: Auto-create workspace
     await this.workspaceRepo.findOrCreate(workspaceId);
 
-    // Capture backend-specific sync state (vault: pull/push/parse status).
+    // Fields merge into envelope meta — see BackendSessionStartMeta.
     const backendMeta = this.backend ? await this.backend.sessionStart() : {};
 
     // Phase 4: Generate session_id and create session record for budget tracking (D-18)
@@ -1080,23 +1080,9 @@ export class MemoryService {
 
     const timing = Date.now() - start;
 
-    // Merge backend-specific sync state into envelope meta. Zero/false
-    // values are stripped so clients treat absence as healthy.
-    const backendMetaFields: BackendSessionStartMeta = {};
-    if (backendMeta.offline) backendMetaFields.offline = true;
-    if (backendMeta.pull_conflict) backendMetaFields.pull_conflict = true;
-    if (
-      typeof backendMeta.unpushed_commits === "number" &&
-      backendMeta.unpushed_commits > 0
-    ) {
-      backendMetaFields.unpushed_commits = backendMeta.unpushed_commits;
-    }
-    if (
-      typeof backendMeta.parse_errors === "number" &&
-      backendMeta.parse_errors > 0
-    ) {
-      backendMetaFields.parse_errors = backendMeta.parse_errors;
-    }
+    // Backend contract already strips zero/false before returning, so
+    // spreading preserves the "absent = healthy" invariant.
+    const backendMetaFields: BackendSessionStartMeta = { ...backendMeta };
 
     return {
       data: result.data,

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -17,7 +17,10 @@ import type {
 import { toSummary, toDetail } from "../types/memory.js";
 import type { Envelope } from "../types/envelope.js";
 import type { EmbeddingProvider } from "../providers/embedding/types.js";
-import type { StorageBackend } from "../backend/types.js";
+import type {
+  StorageBackend,
+  BackendSessionStartMeta,
+} from "../backend/types.js";
 import type {
   MemoryRepository,
   WorkspaceRepository,
@@ -858,7 +861,7 @@ export class MemoryService {
     // D-34: Auto-create workspace
     await this.workspaceRepo.findOrCreate(workspaceId);
 
-    // Phase 4b: Capture backend-specific sync state (vault: pull/push/parse status)
+    // Capture backend-specific sync state (vault: pull/push/parse status).
     const backendMeta = this.backend ? await this.backend.sessionStart() : {};
 
     // Phase 4: Generate session_id and create session record for budget tracking (D-18)
@@ -1077,13 +1080,9 @@ export class MemoryService {
 
     const timing = Date.now() - start;
 
-    // Phase 4b: Merge backend-specific sync state into envelope meta
-    const backendMetaFields: {
-      offline?: true;
-      unpushed_commits?: number;
-      pull_conflict?: true;
-      parse_errors?: number;
-    } = {};
+    // Merge backend-specific sync state into envelope meta. Zero/false
+    // values are stripped so clients treat absence as healthy.
+    const backendMetaFields: BackendSessionStartMeta = {};
     if (backendMeta.offline) backendMetaFields.offline = true;
     if (backendMeta.pull_conflict) backendMetaFields.pull_conflict = true;
     if (

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -17,6 +17,7 @@ import type {
 import { toSummary, toDetail } from "../types/memory.js";
 import type { Envelope } from "../types/envelope.js";
 import type { EmbeddingProvider } from "../providers/embedding/types.js";
+import type { StorageBackend } from "../backend/types.js";
 import type {
   MemoryRepository,
   WorkspaceRepository,
@@ -63,6 +64,7 @@ export class MemoryService {
     private readonly flagService?: FlagService,
     private readonly maxFlagsPerSession: number = 5,
     private readonly relationshipService?: RelationshipService,
+    private readonly backend?: StorageBackend,
   ) {}
 
   // D-12: Descriptive error for mutations
@@ -856,6 +858,9 @@ export class MemoryService {
     // D-34: Auto-create workspace
     await this.workspaceRepo.findOrCreate(workspaceId);
 
+    // Phase 4b: Capture backend-specific sync state (vault: pull/push/parse status)
+    const backendMeta = this.backend ? await this.backend.sessionStart() : {};
+
     // Phase 4: Generate session_id and create session record for budget tracking (D-18)
     const sessionId = generateId();
     await this.sessionLifecycleRepo?.createSession(
@@ -1071,6 +1076,29 @@ export class MemoryService {
     }
 
     const timing = Date.now() - start;
+
+    // Phase 4b: Merge backend-specific sync state into envelope meta
+    const backendMetaFields: {
+      offline?: true;
+      unpushed_commits?: number;
+      pull_conflict?: true;
+      parse_errors?: number;
+    } = {};
+    if (backendMeta.offline) backendMetaFields.offline = true;
+    if (backendMeta.pull_conflict) backendMetaFields.pull_conflict = true;
+    if (
+      typeof backendMeta.unpushed_commits === "number" &&
+      backendMeta.unpushed_commits > 0
+    ) {
+      backendMetaFields.unpushed_commits = backendMeta.unpushed_commits;
+    }
+    if (
+      typeof backendMeta.parse_errors === "number" &&
+      backendMeta.parse_errors > 0
+    ) {
+      backendMetaFields.parse_errors = backendMeta.parse_errors;
+    }
+
     return {
       data: result.data,
       meta: {
@@ -1080,6 +1108,7 @@ export class MemoryService {
         session_id: sessionId,
         flags: flagsData,
         relationships: relationshipsData,
+        ...backendMetaFields,
       },
     };
   }

--- a/src/types/envelope.ts
+++ b/src/types/envelope.ts
@@ -1,41 +1,42 @@
 import type { RelationshipSummary } from "./relationship.js";
 import type { FlagResponse } from "./flag.js";
+import type { BackendSessionStartMeta } from "../backend/types.js";
 
 // D-02: Envelope response structure
+//
+// Backend-contributed sync fields (offline, unpushed_commits, pull_conflict,
+// parse_errors) are defined once on BackendSessionStartMeta and intersected
+// in here so the envelope never drifts from the backend contract.
 export interface Envelope<T> {
   data: T;
-  meta: {
-    count?: number;
-    timing?: number; // ms
-    cursor?: string;
-    has_more?: boolean;
-    team_activity?: {
-      // D-29: session_start only
-      new_memories: number;
-      updated_memories: number;
-      commented_memories: number;
-      since: string; // ISO timestamp
-    };
-    comment_count?: number; // D-67: memory_comment response
-    session_id?: string; // Phase 4: returned from session_start
-    budget?: {
-      // Phase 4: returned from memory_create for autonomous writes
-      used: number;
-      limit: number;
-      exceeded: boolean;
-    };
-    flags?: FlagResponse[];
-    relationships?: RelationshipSummary[];
-    omitted?: string[]; // IDs requested but not returned (inaccessible/not found)
-    project_truncated?: boolean; // session_start only: true when project-scoped memories exceeded project_limit
-    project_scope_status?: "ok" | "failed"; // session_start only: "failed" when listProjectScoped threw and ranked results were returned without project-scoped memories
-    /** session_start only: backend is offline (vault: no network / git pull skipped) */
-    offline?: true;
-    /** session_start only: number of local commits not yet pushed to remote */
-    unpushed_commits?: number;
-    /** session_start only: a git rebase conflict was detected during pull */
-    pull_conflict?: true;
-    /** session_start only: number of vault YAML files that failed to parse */
-    parse_errors?: number;
+  meta: EnvelopeMeta;
+}
+
+export type EnvelopeMeta = EnvelopeCoreMeta & BackendSessionStartMeta;
+
+interface EnvelopeCoreMeta {
+  count?: number;
+  timing?: number; // ms
+  cursor?: string;
+  has_more?: boolean;
+  team_activity?: {
+    // D-29: session_start only
+    new_memories: number;
+    updated_memories: number;
+    commented_memories: number;
+    since: string; // ISO timestamp
   };
+  comment_count?: number; // D-67: memory_comment response
+  session_id?: string; // returned from session_start
+  budget?: {
+    // returned from memory_create for autonomous writes
+    used: number;
+    limit: number;
+    exceeded: boolean;
+  };
+  flags?: FlagResponse[];
+  relationships?: RelationshipSummary[];
+  omitted?: string[]; // IDs requested but not returned (inaccessible/not found)
+  project_truncated?: boolean; // session_start only: true when project-scoped memories exceeded project_limit
+  project_scope_status?: "ok" | "failed"; // session_start only: "failed" when listProjectScoped threw and ranked results were returned without project-scoped memories
 }

--- a/src/types/envelope.ts
+++ b/src/types/envelope.ts
@@ -3,10 +3,6 @@ import type { FlagResponse } from "./flag.js";
 import type { BackendSessionStartMeta } from "../backend/types.js";
 
 // D-02: Envelope response structure
-//
-// Backend-contributed sync fields (offline, unpushed_commits, pull_conflict,
-// parse_errors) are defined once on BackendSessionStartMeta and intersected
-// in here so the envelope never drifts from the backend contract.
 export interface Envelope<T> {
   data: T;
   meta: EnvelopeMeta;

--- a/src/types/envelope.ts
+++ b/src/types/envelope.ts
@@ -29,5 +29,13 @@ export interface Envelope<T> {
     omitted?: string[]; // IDs requested but not returned (inaccessible/not found)
     project_truncated?: boolean; // session_start only: true when project-scoped memories exceeded project_limit
     project_scope_status?: "ok" | "failed"; // session_start only: "failed" when listProjectScoped threw and ranked results were returned without project-scoped memories
+    /** session_start only: backend is offline (vault: no network / git pull skipped) */
+    offline?: true;
+    /** session_start only: number of local commits not yet pushed to remote */
+    unpushed_commits?: number;
+    /** session_start only: a git rebase conflict was detected during pull */
+    pull_conflict?: true;
+    /** session_start only: number of vault YAML files that failed to parse */
+    parse_errors?: number;
   };
 }

--- a/tests/contract/backend.test.ts
+++ b/tests/contract/backend.test.ts
@@ -199,4 +199,9 @@ describe.each(cases)("StorageBackend assembly — $name", (c) => {
     const second = await backend.sessionRepo.upsert("u1", "p1", "ws1");
     expect(second).toBeInstanceOf(Date);
   });
+
+  it("sessionStart returns empty meta", async () => {
+    const meta = await backend.sessionStart();
+    expect(meta).toEqual({});
+  });
 });

--- a/tests/contract/repositories/_git-helpers.ts
+++ b/tests/contract/repositories/_git-helpers.ts
@@ -1,3 +1,6 @@
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { simpleGit } from "simple-git";
 import { scrubGitEnv } from "../../../src/backend/vault/git/env.js";
 import type { Memory, MemoryScope } from "../../../src/types/memory.js";
@@ -48,4 +51,26 @@ export async function commitCount(root: string): Promise<number> {
 export async function lastCommitMessage(root: string): Promise<string> {
   const log = await simpleGit({ baseDir: root }).env(scrubGitEnv()).log();
   return `${log.latest?.message ?? ""}\n\n${log.latest?.body ?? ""}`;
+}
+
+export async function setupBareAndTwoVaults(): Promise<{
+  dir: string;
+  bare: string;
+  vaultA: string;
+  vaultB: string;
+  cleanup: () => Promise<void>;
+}> {
+  const dir = await mkdtemp(join(tmpdir(), "two-clone-"));
+  const bare = join(dir, "origin.git");
+  await mkdir(bare, { recursive: true });
+  await simpleGit().env(scrubGitEnv()).cwd(bare).init(true);
+  const vaultA = join(dir, "a");
+  const vaultB = join(dir, "b");
+  return {
+    dir,
+    bare,
+    vaultA,
+    vaultB,
+    cleanup: () => rm(dir, { recursive: true, force: true }),
+  };
 }

--- a/tests/contract/repositories/_git-helpers.ts
+++ b/tests/contract/repositories/_git-helpers.ts
@@ -64,6 +64,11 @@ export async function setupBareAndTwoVaults(): Promise<{
   const bare = join(dir, "origin.git");
   await mkdir(bare, { recursive: true });
   await simpleGit().env(scrubGitEnv()).cwd(bare).init(true);
+  // Pin bare HEAD to `main` so CI (no init.defaultBranch) matches local.
+  await simpleGit()
+    .env(scrubGitEnv())
+    .cwd(bare)
+    .raw(["symbolic-ref", "HEAD", "refs/heads/main"]);
   const vaultA = join(dir, "a");
   const vaultB = join(dir, "b");
   return {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -15,6 +15,10 @@ import { MockEmbeddingProvider } from "../src/providers/embedding/mock.js";
 import { config } from "../src/config.js";
 import { MemoryService } from "../src/services/memory-service.js";
 import type { Memory, CreateSkipResult } from "../src/types/memory.js";
+import type {
+  StorageBackend,
+  BackendSessionStartMeta,
+} from "../src/backend/types.js";
 import {
   memories,
   workspaces,
@@ -37,12 +41,29 @@ export function getTestDb(): Database {
   return db;
 }
 
+/**
+ * Minimal StorageBackend stub for unit/integration tests. Only implements
+ * sessionStart() — all repo fields are intentionally omitted because tests
+ * inject real repos directly. Override sessionStartMeta to control what
+ * backend.sessionStart() returns.
+ */
+export class StubBackend {
+  sessionStartMeta: BackendSessionStartMeta = {};
+
+  async sessionStart(): Promise<BackendSessionStartMeta> {
+    return this.sessionStartMeta;
+  }
+
+  async close(): Promise<void> {}
+}
+
 interface TestServiceOptions {
   auditService?: AuditService;
   flagService?: FlagService;
   withSessions?: boolean;
   maxFlagsPerSession?: number;
   relationshipService?: RelationshipService;
+  backend?: StorageBackend;
 }
 
 /** Configurable factory — accepts any combination of optional services */
@@ -71,6 +92,7 @@ export function createTestServiceWith(
     options.flagService,
     options.maxFlagsPerSession,
     options.relationshipService,
+    options.backend,
   );
 }
 

--- a/tests/integration/session-start.test.ts
+++ b/tests/integration/session-start.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 import {
   createTestService,
+  createTestServiceWith,
+  StubBackend,
   getTestDb,
   truncateAll,
   closeDb,
   assertMemory,
 } from "../helpers.js";
 import type { MemoryService } from "../../src/services/memory-service.js";
+import type { StorageBackend } from "../../src/backend/types.js";
 import { ValidationError } from "../../src/utils/errors.js";
 import { memories } from "../../src/db/schema.js";
 import { config } from "../../src/config.js";
@@ -621,5 +624,52 @@ describe("memory_session_start integration tests", () => {
     expect(result.meta).toHaveProperty("timing");
     expect(result.meta.count).toBe(1);
     expect(result.meta.timing).toBeTypeOf("number");
+  });
+
+  it("envelope meta includes backend fields when backend.sessionStart returns non-empty", async () => {
+    const stubBackend = new StubBackend();
+    stubBackend.sessionStartMeta = {
+      offline: true,
+      unpushed_commits: 2,
+      parse_errors: 1,
+    };
+    const svc = createTestServiceWith({
+      backend: stubBackend as unknown as StorageBackend,
+    });
+
+    const result = await svc.sessionStart("test-project", "alice");
+
+    expect(result.meta.offline).toBe(true);
+    expect(result.meta.unpushed_commits).toBe(2);
+    expect(result.meta.parse_errors).toBe(1);
+    expect(result.meta.pull_conflict).toBeUndefined();
+  });
+
+  it("envelope meta is unchanged when backend.sessionStart returns empty (pg-style)", async () => {
+    const stubBackend = new StubBackend();
+    stubBackend.sessionStartMeta = {}; // pg returns {}
+    const svc = createTestServiceWith({
+      backend: stubBackend as unknown as StorageBackend,
+    });
+
+    const result = await svc.sessionStart("test-project", "alice");
+
+    expect(result.meta.offline).toBeUndefined();
+    expect(result.meta.pull_conflict).toBeUndefined();
+    expect(result.meta.unpushed_commits).toBeUndefined();
+    expect(result.meta.parse_errors).toBeUndefined();
+  });
+
+  it("zero-value unpushed_commits and parse_errors are not merged into meta", async () => {
+    const stubBackend = new StubBackend();
+    stubBackend.sessionStartMeta = { unpushed_commits: 0, parse_errors: 0 };
+    const svc = createTestServiceWith({
+      backend: stubBackend as unknown as StorageBackend,
+    });
+
+    const result = await svc.sessionStart("test-project", "alice");
+
+    expect(result.meta.unpushed_commits).toBeUndefined();
+    expect(result.meta.parse_errors).toBeUndefined();
   });
 });

--- a/tests/integration/vault/two-clone-sync.test.ts
+++ b/tests/integration/vault/two-clone-sync.test.ts
@@ -9,6 +9,30 @@ import {
 import { VaultBackend } from "../../../src/backend/vault/index.js";
 import { scrubGitEnv } from "../../../src/backend/vault/git/env.js";
 
+/**
+ * Polls until `@{u}` resolves AND `@{u}..HEAD` is empty, meaning at
+ * least one push has landed and there are no further unpushed commits.
+ * Unlike the indirect sessionStart meta signal, this directly checks
+ * what we care about: upstream tracking is configured AND all commits
+ * are pushed.
+ */
+async function waitForPushSettled(root: string): Promise<void> {
+  const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+  for (let i = 0; i < 100; i++) {
+    try {
+      await git.raw(["rev-parse", "@{u}"]);
+      const out = await git.raw(["rev-list", "--count", "@{u}..HEAD"]);
+      if (Number(out.trim()) === 0) return;
+    } catch {
+      // @{u} not yet set — first push hasn't landed yet. Keep polling.
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(
+    "timed out waiting for push to settle (@{u} set + 0 unpushed)",
+  );
+}
+
 const DIMS = 768;
 
 function fakeEmbed(): (text: string) => Promise<number[]> {
@@ -29,15 +53,6 @@ async function createBackend(
   });
 }
 
-async function waitForUnpushedZero(backend: VaultBackend): Promise<void> {
-  for (let i = 0; i < 50; i++) {
-    const meta = await backend.sessionStart();
-    if (!meta.unpushed_commits || meta.unpushed_commits === 0) return;
-    await new Promise((r) => setTimeout(r, 50));
-  }
-  throw new Error("timed out waiting for unpushed_commits=0");
-}
-
 describe("vault two-clone sync", () => {
   it("write on A is visible on B after A pushes and B session-starts", async () => {
     const { bare, vaultA, vaultB, cleanup } = await setupBareAndTwoVaults();
@@ -45,7 +60,7 @@ describe("vault two-clone sync", () => {
       const a = await createBackend(vaultA, bare);
       // Seed first commit so bare repo has `main` branch.
       await a.memoryRepo.create(makeMemory("m1"));
-      await waitForUnpushedZero(a);
+      await waitForPushSettled(vaultA);
 
       const b = await createBackend(vaultB, bare);
       const meta = await b.sessionStart();
@@ -67,18 +82,18 @@ describe("vault two-clone sync", () => {
     try {
       const a = await createBackend(vaultA, bare);
       await a.memoryRepo.create(makeMemory("seed"));
-      await waitForUnpushedZero(a);
+      await waitForPushSettled(vaultA);
 
       const b = await createBackend(vaultB, bare);
       await b.sessionStart();
 
       await a.memoryRepo.create(makeMemory("from-a"));
       await b.memoryRepo.create(makeMemory("from-b"));
-      await waitForUnpushedZero(a);
+      await waitForPushSettled(vaultA);
 
       const bMeta = await b.sessionStart();
       expect(bMeta.pull_conflict).toBeUndefined();
-      await waitForUnpushedZero(b);
+      await waitForPushSettled(vaultB);
 
       const aMeta = await a.sessionStart();
       expect(aMeta.pull_conflict).toBeUndefined();
@@ -99,7 +114,7 @@ describe("vault two-clone sync", () => {
       const a = await createBackend(vaultA, bare);
       // Create a memory that will be the conflict target.
       await a.memoryRepo.create(makeMemory("target"));
-      await waitForUnpushedZero(a);
+      await waitForPushSettled(vaultA);
 
       const b = await createBackend(vaultB, bare);
       await b.sessionStart(); // pull A's target into B
@@ -141,7 +156,7 @@ describe("vault two-clone sync", () => {
     try {
       const a = await createBackend(vaultA, bare);
       await a.memoryRepo.create(makeMemory("seed"));
-      await waitForUnpushedZero(a);
+      await waitForPushSettled(vaultA);
       // Break origin. Retry a few times on ENOTEMPTY — macOS can hold
       // file descriptors on bare-repo pack files briefly after git ops.
       for (let attempt = 0; attempt < 5; attempt++) {

--- a/tests/integration/vault/two-clone-sync.test.ts
+++ b/tests/integration/vault/two-clone-sync.test.ts
@@ -151,6 +151,58 @@ describe("vault two-clone sync", () => {
     }
   }, 30_000);
 
+  it("diverged clone with shared ancestor refuses destructive reset at bootstrap", async () => {
+    const { bare, vaultA, vaultB, cleanup } = await setupBareAndTwoVaults();
+    try {
+      // A seeds the remote.
+      const a = await createBackend(vaultA, bare);
+      await a.memoryRepo.create(makeMemory("from-a"));
+      await waitForPushSettled(vaultA);
+      await a.close();
+
+      // Clone origin into vaultB so both share the bootstrap history,
+      // then diverge: add a local-only commit on B AND a new commit on A
+      // that doesn't exist in B.
+      await simpleGit().env(scrubGitEnv()).clone(bare, vaultB);
+      const gitB = simpleGit({ baseDir: vaultB }).env(scrubGitEnv());
+      await gitB.addConfig("user.email", "b@x", false, "local");
+      await gitB.addConfig("user.name", "b", false, "local");
+
+      // B commits an unpushed local memory.
+      const bLocalOnly = await VaultBackend.create({
+        root: vaultB,
+        embeddingDimensions: DIMS,
+        pushDebounceMs: 10,
+        pushBackoffMs: [50, 200],
+        embed: fakeEmbed(),
+      });
+      await bLocalOnly.memoryRepo.create(makeMemory("from-b-local"));
+      await bLocalOnly.close();
+
+      // A (a third clone) pushes a new commit so origin moves forward
+      // without B's commit.
+      const vaultC = vaultA + "-c";
+      await simpleGit().env(scrubGitEnv()).clone(bare, vaultC);
+      const c = await createBackend(vaultC, bare);
+      await c.memoryRepo.create(makeMemory("from-a-2"));
+      await waitForPushSettled(vaultC);
+      await c.close();
+
+      const headBefore = (await gitB.revparse(["HEAD"])).trim();
+
+      // B now diverges from origin (ahead=1, behind=1) with shared
+      // ancestor — align must throw rather than reset --hard.
+      await expect(createBackend(vaultB, bare)).rejects.toThrow(
+        /shared ancestor/i,
+      );
+
+      const headAfter = (await gitB.revparse(["HEAD"])).trim();
+      expect(headAfter).toBe(headBefore);
+    } finally {
+      await cleanup();
+    }
+  }, 30_000);
+
   it("offline mode: origin unreachable → meta.offline=true, writes still commit", async () => {
     const { bare, vaultA, cleanup } = await setupBareAndTwoVaults();
     try {

--- a/tests/integration/vault/two-clone-sync.test.ts
+++ b/tests/integration/vault/two-clone-sync.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from "vitest";
+import { rm, unlink } from "node:fs/promises";
+import { join } from "node:path";
+import { simpleGit } from "simple-git";
+import {
+  makeMemory,
+  setupBareAndTwoVaults,
+} from "../../contract/repositories/_git-helpers.js";
+import { VaultBackend } from "../../../src/backend/vault/index.js";
+import { scrubGitEnv } from "../../../src/backend/vault/git/env.js";
+
+const DIMS = 768;
+
+function fakeEmbed(): (text: string) => Promise<number[]> {
+  return async () => new Array(DIMS).fill(0.01);
+}
+
+async function createBackend(
+  root: string,
+  remoteUrl: string,
+): Promise<VaultBackend> {
+  return VaultBackend.create({
+    root,
+    embeddingDimensions: DIMS,
+    remoteUrl,
+    pushDebounceMs: 10,
+    pushBackoffMs: [50, 200],
+    embed: fakeEmbed(),
+  });
+}
+
+async function waitForUnpushedZero(backend: VaultBackend): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    const meta = await backend.sessionStart();
+    if (!meta.unpushed_commits || meta.unpushed_commits === 0) return;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error("timed out waiting for unpushed_commits=0");
+}
+
+describe("vault two-clone sync", () => {
+  it("write on A is visible on B after A pushes and B session-starts", async () => {
+    const { bare, vaultA, vaultB, cleanup } = await setupBareAndTwoVaults();
+    try {
+      const a = await createBackend(vaultA, bare);
+      // Seed first commit so bare repo has `main` branch.
+      await a.memoryRepo.create(makeMemory("m1"));
+      await waitForUnpushedZero(a);
+
+      const b = await createBackend(vaultB, bare);
+      const meta = await b.sessionStart();
+      expect(meta.pull_conflict).toBeUndefined();
+      expect(meta.offline).toBeUndefined();
+
+      const found = await b.memoryRepo.findById("m1");
+      expect(found?.title).toBe("t-m1");
+
+      await a.close();
+      await b.close();
+    } finally {
+      await cleanup();
+    }
+  }, 30_000);
+
+  it("non-conflicting concurrent writes merge cleanly", async () => {
+    const { bare, vaultA, vaultB, cleanup } = await setupBareAndTwoVaults();
+    try {
+      const a = await createBackend(vaultA, bare);
+      await a.memoryRepo.create(makeMemory("seed"));
+      await waitForUnpushedZero(a);
+
+      const b = await createBackend(vaultB, bare);
+      await b.sessionStart();
+
+      await a.memoryRepo.create(makeMemory("from-a"));
+      await b.memoryRepo.create(makeMemory("from-b"));
+      await waitForUnpushedZero(a);
+
+      const bMeta = await b.sessionStart();
+      expect(bMeta.pull_conflict).toBeUndefined();
+      await waitForUnpushedZero(b);
+
+      const aMeta = await a.sessionStart();
+      expect(aMeta.pull_conflict).toBeUndefined();
+
+      expect(await a.memoryRepo.findById("from-b")).not.toBeNull();
+      expect(await b.memoryRepo.findById("from-a")).not.toBeNull();
+
+      await a.close();
+      await b.close();
+    } finally {
+      await cleanup();
+    }
+  }, 30_000);
+
+  it("conflicting writes on same file surface pull_conflict", async () => {
+    const { bare, vaultA, vaultB, cleanup } = await setupBareAndTwoVaults();
+    try {
+      const a = await createBackend(vaultA, bare);
+      // Create a memory that will be the conflict target.
+      await a.memoryRepo.create(makeMemory("target"));
+      await waitForUnpushedZero(a);
+
+      const b = await createBackend(vaultB, bare);
+      await b.sessionStart(); // pull A's target into B
+
+      // Strategy: produce a modify/delete conflict, which git rebase
+      // cannot resolve even with `*.md merge=union`. A deletes the
+      // file via direct git manipulation; B updates it via the vault
+      // API. When B pulls (rebases), git sees "deleted in HEAD,
+      // modified in B's commit" → CONFLICT.
+      const gitA = simpleGit({ baseDir: vaultA }).env(scrubGitEnv());
+      const targetPath = join("workspaces", "ws1", "memories", "target.md");
+      await unlink(join(vaultA, targetPath));
+      await gitA.rm([targetPath]);
+      await gitA.commit("[test] delete target to force conflict", [targetPath]);
+      // Push A's deletion so origin has "target deleted".
+      await gitA.raw(["push", "--set-upstream", "origin", "HEAD:main"]);
+
+      // B updates the same file through the vault API.
+      const targetOnB = await b.memoryRepo.findById("target");
+      if (!targetOnB) throw new Error("target not found on B");
+      await b.memoryRepo.update("target", targetOnB.version, {
+        title: "b-updated-title",
+      });
+
+      // B's sessionStart pulls → rebase applies B's modify-commit on
+      // top of A's delete-commit → modify/delete conflict → pull_conflict.
+      const bMeta = await b.sessionStart();
+      expect(bMeta.pull_conflict).toBe(true);
+
+      await a.close();
+      await b.close();
+    } finally {
+      await cleanup();
+    }
+  }, 30_000);
+
+  it("offline mode: origin unreachable → meta.offline=true, writes still commit", async () => {
+    const { bare, vaultA, cleanup } = await setupBareAndTwoVaults();
+    try {
+      const a = await createBackend(vaultA, bare);
+      await a.memoryRepo.create(makeMemory("seed"));
+      await waitForUnpushedZero(a);
+      // Break origin. Retry a few times on ENOTEMPTY — macOS can hold
+      // file descriptors on bare-repo pack files briefly after git ops.
+      for (let attempt = 0; attempt < 5; attempt++) {
+        try {
+          await rm(bare, { recursive: true, force: true });
+          break;
+        } catch (err) {
+          const code = (err as NodeJS.ErrnoException).code;
+          if (code === "ENOTEMPTY" && attempt < 4) {
+            await new Promise((r) => setTimeout(r, 50));
+          } else {
+            throw err;
+          }
+        }
+      }
+
+      await a.memoryRepo.create(makeMemory("offline-write"));
+      const meta = await a.sessionStart();
+      expect(meta.offline).toBe(true);
+      expect(meta.unpushed_commits ?? 0).toBeGreaterThan(0);
+
+      await a.close();
+    } finally {
+      await cleanup();
+    }
+  }, 30_000);
+});

--- a/tests/unit/backend/factory.test.ts
+++ b/tests/unit/backend/factory.test.ts
@@ -21,6 +21,23 @@ describe("createBackend", () => {
     }
   });
 
+  it("vault backend sessionStart returns empty meta", async () => {
+    const root = await mkdtemp(join(tmpdir(), "factory-vault-"));
+    try {
+      const backend = await createBackend({
+        backend: "vault",
+        databaseUrl: "postgresql://unused",
+        vaultRoot: root,
+        embeddingDimensions: 768,
+      });
+      const meta = await backend.sessionStart();
+      expect(meta).toEqual({});
+      await backend.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("rejects the vault backend when vaultRoot is empty", async () => {
     await expect(
       createBackend({

--- a/tests/unit/backend/vault/git/align.test.ts
+++ b/tests/unit/backend/vault/git/align.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { simpleGit, type SimpleGit } from "simple-git";
 import { scrubGitEnv } from "../../../../../src/backend/vault/git/env.js";
 import { alignWithRemote } from "../../../../../src/backend/vault/git/align.js";
+import { logger } from "../../../../../src/utils/logger.js";
 
 interface OriginAndClone {
   origin: string;
@@ -174,8 +175,9 @@ describe("alignWithRemote", () => {
     }
   });
 
-  it("hard-resets to remote when histories are unrelated (no common ancestor)", async () => {
+  it("hard-resets to remote when histories are unrelated (no common ancestor) and logs error", async () => {
     const dir = await mkdtemp(join(tmpdir(), "align-test-"));
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
     try {
       const origin = join(dir, "origin.git");
       const seed = join(dir, "seed");
@@ -183,7 +185,6 @@ describe("alignWithRemote", () => {
       await mkdir(origin);
       await initBareMain(origin);
 
-      // Populate origin via seed clone.
       await simpleGit().env(scrubGitEnv()).clone(origin, seed);
       await configureIdentity(seed);
       const seedGit = simpleGit({ baseDir: seed }).env(scrubGitEnv());
@@ -191,9 +192,6 @@ describe("alignWithRemote", () => {
       await seedGit.push("origin", "HEAD:main");
       const remoteHeadSha = (await seedGit.revparse(["HEAD"])).trim();
 
-      // Fresh repo with its OWN initial commit and origin pointing at the
-      // pre-populated bare — simulates a second-vault bootstrap where
-      // ensureVaultGit ran locally before the first fetch.
       await mkdir(fresh);
       const freshGit = simpleGit({ baseDir: fresh }).env(scrubGitEnv());
       await freshGit.init();
@@ -206,7 +204,11 @@ describe("alignWithRemote", () => {
 
       const after = (await freshGit.revparse(["HEAD"])).trim();
       expect(after).toBe(remoteHeadSha);
+      // Destructive branch must log at error severity so the operator notices.
+      const calls = errorSpy.mock.calls.map((c) => String(c[0]));
+      expect(calls.some((m) => /unrelated-history reset/i.test(m))).toBe(true);
     } finally {
+      errorSpy.mockRestore();
       await rm(dir, { recursive: true, force: true });
     }
   });

--- a/tests/unit/backend/vault/git/align.test.ts
+++ b/tests/unit/backend/vault/git/align.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { simpleGit, type SimpleGit } from "simple-git";
+import { scrubGitEnv } from "../../../../../src/backend/vault/git/env.js";
+import { alignWithRemote } from "../../../../../src/backend/vault/git/align.js";
+
+interface OriginAndClone {
+  origin: string;
+  clone: string;
+  cleanup: () => Promise<void>;
+}
+
+async function setupOriginWithCommit(): Promise<OriginAndClone> {
+  const dir = await mkdtemp(join(tmpdir(), "align-test-"));
+  const origin = join(dir, "origin.git");
+  const seed = join(dir, "seed");
+  const clone = join(dir, "clone");
+  await mkdir(origin);
+  await initBareMain(origin);
+  await simpleGit().env(scrubGitEnv()).clone(origin, seed);
+  await configureIdentity(seed);
+  await writeFile(join(seed, "first.md"), "shared\n");
+  const seedGit = simpleGit({ baseDir: seed }).env(scrubGitEnv());
+  await seedGit.add("first.md");
+  await seedGit.commit("seed");
+  await seedGit.push("origin", "HEAD:main");
+  await simpleGit().env(scrubGitEnv()).clone(origin, clone);
+  await configureIdentity(clone);
+  return {
+    origin,
+    clone,
+    cleanup: () => rm(dir, { recursive: true, force: true }),
+  };
+}
+
+async function configureIdentity(repo: string): Promise<void> {
+  const git = simpleGit({ baseDir: repo }).env(scrubGitEnv());
+  await git.addConfig("user.email", "t@x", false, "local");
+  await git.addConfig("user.name", "t", false, "local");
+}
+
+// `init --bare` picks HEAD from init.defaultBranch, which is unset in CI —
+// leaving HEAD symref'd to refs/heads/master. Clones then have no branch and
+// pushes to `main` become non-fast-forward. Pin the bare HEAD to `main`.
+async function initBareMain(origin: string): Promise<void> {
+  await simpleGit().env(scrubGitEnv()).cwd(origin).init(true);
+  await simpleGit()
+    .env(scrubGitEnv())
+    .cwd(origin)
+    .raw(["symbolic-ref", "HEAD", "refs/heads/main"]);
+}
+
+async function commit(
+  git: SimpleGit,
+  file: string,
+  body: string,
+  msg: string,
+): Promise<void> {
+  await writeFile(
+    join((await git.revparse(["--show-toplevel"])).trim(), file),
+    body,
+  );
+  await git.add(file);
+  await git.commit(msg);
+}
+
+describe("alignWithRemote", () => {
+  it("no-op when no origin remote configured", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "align-test-"));
+    try {
+      const git = simpleGit({ baseDir: dir }).env(scrubGitEnv());
+      await git.init();
+      await configureIdentity(dir);
+      await commit(git, "x.md", "hi\n", "init");
+      const before = (await git.log()).latest?.hash;
+      await alignWithRemote(git);
+      const after = (await git.log()).latest?.hash;
+      expect(after).toBe(before);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("no-op when origin unreachable", async () => {
+    const { clone, cleanup } = await setupOriginWithCommit();
+    try {
+      const git = simpleGit({ baseDir: clone }).env(scrubGitEnv());
+      await git.remote(["set-url", "origin", "/tmp/does-not-exist-xyz-align"]);
+      const before = (await git.log()).latest?.hash;
+      await alignWithRemote(git);
+      const after = (await git.log()).latest?.hash;
+      expect(after).toBe(before);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("no-op when origin/main missing (empty bare origin)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "align-test-"));
+    try {
+      const origin = join(dir, "origin.git");
+      const clone = join(dir, "clone");
+      await mkdir(origin);
+      await initBareMain(origin);
+      await mkdir(clone);
+      const git = simpleGit({ baseDir: clone }).env(scrubGitEnv());
+      await git.init();
+      await configureIdentity(clone);
+      await git.addRemote("origin", origin);
+      await commit(git, "local.md", "local-only\n", "local-init");
+      const before = (await git.log()).latest?.hash;
+      await alignWithRemote(git);
+      const after = (await git.log()).latest?.hash;
+      expect(after).toBe(before);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("no-op when local is up-to-date with remote", async () => {
+    const { clone, cleanup } = await setupOriginWithCommit();
+    try {
+      const git = simpleGit({ baseDir: clone }).env(scrubGitEnv());
+      const before = (await git.log()).latest?.hash;
+      await alignWithRemote(git);
+      const after = (await git.log()).latest?.hash;
+      expect(after).toBe(before);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("no-op when local is ahead of remote (local has unpushed commits)", async () => {
+    const { clone, cleanup } = await setupOriginWithCommit();
+    try {
+      const git = simpleGit({ baseDir: clone }).env(scrubGitEnv());
+      await commit(git, "local.md", "ahead\n", "local commit");
+      const before = (await git.log()).latest?.hash;
+      await alignWithRemote(git);
+      const after = (await git.log()).latest?.hash;
+      expect(after).toBe(before);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("fast-forwards when local is strictly behind remote", async () => {
+    const { origin, clone, cleanup } = await setupOriginWithCommit();
+    try {
+      // Push a remote-only commit via a third clone.
+      const other = clone + "-other";
+      await simpleGit().env(scrubGitEnv()).clone(origin, other);
+      await configureIdentity(other);
+      const og = simpleGit({ baseDir: other }).env(scrubGitEnv());
+      await commit(og, "added.md", "remote-new\n", "remote-add");
+      await og.push("origin", "HEAD:main");
+
+      const git = simpleGit({ baseDir: clone }).env(scrubGitEnv());
+      const localBefore = (await git.log()).latest?.hash;
+      await alignWithRemote(git);
+      const localAfter = (await git.log()).latest?.hash;
+      const remoteHead = (await git.raw(["rev-parse", "origin/main"])).trim();
+      expect(localAfter).toBe(remoteHead);
+      expect(localAfter).not.toBe(localBefore);
+      // Upstream tracking now set.
+      const upstream = (
+        await git.raw(["rev-parse", "--abbrev-ref", "main@{u}"])
+      ).trim();
+      expect(upstream).toBe("origin/main");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("hard-resets to remote when histories are unrelated (no common ancestor)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "align-test-"));
+    try {
+      const origin = join(dir, "origin.git");
+      const seed = join(dir, "seed");
+      const fresh = join(dir, "fresh");
+      await mkdir(origin);
+      await initBareMain(origin);
+
+      // Populate origin via seed clone.
+      await simpleGit().env(scrubGitEnv()).clone(origin, seed);
+      await configureIdentity(seed);
+      const seedGit = simpleGit({ baseDir: seed }).env(scrubGitEnv());
+      await commit(seedGit, "remote-only.md", "remote\n", "remote-root");
+      await seedGit.push("origin", "HEAD:main");
+      const remoteHeadSha = (await seedGit.revparse(["HEAD"])).trim();
+
+      // Fresh repo with its OWN initial commit and origin pointing at the
+      // pre-populated bare — simulates a second-vault bootstrap where
+      // ensureVaultGit ran locally before the first fetch.
+      await mkdir(fresh);
+      const freshGit = simpleGit({ baseDir: fresh }).env(scrubGitEnv());
+      await freshGit.init();
+      await configureIdentity(fresh);
+      await freshGit.addRemote("origin", origin);
+      await commit(freshGit, "local-bootstrap.md", "local\n", "local-root");
+      await freshGit.raw(["branch", "-m", "main"]).catch(() => undefined);
+
+      await alignWithRemote(freshGit);
+
+      const after = (await freshGit.revparse(["HEAD"])).trim();
+      expect(after).toBe(remoteHeadSha);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws when histories diverge with shared ancestor (refuses destructive reset)", async () => {
+    const { origin, clone, cleanup } = await setupOriginWithCommit();
+    try {
+      // Local-only commit on top of shared ancestor.
+      const git = simpleGit({ baseDir: clone }).env(scrubGitEnv());
+      await commit(git, "local.md", "local-only\n", "local divergence");
+      const localBefore = (await git.log()).latest?.hash;
+
+      // Remote-only commit pushed via another clone.
+      const other = clone + "-other";
+      await simpleGit().env(scrubGitEnv()).clone(origin, other);
+      await configureIdentity(other);
+      const og = simpleGit({ baseDir: other }).env(scrubGitEnv());
+      await commit(og, "remote.md", "remote-only\n", "remote divergence");
+      await og.push("origin", "HEAD:main");
+
+      await expect(alignWithRemote(git)).rejects.toThrow(
+        /diverged.*shared ancestor/i,
+      );
+      // Local HEAD untouched.
+      const localAfter = (await git.log()).latest?.hash;
+      expect(localAfter).toBe(localBefore);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/tests/unit/backend/vault/git/git-ops.test.ts
+++ b/tests/unit/backend/vault/git/git-ops.test.ts
@@ -78,59 +78,46 @@ describe("GitOpsImpl", () => {
   });
 
   it("fires afterCommit after a successful commit", async () => {
-    const root = await mkdtemp(join(tmpdir(), "git-ops-hook-"));
-    try {
-      const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
-      await git.init();
-      await git.addConfig("user.email", "t@x", false, "local");
-      await git.addConfig("user.name", "t", false, "local");
+    const ops = new GitOpsImpl({ root });
+    await ops.init();
+    await configUser(root);
 
-      const calls: number[] = [];
-      const ops = new GitOpsImpl({ root });
-      ops.afterCommit = () => calls.push(Date.now());
+    const calls: number[] = [];
+    ops.afterCommit = () => calls.push(Date.now());
 
-      const path = "note.md";
-      await writeFile(join(root, path), "hi\n");
-      await ops.stageAndCommit([path], "[t] first", {
-        action: "created",
-        memoryId: "m1",
-        actor: "a",
-      });
+    const path = "note.md";
+    await writeFile(join(root, path), "hi\n");
+    await ops.stageAndCommit([path], "[t] first", {
+      action: "created",
+      memoryId: "m1",
+      actor: "a",
+    });
 
-      expect(calls).toHaveLength(1);
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
+    expect(calls).toHaveLength(1);
   });
 
   it("does not fire afterCommit when stageAndCommit throws", async () => {
-    const root = await mkdtemp(join(tmpdir(), "git-ops-hook-fail-"));
-    try {
-      const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
-      await git.init();
-      await git.addConfig("user.email", "t@x", false, "local");
-      await git.addConfig("user.name", "t", false, "local");
+    const ops = new GitOpsImpl({ root });
+    await ops.init();
+    await configUser(root);
 
-      const calls: number[] = [];
-      const ops = new GitOpsImpl({ root });
-      ops.afterCommit = () => calls.push(Date.now());
+    const calls: number[] = [];
+    ops.afterCommit = () => calls.push(Date.now());
 
-      // Nothing to commit → VaultGitNothingToCommitError.
-      await writeFile(join(root, "ignored.md"), "x\n");
-      await git.add("ignored.md");
-      await git.commit("initial", ["ignored.md"]);
-      await expect(
-        ops.stageAndCommit(["ignored.md"], "again", {
-          action: "created",
-          memoryId: "m1",
-          actor: "a",
-        }),
-      ).rejects.toThrow();
+    // Nothing to commit → VaultGitNothingToCommitError.
+    const git = simpleGit(root).env(scrubGitEnv());
+    await writeFile(join(root, "ignored.md"), "x\n");
+    await git.add("ignored.md");
+    await git.commit("initial", ["ignored.md"]);
+    await expect(
+      ops.stageAndCommit(["ignored.md"], "again", {
+        action: "created",
+        memoryId: "m1",
+        actor: "a",
+      }),
+    ).rejects.toThrow(/nothing to commit/i);
 
-      expect(calls).toHaveLength(0);
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
+    expect(calls).toHaveLength(0);
   });
 });
 

--- a/tests/unit/backend/vault/git/git-ops.test.ts
+++ b/tests/unit/backend/vault/git/git-ops.test.ts
@@ -76,6 +76,62 @@ describe("GitOpsImpl", () => {
     await ops.init();
     expect((await ops.status()).clean).toBe(true);
   });
+
+  it("fires afterCommit after a successful commit", async () => {
+    const root = await mkdtemp(join(tmpdir(), "git-ops-hook-"));
+    try {
+      const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+      await git.init();
+      await git.addConfig("user.email", "t@x", false, "local");
+      await git.addConfig("user.name", "t", false, "local");
+
+      const calls: number[] = [];
+      const ops = new GitOpsImpl({ root });
+      ops.afterCommit = () => calls.push(Date.now());
+
+      const path = "note.md";
+      await writeFile(join(root, path), "hi\n");
+      await ops.stageAndCommit([path], "[t] first", {
+        action: "created",
+        memoryId: "m1",
+        actor: "a",
+      });
+
+      expect(calls).toHaveLength(1);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not fire afterCommit when stageAndCommit throws", async () => {
+    const root = await mkdtemp(join(tmpdir(), "git-ops-hook-fail-"));
+    try {
+      const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+      await git.init();
+      await git.addConfig("user.email", "t@x", false, "local");
+      await git.addConfig("user.name", "t", false, "local");
+
+      const calls: number[] = [];
+      const ops = new GitOpsImpl({ root });
+      ops.afterCommit = () => calls.push(Date.now());
+
+      // Nothing to commit → VaultGitNothingToCommitError.
+      await writeFile(join(root, "ignored.md"), "x\n");
+      await git.add("ignored.md");
+      await git.commit("initial", ["ignored.md"]);
+      await expect(
+        ops.stageAndCommit(["ignored.md"], "again", {
+          action: "created",
+          memoryId: "m1",
+          actor: "a",
+        }),
+      ).rejects.toThrow();
+
+      expect(calls).toHaveLength(0);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });
 
 async function configUser(root: string): Promise<void> {

--- a/tests/unit/backend/vault/git/pull.test.ts
+++ b/tests/unit/backend/vault/git/pull.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { simpleGit } from "simple-git";
+import { scrubGitEnv } from "../../../../../src/backend/vault/git/env.js";
+import { syncFromRemote } from "../../../../../src/backend/vault/git/pull.js";
+
+async function setupOriginAndClone(): Promise<{
+  origin: string;
+  clone: string;
+  cleanup: () => Promise<void>;
+}> {
+  const dir = await mkdtemp(join(tmpdir(), "pull-test-"));
+  const origin = join(dir, "origin.git");
+  const clone = join(dir, "clone");
+  await mkdir(origin);
+  await simpleGit().env(scrubGitEnv()).cwd(origin).init(true);
+  await simpleGit().env(scrubGitEnv()).clone(origin, clone);
+  const git = simpleGit({ baseDir: clone }).env(scrubGitEnv());
+  await git.addConfig("user.email", "t@x", false, "local");
+  await git.addConfig("user.name", "t", false, "local");
+  await writeFile(join(clone, "first.md"), "hello\n");
+  await git.add("first.md");
+  await git.commit("initial");
+  await git.push("origin", "HEAD:main");
+  return {
+    origin,
+    clone,
+    cleanup: () => rm(dir, { recursive: true, force: true }),
+  };
+}
+
+describe("syncFromRemote", () => {
+  it("fast-forward returns changedPaths, not offline/conflict", async () => {
+    const { origin, clone, cleanup } = await setupOriginAndClone();
+    try {
+      // Make a second clone, commit, push.
+      const other = clone + "-other";
+      await simpleGit().env(scrubGitEnv()).clone(origin, other);
+      const og = simpleGit({ baseDir: other }).env(scrubGitEnv());
+      await og.addConfig("user.email", "t@x", false, "local");
+      await og.addConfig("user.name", "t", false, "local");
+      await writeFile(join(other, "added.md"), "new\n");
+      await og.add("added.md");
+      await og.commit("add file");
+      await og.push("origin", "HEAD:main");
+
+      const git = simpleGit({ baseDir: clone }).env(scrubGitEnv());
+      const result = await syncFromRemote({ git });
+      expect(result.offline).toBe(false);
+      expect(result.conflict).toBe(false);
+      expect(result.changedPaths).toContain("added.md");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("up-to-date returns empty changedPaths", async () => {
+    const { clone, cleanup } = await setupOriginAndClone();
+    try {
+      const git = simpleGit({ baseDir: clone }).env(scrubGitEnv());
+      const result = await syncFromRemote({ git });
+      expect(result.offline).toBe(false);
+      expect(result.conflict).toBe(false);
+      expect(result.changedPaths).toEqual([]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("rebase conflict → conflict=true, rebase aborted, working tree clean", async () => {
+    const { origin, clone, cleanup } = await setupOriginAndClone();
+    try {
+      // Remote commit modifies first.md.
+      const other = clone + "-other";
+      await simpleGit().env(scrubGitEnv()).clone(origin, other);
+      const og = simpleGit({ baseDir: other }).env(scrubGitEnv());
+      await og.addConfig("user.email", "t@x", false, "local");
+      await og.addConfig("user.name", "t", false, "local");
+      await writeFile(join(other, "first.md"), "remote-change\n");
+      await og.add("first.md");
+      await og.commit("remote");
+      await og.push("origin", "HEAD:main");
+
+      // Local conflicting commit on the same file.
+      const git = simpleGit({ baseDir: clone }).env(scrubGitEnv());
+      await writeFile(join(clone, "first.md"), "local-change\n");
+      await git.add("first.md");
+      await git.commit("local");
+
+      const result = await syncFromRemote({ git });
+      expect(result.conflict).toBe(true);
+      expect(result.offline).toBe(false);
+      const status = await git.status();
+      expect(status.files).toHaveLength(0); // clean working tree
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("network failure → offline=true, no throw", async () => {
+    const { clone, cleanup } = await setupOriginAndClone();
+    try {
+      const git = simpleGit({ baseDir: clone }).env(scrubGitEnv());
+      // Point origin at a bogus URL.
+      await git.remote(["set-url", "origin", "/tmp/does-not-exist-xyz"]);
+      const result = await syncFromRemote({ git });
+      expect(result.offline).toBe(true);
+      expect(result.conflict).toBe(false);
+      expect(result.changedPaths).toEqual([]);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/tests/unit/backend/vault/git/pull.test.ts
+++ b/tests/unit/backend/vault/git/pull.test.ts
@@ -16,6 +16,13 @@ async function setupOriginAndClone(): Promise<{
   const clone = join(dir, "clone");
   await mkdir(origin);
   await simpleGit().env(scrubGitEnv()).cwd(origin).init(true);
+  // Force bare HEAD to `main` so environments without init.defaultBranch=main
+  // (e.g. CI) don't leave HEAD pointing at a nonexistent `master` ref, which
+  // breaks subsequent clones and non-ff pushes.
+  await simpleGit()
+    .env(scrubGitEnv())
+    .cwd(origin)
+    .raw(["symbolic-ref", "HEAD", "refs/heads/main"]);
   await simpleGit().env(scrubGitEnv()).clone(origin, clone);
   const git = simpleGit({ baseDir: clone }).env(scrubGitEnv());
   await git.addConfig("user.email", "t@x", false, "local");
@@ -109,6 +116,27 @@ describe("syncFromRemote", () => {
       expect(result.offline).toBe(true);
       expect(result.conflict).toBe(false);
       expect(result.changedPaths).toEqual([]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("unexpected error rethrows instead of masquerading as offline", async () => {
+    const { clone, cleanup } = await setupOriginAndClone();
+    try {
+      const git = simpleGit({ baseDir: clone }).env(scrubGitEnv());
+      const stub = {
+        getRemotes: git.getRemotes.bind(git),
+        raw: git.raw.bind(git),
+        pull: async () => {
+          throw new Error(
+            "fatal: unable to read tree (abc123): corrupt object",
+          );
+        },
+      } as unknown as typeof git;
+      await expect(syncFromRemote({ git: stub })).rejects.toThrow(
+        /corrupt object/,
+      );
     } finally {
       await cleanup();
     }

--- a/tests/unit/backend/vault/git/pull.test.ts
+++ b/tests/unit/backend/vault/git/pull.test.ts
@@ -55,9 +55,10 @@ describe("syncFromRemote", () => {
 
       const git = simpleGit({ baseDir: clone }).env(scrubGitEnv());
       const result = await syncFromRemote({ git });
-      expect(result.offline).toBe(false);
-      expect(result.conflict).toBe(false);
-      expect(result.changedPaths).toContain("added.md");
+      expect(result.kind).toBe("ok");
+      if (result.kind === "ok") {
+        expect(result.changedPaths).toContain("added.md");
+      }
     } finally {
       await cleanup();
     }
@@ -68,9 +69,10 @@ describe("syncFromRemote", () => {
     try {
       const git = simpleGit({ baseDir: clone }).env(scrubGitEnv());
       const result = await syncFromRemote({ git });
-      expect(result.offline).toBe(false);
-      expect(result.conflict).toBe(false);
-      expect(result.changedPaths).toEqual([]);
+      expect(result.kind).toBe("ok");
+      if (result.kind === "ok") {
+        expect(result.changedPaths).toEqual([]);
+      }
     } finally {
       await cleanup();
     }
@@ -97,8 +99,7 @@ describe("syncFromRemote", () => {
       await git.commit("local");
 
       const result = await syncFromRemote({ git });
-      expect(result.conflict).toBe(true);
-      expect(result.offline).toBe(false);
+      expect(result.kind).toBe("conflict");
       const status = await git.status();
       expect(status.files).toHaveLength(0); // clean working tree
     } finally {
@@ -106,16 +107,14 @@ describe("syncFromRemote", () => {
     }
   });
 
-  it("network failure → offline=true, no throw", async () => {
+  it("network failure → kind=offline, no throw", async () => {
     const { clone, cleanup } = await setupOriginAndClone();
     try {
       const git = simpleGit({ baseDir: clone }).env(scrubGitEnv());
       // Point origin at a bogus URL.
       await git.remote(["set-url", "origin", "/tmp/does-not-exist-xyz"]);
       const result = await syncFromRemote({ git });
-      expect(result.offline).toBe(true);
-      expect(result.conflict).toBe(false);
-      expect(result.changedPaths).toEqual([]);
+      expect(result.kind).toBe("offline");
     } finally {
       await cleanup();
     }

--- a/tests/unit/backend/vault/git/push-queue.test.ts
+++ b/tests/unit/backend/vault/git/push-queue.test.ts
@@ -191,3 +191,38 @@ describe("PushQueue backoff", () => {
     await q.close();
   });
 });
+
+describe("PushQueue.unpushedCommits", () => {
+  it("delegates to injected counter", async () => {
+    const { push } = fakePusher();
+    const q = new PushQueue({
+      push,
+      debounceMs: 100,
+      backoffMs: [],
+      countUnpushed: async () => 7,
+    });
+    expect(await q.unpushedCommits()).toBe(7);
+    await q.close();
+  });
+
+  it("returns 0 when counter throws (no upstream configured)", async () => {
+    const { push } = fakePusher();
+    const q = new PushQueue({
+      push,
+      debounceMs: 100,
+      backoffMs: [],
+      countUnpushed: async () => {
+        throw new Error("no upstream");
+      },
+    });
+    expect(await q.unpushedCommits()).toBe(0);
+    await q.close();
+  });
+
+  it("returns 0 when counter not provided", async () => {
+    const { push } = fakePusher();
+    const q = new PushQueue({ push, debounceMs: 100, backoffMs: [] });
+    expect(await q.unpushedCommits()).toBe(0);
+    await q.close();
+  });
+});

--- a/tests/unit/backend/vault/git/push-queue.test.ts
+++ b/tests/unit/backend/vault/git/push-queue.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { PushQueue } from "../../../../../src/backend/vault/git/push-queue.js";
+
+interface FakePushResult {
+  resolve: (value: void) => void;
+  reject: (err: Error) => void;
+  calls: number;
+}
+
+function fakePusher(): { push: () => Promise<void>; state: FakePushResult } {
+  const state: FakePushResult = {
+    resolve: () => {},
+    reject: () => {},
+    calls: 0,
+  };
+  const push = () => {
+    state.calls += 1;
+    return new Promise<void>((resolve, reject) => {
+      state.resolve = resolve;
+      state.reject = reject;
+    });
+  };
+  return { push, state };
+}
+
+describe("PushQueue debounce + single-flight", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("coalesces rapid requests into one push", async () => {
+    const { push, state } = fakePusher();
+    const q = new PushQueue({ push, debounceMs: 100, backoffMs: [] });
+    q.request();
+    q.request();
+    q.request();
+    expect(state.calls).toBe(0);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(state.calls).toBe(1);
+    state.resolve();
+    await q.close();
+  });
+
+  it("bumps debounce on each request", async () => {
+    const { push, state } = fakePusher();
+    const q = new PushQueue({ push, debounceMs: 100, backoffMs: [] });
+    q.request();
+    await vi.advanceTimersByTimeAsync(60);
+    q.request();
+    await vi.advanceTimersByTimeAsync(60);
+    // Still not fired — second request reset timer to now+100.
+    expect(state.calls).toBe(0);
+    await vi.advanceTimersByTimeAsync(40);
+    expect(state.calls).toBe(1);
+    state.resolve();
+    await q.close();
+  });
+
+  it("single-flight: second push waits for first to finish", async () => {
+    const { push, state } = fakePusher();
+    const q = new PushQueue({ push, debounceMs: 100, backoffMs: [] });
+    q.request();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(state.calls).toBe(1);
+    // Trigger follow-up push while first in-flight.
+    q.request();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(state.calls).toBe(1); // still blocked behind in-flight
+    state.resolve();
+    // Allow microtask queue + scheduled follow-up.
+    await vi.advanceTimersByTimeAsync(100);
+    expect(state.calls).toBe(2);
+    state.resolve();
+    await q.close();
+  });
+
+  it("close() drains in-flight and cancels pending debounce", async () => {
+    const { push, state } = fakePusher();
+    const q = new PushQueue({ push, debounceMs: 100, backoffMs: [] });
+    q.request();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(state.calls).toBe(1);
+    state.resolve();
+    q.request();
+    const closed = q.close();
+    // Pending debounce cancelled — no new push.
+    await vi.advanceTimersByTimeAsync(1000);
+    await closed;
+    expect(state.calls).toBe(1);
+  });
+});

--- a/tests/unit/backend/vault/git/push-queue.test.ts
+++ b/tests/unit/backend/vault/git/push-queue.test.ts
@@ -92,3 +92,102 @@ describe("PushQueue debounce + single-flight", () => {
     expect(state.calls).toBe(1);
   });
 });
+
+describe("PushQueue backoff", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retries according to backoffMs schedule", async () => {
+    const { push, state } = fakePusher();
+    const q = new PushQueue({
+      push,
+      debounceMs: 100,
+      backoffMs: [500, 2000],
+    });
+    q.request();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(state.calls).toBe(1);
+    state.reject(new Error("boom"));
+    // Wait for the rejection to propagate and state to flip to backoff.
+    await vi.advanceTimersByTimeAsync(0);
+
+    // No retry before 500ms.
+    await vi.advanceTimersByTimeAsync(499);
+    expect(state.calls).toBe(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(state.calls).toBe(2);
+
+    state.reject(new Error("boom again"));
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(state.calls).toBe(2);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(state.calls).toBe(3);
+    state.resolve();
+    await q.close();
+  });
+
+  it("stays at last backoff step after exhausting schedule", async () => {
+    const { push, state } = fakePusher();
+    const q = new PushQueue({ push, debounceMs: 100, backoffMs: [500] });
+    q.request();
+    await vi.advanceTimersByTimeAsync(100);
+    state.reject(new Error("1"));
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(500);
+    state.reject(new Error("2"));
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(state.calls).toBe(3);
+    state.resolve();
+    await q.close();
+  });
+
+  it("success resets backoff to 0", async () => {
+    const { push, state } = fakePusher();
+    const q = new PushQueue({
+      push,
+      debounceMs: 100,
+      backoffMs: [500, 2000],
+    });
+    q.request();
+    await vi.advanceTimersByTimeAsync(100);
+    state.reject(new Error("1"));
+    await vi.advanceTimersByTimeAsync(500);
+    state.resolve();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Trigger another push.
+    q.request();
+    await vi.advanceTimersByTimeAsync(100);
+    state.reject(new Error("2"));
+    await vi.advanceTimersByTimeAsync(0);
+    // Should wait 500ms (attempt=0) again, not 2000ms.
+    await vi.advanceTimersByTimeAsync(499);
+    expect(state.calls).toBe(3);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(state.calls).toBe(4);
+    state.resolve();
+    await q.close();
+  });
+
+  it("request during backoff does not shorten timer", async () => {
+    const { push, state } = fakePusher();
+    const q = new PushQueue({ push, debounceMs: 100, backoffMs: [1000] });
+    q.request();
+    await vi.advanceTimersByTimeAsync(100);
+    state.reject(new Error("boom"));
+    await vi.advanceTimersByTimeAsync(0);
+    q.request(); // during backoff
+    await vi.advanceTimersByTimeAsync(500);
+    expect(state.calls).toBe(1);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(state.calls).toBe(2);
+    state.resolve();
+    await q.close();
+  });
+});

--- a/tests/unit/backend/vault/git/push-queue.test.ts
+++ b/tests/unit/backend/vault/git/push-queue.test.ts
@@ -91,6 +91,24 @@ describe("PushQueue debounce + single-flight", () => {
     await closed;
     expect(state.calls).toBe(1);
   });
+
+  it("close() during in-flight reject: no leaked timer, no backoff schedules", async () => {
+    const { push, state } = fakePusher();
+    const q = new PushQueue({ push, debounceMs: 100, backoffMs: [500, 2000] });
+    q.request();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(state.calls).toBe(1);
+
+    // Close arrives before the in-flight push settles.
+    const closed = q.close();
+    state.reject(new Error("boom during close"));
+    await closed;
+
+    // Advance past the full backoff window — no retry should schedule.
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(state.calls).toBe(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
 });
 
 describe("PushQueue backoff", () => {

--- a/tests/unit/backend/vault/git/reconcile.test.ts
+++ b/tests/unit/backend/vault/git/reconcile.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { simpleGit } from "simple-git";
+import { scrubGitEnv } from "../../../../../src/backend/vault/git/env.js";
+import { GitOpsImpl } from "../../../../../src/backend/vault/git/git-ops.js";
+import { reconcileDirty } from "../../../../../src/backend/vault/git/reconcile.js";
+
+async function makeRepo(): Promise<{
+  root: string;
+  cleanup: () => Promise<void>;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "reconcile-test-"));
+  const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+  await git.init();
+  await git.addConfig("user.email", "t@x", false, "local");
+  await git.addConfig("user.name", "t", false, "local");
+  // Ignore a runtime subtree to prove reconcile skips gitignored files.
+  await writeFile(join(root, ".gitignore"), ".agent-brain/\n");
+  await git.add(".gitignore");
+  await git.commit("init");
+  return { root, cleanup: () => rm(root, { recursive: true, force: true }) };
+}
+
+describe("reconcileDirty", () => {
+  it("collapses dirty tracked memory markdown into one reconcile commit", async () => {
+    const { root, cleanup } = await makeRepo();
+    try {
+      const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+      const ops = new GitOpsImpl({ root });
+
+      // Create + commit two memory files so they're tracked.
+      await mkdir(join(root, "workspaces/ws1/memories"), { recursive: true });
+      await writeFile(join(root, "workspaces/ws1/memories/a.md"), "v1-a\n");
+      await writeFile(join(root, "workspaces/ws1/memories/b.md"), "v1-b\n");
+      await git.add([
+        "workspaces/ws1/memories/a.md",
+        "workspaces/ws1/memories/b.md",
+      ]);
+      await git.commit("seed");
+
+      // Now dirty them outside git — simulates post-crash state.
+      await writeFile(join(root, "workspaces/ws1/memories/a.md"), "v2-a\n");
+      await writeFile(join(root, "workspaces/ws1/memories/b.md"), "v2-b\n");
+
+      await reconcileDirty({ git, ops });
+
+      const log = await git.log();
+      expect(log.latest?.message).toMatch(/reconcile/i);
+      const showFiles = await git.raw([
+        "show",
+        "--name-only",
+        "--pretty=format:",
+        "HEAD",
+      ]);
+      const files = showFiles
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean);
+      expect(files).toEqual(
+        expect.arrayContaining([
+          "workspaces/ws1/memories/a.md",
+          "workspaces/ws1/memories/b.md",
+        ]),
+      );
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("no-op when tree clean", async () => {
+    const { root, cleanup } = await makeRepo();
+    try {
+      const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+      const ops = new GitOpsImpl({ root });
+      const before = (await git.log()).total;
+      await reconcileDirty({ git, ops });
+      const after = (await git.log()).total;
+      expect(after).toBe(before);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("ignores untracked files and gitignored dirty files", async () => {
+    const { root, cleanup } = await makeRepo();
+    try {
+      const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+      const ops = new GitOpsImpl({ root });
+
+      await mkdir(join(root, ".agent-brain"), { recursive: true });
+      await writeFile(join(root, ".agent-brain/state.json"), "{}");
+      await mkdir(join(root, "workspaces/ws1/memories"), { recursive: true });
+      await writeFile(
+        join(root, "workspaces/ws1/memories/new.md"),
+        "untracked\n",
+      );
+
+      const before = (await git.log()).total;
+      await reconcileDirty({ git, ops });
+      const after = (await git.log()).total;
+      expect(after).toBe(before);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/tests/unit/backend/vault/git/reconcile.test.ts
+++ b/tests/unit/backend/vault/git/reconcile.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { mkdtemp, rm, writeFile, mkdir, unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { simpleGit } from "simple-git";
@@ -78,6 +78,81 @@ describe("reconcileDirty", () => {
       await reconcileDirty({ git, ops });
       const after = (await git.log()).total;
       expect(after).toBe(before);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("includes tracked deletions in reconcile commit", async () => {
+    const { root, cleanup } = await makeRepo();
+    try {
+      const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+      const ops = new GitOpsImpl({ root });
+
+      await mkdir(join(root, "workspaces/ws1/memories"), { recursive: true });
+      await writeFile(join(root, "workspaces/ws1/memories/gone.md"), "v1\n");
+      await git.add("workspaces/ws1/memories/gone.md");
+      await git.commit("seed");
+
+      await unlink(join(root, "workspaces/ws1/memories/gone.md"));
+
+      const result = await reconcileDirty({ git, ops });
+      expect(result.failed).toBe(false);
+
+      const log = await git.log();
+      expect(log.latest?.message).toMatch(/reconcile/i);
+      // File should no longer be in the tree at HEAD.
+      const lsTree = await git.raw(["ls-tree", "-r", "--name-only", "HEAD"]);
+      expect(lsTree).not.toMatch(/gone\.md/);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("collapses dirty memory markdown across workspace, project, and user scopes", async () => {
+    const { root, cleanup } = await makeRepo();
+    try {
+      const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+      const ops = new GitOpsImpl({ root });
+
+      // Seed one memory of each scope.
+      await mkdir(join(root, "workspaces/ws1/memories"), { recursive: true });
+      await mkdir(join(root, "project/memories"), { recursive: true });
+      await mkdir(join(root, "users/alice/ws1"), { recursive: true });
+      await writeFile(join(root, "workspaces/ws1/memories/w.md"), "v1\n");
+      await writeFile(join(root, "project/memories/p.md"), "v1\n");
+      await writeFile(join(root, "users/alice/ws1/u.md"), "v1\n");
+      await git.add([
+        "workspaces/ws1/memories/w.md",
+        "project/memories/p.md",
+        "users/alice/ws1/u.md",
+      ]);
+      await git.commit("seed");
+
+      // Dirty all three.
+      await writeFile(join(root, "workspaces/ws1/memories/w.md"), "v2\n");
+      await writeFile(join(root, "project/memories/p.md"), "v2\n");
+      await writeFile(join(root, "users/alice/ws1/u.md"), "v2\n");
+
+      await reconcileDirty({ git, ops });
+
+      const showFiles = await git.raw([
+        "show",
+        "--name-only",
+        "--pretty=format:",
+        "HEAD",
+      ]);
+      const files = showFiles
+        .split("\n")
+        .map((l) => l.trim())
+        .filter(Boolean);
+      expect(files).toEqual(
+        expect.arrayContaining([
+          "workspaces/ws1/memories/w.md",
+          "project/memories/p.md",
+          "users/alice/ws1/u.md",
+        ]),
+      );
     } finally {
       await cleanup();
     }

--- a/tests/unit/backend/vault/git/remote.test.ts
+++ b/tests/unit/backend/vault/git/remote.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { simpleGit } from "simple-git";
+import { scrubGitEnv } from "../../../../../src/backend/vault/git/env.js";
+import { ensureRemote } from "../../../../../src/backend/vault/git/remote.js";
+
+async function makeRepo(): Promise<{
+  root: string;
+  cleanup: () => Promise<void>;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "remote-test-"));
+  const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+  await git.init();
+  return { root, cleanup: () => rm(root, { recursive: true, force: true }) };
+}
+
+describe("ensureRemote", () => {
+  it("adds origin when absent + URL provided", async () => {
+    const { root, cleanup } = await makeRepo();
+    try {
+      const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+      await ensureRemote({ git, remoteUrl: "git@example.com:x/y.git" });
+      const remotes = await git.getRemotes(true);
+      const origin = remotes.find((r) => r.name === "origin");
+      expect(origin?.refs.fetch).toBe("git@example.com:x/y.git");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("no-ops when origin already matches", async () => {
+    const { root, cleanup } = await makeRepo();
+    try {
+      const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+      await git.addRemote("origin", "git@example.com:x/y.git");
+      await ensureRemote({ git, remoteUrl: "git@example.com:x/y.git" });
+      const remotes = await git.getRemotes(true);
+      expect(remotes).toHaveLength(1);
+      expect(remotes[0].refs.fetch).toBe("git@example.com:x/y.git");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("leaves mismatched origin in place + warns", async () => {
+    const { root, cleanup } = await makeRepo();
+    try {
+      const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+      await git.addRemote("origin", "git@existing:a/b.git");
+      await ensureRemote({ git, remoteUrl: "git@new:c/d.git" });
+      const remotes = await git.getRemotes(true);
+      expect(remotes[0].refs.fetch).toBe("git@existing:a/b.git");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("no-ops when no URL and no origin", async () => {
+    const { root, cleanup } = await makeRepo();
+    try {
+      const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+      await ensureRemote({ git, remoteUrl: undefined });
+      const remotes = await git.getRemotes(true);
+      expect(remotes).toHaveLength(0);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/tests/unit/backend/vault/git/remote.test.ts
+++ b/tests/unit/backend/vault/git/remote.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { simpleGit } from "simple-git";
 import { scrubGitEnv } from "../../../../../src/backend/vault/git/env.js";
 import { ensureRemote } from "../../../../../src/backend/vault/git/remote.js";
+import { logger } from "../../../../../src/utils/logger.js";
 
 async function makeRepo(): Promise<{
   root: string;
@@ -46,13 +47,19 @@ describe("ensureRemote", () => {
 
   it("leaves mismatched origin in place + warns", async () => {
     const { root, cleanup } = await makeRepo();
+    const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
     try {
       const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
       await git.addRemote("origin", "git@existing:a/b.git");
       await ensureRemote({ git, remoteUrl: "git@new:c/d.git" });
       const remotes = await git.getRemotes(true);
       expect(remotes[0].refs.fetch).toBe("git@existing:a/b.git");
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/configured remoteUrl/),
+      );
     } finally {
+      warnSpy.mockRestore();
       await cleanup();
     }
   });

--- a/tests/unit/backend/vault/git/trailers.test.ts
+++ b/tests/unit/backend/vault/git/trailers.test.ts
@@ -44,20 +44,9 @@ describe("formatTrailers", () => {
     expect(out).not.toContain("AB-Reason");
   });
 
-  it("throws on action requiring memoryId with no id", () => {
-    expect(() =>
-      formatTrailers({ action: "created", actor: "alice" } as CommitTrailer),
-    ).toThrow(/memoryId/);
-  });
-
-  it("throws on workspace_upsert without workspaceId", () => {
-    expect(() =>
-      formatTrailers({
-        action: "workspace_upsert",
-        actor: "alice",
-      } as CommitTrailer),
-    ).toThrow(/workspaceId/);
-  });
+  // Note: CommitTrailer is a discriminated union — `action: "created"` with
+  // no `memoryId` and `action: "workspace_upsert"` with no `workspaceId`
+  // now fail at compile time, so no runtime-throw tests are needed.
 
   it("roundtrips through a conservative trailer parser (property)", () => {
     const actionArb = fc.constantFrom(
@@ -73,10 +62,11 @@ describe("formatTrailers", () => {
     );
     const idArb = fc.stringMatching(/^[a-zA-Z0-9_-]{1,32}$/);
     const actorArb = fc.stringMatching(/^[a-zA-Z0-9_-]{1,32}$/);
+    type MemoryAction = Extract<CommitTrailer, { memoryId: string }>["action"];
     fc.assert(
       fc.property(actionArb, idArb, actorArb, (action, memoryId, actor) => {
         const out = formatTrailers({
-          action: action as CommitTrailer["action"],
+          action: action as MemoryAction,
           memoryId,
           actor,
         });

--- a/tests/unit/backend/vault/repositories/memory-repository-index-sync.test.ts
+++ b/tests/unit/backend/vault/repositories/memory-repository-index-sync.test.ts
@@ -313,13 +313,31 @@ describe("VaultMemoryRepository — syncPaths", () => {
     expect(await repo.findById("m1")).toBeNull();
   });
 
-  it("unreadable file: syncPaths registers path, but findById throws on read (file missing)", async () => {
+  it("missing file: syncPaths skips registration so findById returns null (post-delete)", async () => {
     const relPath = "workspaces/ws1/memories/missing.md";
-    // syncPaths itself should not throw even if the file doesn't exist yet.
     expect(() => repo.syncPaths([relPath])).not.toThrow();
-    // The path IS in the index now; findById will attempt to read and reject.
-    await expect(repo.findById("missing")).rejects.toMatchObject({
-      code: "ENOENT",
-    });
+    expect(await repo.findById("missing")).toBeNull();
+  });
+
+  it("remote delete: syncPaths on a path whose file was removed evicts the stale entry", async () => {
+    const relPath = "workspaces/ws1/memories/gone.md";
+    const absPath = join(root, relPath);
+    await mkdir(join(root, "workspaces/ws1/memories"), { recursive: true });
+    await writeFile(
+      absPath,
+      serializeMemoryFile({
+        memory: makeMemory({ id: "gone", workspace_id: "ws1" }),
+        flags: [],
+        comments: [],
+        relationships: [],
+      }),
+    );
+    repo.syncPaths([relPath]);
+    expect((await repo.findById("gone"))?.id).toBe("gone");
+
+    // Simulate a pulled remote delete: file gone, syncPaths called with the path.
+    await rm(absPath);
+    repo.syncPaths([relPath]);
+    expect(await repo.findById("gone")).toBeNull();
   });
 });

--- a/tests/unit/backend/vault/repositories/memory-repository-index-sync.test.ts
+++ b/tests/unit/backend/vault/repositories/memory-repository-index-sync.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { serializeMemoryFile } from "../../../../../src/backend/vault/parser/memory-parser.js";
 import { VaultMemoryRepository } from "../../../../../src/backend/vault/repositories/memory-repository.js";
 import { VaultWorkspaceRepository } from "../../../../../src/backend/vault/repositories/workspace-repository.js";
 import { VaultVectorIndex } from "../../../../../src/backend/vault/vector/lance-index.js";
@@ -250,6 +251,75 @@ describe("VaultMemoryRepository — lance index sync", () => {
       // Version should still be 1 (no write committed).
       const current = await repo.findById("m1");
       expect(current?.version).toBe(1);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// syncPaths — updates the in-memory path index from git-relative paths
+// ---------------------------------------------------------------------------
+
+describe("VaultMemoryRepository — syncPaths", () => {
+  let root: string;
+  let idx: VaultVectorIndex;
+  let repo: VaultMemoryRepository;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "repo-sync-paths-"));
+    idx = await VaultVectorIndex.create({ root, dims: DIMS });
+    repo = await VaultMemoryRepository.create({
+      root,
+      index: idx,
+      gitOps: NOOP_GIT_OPS,
+    });
+    await new VaultWorkspaceRepository({
+      root,
+      gitOps: NOOP_GIT_OPS,
+    }).findOrCreate("ws1");
+  });
+
+  afterEach(async () => {
+    await idx.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("happy path: syncPaths registers a newly-dropped memory file so findById resolves", async () => {
+    // Write a valid memory markdown file directly to disk (simulating git pull).
+    const relPath = "workspaces/ws1/memories/synced.md";
+    const absPath = join(root, relPath);
+    await mkdir(join(root, "workspaces/ws1/memories"), { recursive: true });
+    const content = serializeMemoryFile({
+      memory: makeMemory({ id: "synced", workspace_id: "ws1" }),
+      flags: [],
+      comments: [],
+      relationships: [],
+    });
+    await writeFile(absPath, content);
+
+    // Before syncPaths, findById returns null (path not in index).
+    expect(await repo.findById("synced")).toBeNull();
+
+    repo.syncPaths([relPath]);
+
+    // After syncPaths, findById reads and returns the memory.
+    const found = await repo.findById("synced");
+    expect(found?.id).toBe("synced");
+  });
+
+  it("non-memory path: syncPaths silently skips .gitignore — no error, no index entry", async () => {
+    // Should not throw and should not register a path entry.
+    expect(() => repo.syncPaths([".gitignore"])).not.toThrow();
+    // findById for any id is still null (no side effects).
+    expect(await repo.findById("m1")).toBeNull();
+  });
+
+  it("unreadable file: syncPaths registers path, but findById throws on read (file missing)", async () => {
+    const relPath = "workspaces/ws1/memories/missing.md";
+    // syncPaths itself should not throw even if the file doesn't exist yet.
+    expect(() => repo.syncPaths([relPath])).not.toThrow();
+    // The path IS in the index now; findById will attempt to read and reject.
+    await expect(repo.findById("missing")).rejects.toMatchObject({
+      code: "ENOENT",
     });
   });
 });

--- a/tests/unit/backend/vault/session-start.test.ts
+++ b/tests/unit/backend/vault/session-start.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { VaultVectorIndex } from "../../../../src/backend/vault/vector/lance-index.js";
+import { diffReindex } from "../../../../src/backend/vault/session-start.js";
+import { serializeMemoryFile } from "../../../../src/backend/vault/parser/memory-parser.js";
+import type { Memory } from "../../../../src/types/memory.js";
+
+const DIMS = 768;
+
+async function setup(): Promise<{
+  root: string;
+  index: VaultVectorIndex;
+  cleanup: () => Promise<void>;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "reindex-test-"));
+  const index = await VaultVectorIndex.create({ root, dims: DIMS });
+  return {
+    root,
+    index,
+    cleanup: async () => {
+      await index.close();
+      await rm(root, { recursive: true, force: true });
+    },
+  };
+}
+
+function makeMemory(id: string, content: string): Memory {
+  const now = new Date("2024-01-01T00:00:00Z");
+  return {
+    id,
+    project_id: "proj1",
+    workspace_id: "ws1",
+    content,
+    title: `Memory ${id}`,
+    type: "fact",
+    scope: "workspace",
+    tags: null,
+    author: "user1",
+    source: null,
+    session_id: null,
+    metadata: null,
+    embedding_model: null,
+    embedding_dimensions: null,
+    version: 1,
+    created_at: now,
+    updated_at: now,
+    verified_at: null,
+    archived_at: null,
+    comment_count: 0,
+    flag_count: 0,
+    relationship_count: 0,
+    last_comment_at: null,
+    verified_by: null,
+  };
+}
+
+function fakeMemoryMarkdown(id: string, content: string): string {
+  return serializeMemoryFile({
+    memory: makeMemory(id, content),
+    flags: [],
+    comments: [],
+    relationships: [],
+  });
+}
+
+async function writeMemory(
+  root: string,
+  path: string,
+  id: string,
+  content: string,
+): Promise<void> {
+  const abs = join(root, path);
+  await mkdir(join(abs, ".."), { recursive: true });
+  await writeFile(abs, fakeMemoryMarkdown(id, content));
+}
+
+describe("diffReindex", () => {
+  it("re-embeds when content hash changed", async () => {
+    const { root, index, cleanup } = await setup();
+    try {
+      let calls = 0;
+      const embed = async (text: string) => {
+        calls += 1;
+        return new Array(DIMS).fill(text.length / 100);
+      };
+      await writeMemory(root, "workspaces/ws1/memories/m1.md", "m1", "body-v1");
+      const r1 = await diffReindex({
+        paths: ["workspaces/ws1/memories/m1.md"],
+        root,
+        vectorIndex: index,
+        embed,
+      });
+      expect(r1.parseErrors).toBe(0);
+      expect(calls).toBe(1);
+
+      await writeMemory(root, "workspaces/ws1/memories/m1.md", "m1", "body-v2");
+      const r2 = await diffReindex({
+        paths: ["workspaces/ws1/memories/m1.md"],
+        root,
+        vectorIndex: index,
+        embed,
+      });
+      expect(r2.parseErrors).toBe(0);
+      expect(calls).toBe(2);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("skips re-embed when content hash unchanged", async () => {
+    const { root, index, cleanup } = await setup();
+    try {
+      let calls = 0;
+      const embed = async (text: string) => {
+        calls += 1;
+        return new Array(DIMS).fill(text.length / 100);
+      };
+      await writeMemory(
+        root,
+        "workspaces/ws1/memories/m1.md",
+        "m1",
+        "body-stable",
+      );
+      await diffReindex({
+        paths: ["workspaces/ws1/memories/m1.md"],
+        root,
+        vectorIndex: index,
+        embed,
+      });
+      expect(calls).toBe(1);
+      await diffReindex({
+        paths: ["workspaces/ws1/memories/m1.md"],
+        root,
+        vectorIndex: index,
+        embed,
+      });
+      expect(calls).toBe(1); // skipped — same hash
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("counts parse errors without aborting", async () => {
+    const { root, index, cleanup } = await setup();
+    try {
+      const embed = async () => new Array(DIMS).fill(0.1);
+      await writeMemory(root, "workspaces/ws1/memories/good.md", "good", "ok");
+      await mkdir(join(root, "workspaces/ws1/memories"), { recursive: true });
+      await writeFile(
+        join(root, "workspaces/ws1/memories/bad.md"),
+        ":: not YAML ::\n",
+      );
+      const r = await diffReindex({
+        paths: [
+          "workspaces/ws1/memories/good.md",
+          "workspaces/ws1/memories/bad.md",
+        ],
+        root,
+        vectorIndex: index,
+        embed,
+      });
+      expect(r.parseErrors).toBe(1);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("skips non-memory paths", async () => {
+    const { root, index, cleanup } = await setup();
+    try {
+      let calls = 0;
+      const embed = async () => {
+        calls += 1;
+        return new Array(DIMS).fill(0.1);
+      };
+      const r = await diffReindex({
+        paths: [".gitignore", "README.md", "docs/x.md"],
+        root,
+        vectorIndex: index,
+        embed,
+      });
+      expect(r.parseErrors).toBe(0);
+      expect(calls).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/tests/unit/backend/vault/session-start.test.ts
+++ b/tests/unit/backend/vault/session-start.test.ts
@@ -322,4 +322,47 @@ describe("runSessionStart", () => {
       await cleanup();
     }
   });
+
+  it("onChangedPaths fires with changedPaths when pull returns non-empty paths", async () => {
+    const { root, index, cleanup } = await setup();
+    try {
+      const received: string[][] = [];
+      await runSessionStart({
+        root,
+        vectorIndex: index,
+        embed: async () => new Array(DIMS).fill(0.1),
+        syncFromRemote: fakeSync({
+          changedPaths: ["workspaces/ws1/memories/x.md"],
+        }),
+        pushQueue: fakePushQueue(0),
+        onChangedPaths: (paths) => {
+          received.push(paths);
+        },
+      });
+      expect(received).toHaveLength(1);
+      expect(received[0]).toEqual(["workspaces/ws1/memories/x.md"]);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("onChangedPaths does NOT fire when changedPaths is empty", async () => {
+    const { root, index, cleanup } = await setup();
+    try {
+      let callCount = 0;
+      await runSessionStart({
+        root,
+        vectorIndex: index,
+        embed: async () => new Array(DIMS).fill(0.1),
+        syncFromRemote: fakeSync({ changedPaths: [] }),
+        pushQueue: fakePushQueue(0),
+        onChangedPaths: () => {
+          callCount += 1;
+        },
+      });
+      expect(callCount).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
 });

--- a/tests/unit/backend/vault/session-start.test.ts
+++ b/tests/unit/backend/vault/session-start.test.ts
@@ -3,7 +3,10 @@ import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { VaultVectorIndex } from "../../../../src/backend/vault/vector/lance-index.js";
-import { diffReindex } from "../../../../src/backend/vault/session-start.js";
+import {
+  diffReindex,
+  runSessionStart,
+} from "../../../../src/backend/vault/session-start.js";
 import { serializeMemoryFile } from "../../../../src/backend/vault/parser/memory-parser.js";
 import type { Memory } from "../../../../src/types/memory.js";
 
@@ -183,6 +186,138 @@ describe("diffReindex", () => {
       });
       expect(r.parseErrors).toBe(0);
       expect(calls).toBe(0);
+    } finally {
+      await cleanup();
+    }
+  });
+});
+
+function fakeSync(result: {
+  offline?: boolean;
+  conflict?: boolean;
+  changedPaths?: string[];
+}) {
+  return async () => ({
+    offline: result.offline ?? false,
+    conflict: result.conflict ?? false,
+    changedPaths: result.changedPaths ?? [],
+  });
+}
+
+function fakePushQueue(unpushed: number | (() => Promise<number>)) {
+  return {
+    unpushedCommits: async () =>
+      typeof unpushed === "number" ? unpushed : await unpushed(),
+    request: () => {},
+  };
+}
+
+describe("runSessionStart", () => {
+  it("all-happy returns empty meta", async () => {
+    const { root, index, cleanup } = await setup();
+    try {
+      const meta = await runSessionStart({
+        root,
+        vectorIndex: index,
+        embed: async () => new Array(DIMS).fill(0.1),
+        syncFromRemote: fakeSync({}),
+        pushQueue: fakePushQueue(0),
+      });
+      expect(meta).toEqual({});
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("offline surfaces in meta", async () => {
+    const { root, index, cleanup } = await setup();
+    try {
+      const meta = await runSessionStart({
+        root,
+        vectorIndex: index,
+        embed: async () => new Array(DIMS).fill(0.1),
+        syncFromRemote: fakeSync({ offline: true }),
+        pushQueue: fakePushQueue(0),
+      });
+      expect(meta.offline).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("conflict surfaces in meta", async () => {
+    const { root, index, cleanup } = await setup();
+    try {
+      const meta = await runSessionStart({
+        root,
+        vectorIndex: index,
+        embed: async () => new Array(DIMS).fill(0.1),
+        syncFromRemote: fakeSync({ conflict: true }),
+        pushQueue: fakePushQueue(0),
+      });
+      expect(meta.pull_conflict).toBe(true);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("unpushed > 0 surfaces", async () => {
+    const { root, index, cleanup } = await setup();
+    try {
+      const meta = await runSessionStart({
+        root,
+        vectorIndex: index,
+        embed: async () => new Array(DIMS).fill(0.1),
+        syncFromRemote: fakeSync({}),
+        pushQueue: fakePushQueue(3),
+      });
+      expect(meta.unpushed_commits).toBe(3);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("parse errors propagate from diffReindex", async () => {
+    const { root, index, cleanup } = await setup();
+    try {
+      await mkdir(join(root, "workspaces/ws1/memories"), { recursive: true });
+      await writeFile(
+        join(root, "workspaces/ws1/memories/bad.md"),
+        ":: not YAML ::\n",
+      );
+      const meta = await runSessionStart({
+        root,
+        vectorIndex: index,
+        embed: async () => new Array(DIMS).fill(0.1),
+        syncFromRemote: fakeSync({
+          changedPaths: ["workspaces/ws1/memories/bad.md"],
+        }),
+        pushQueue: fakePushQueue(0),
+      });
+      expect(meta.parse_errors).toBe(1);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("kicks pushQueue.request() after collecting meta", async () => {
+    const { root, index, cleanup } = await setup();
+    try {
+      let kicked = 0;
+      const meta = await runSessionStart({
+        root,
+        vectorIndex: index,
+        embed: async () => new Array(DIMS).fill(0.1),
+        syncFromRemote: fakeSync({}),
+        pushQueue: {
+          unpushedCommits: async () => 2,
+          request: () => {
+            kicked += 1;
+          },
+        },
+      });
+      expect(kicked).toBe(1);
+      expect(meta.unpushed_commits).toBe(2);
     } finally {
       await cleanup();
     }

--- a/tests/unit/backend/vault/session-start.test.ts
+++ b/tests/unit/backend/vault/session-start.test.ts
@@ -195,13 +195,18 @@ describe("diffReindex", () => {
 function fakeSync(result: {
   offline?: boolean;
   conflict?: boolean;
+  rebaseWedged?: true;
   changedPaths?: string[];
 }) {
-  return async () => ({
-    offline: result.offline ?? false,
-    conflict: result.conflict ?? false,
-    changedPaths: result.changedPaths ?? [],
-  });
+  return async () => {
+    if (result.offline) return { kind: "offline" as const };
+    if (result.conflict) {
+      return result.rebaseWedged
+        ? { kind: "conflict" as const, rebaseWedged: true as const }
+        : { kind: "conflict" as const };
+    }
+    return { kind: "ok" as const, changedPaths: result.changedPaths ?? [] };
+  };
 }
 
 function fakePushQueue(unpushed: number | (() => Promise<number>)) {

--- a/tests/unit/backend/vault/vector/lance-index.test.ts
+++ b/tests/unit/backend/vault/vector/lance-index.test.ts
@@ -304,6 +304,37 @@ describe("VaultVectorIndex — findPairwiseSimilar", () => {
   });
 });
 
+describe("VaultVectorIndex — getContentHash", () => {
+  let root: string;
+  let idx: VaultVectorIndex;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "lance-test-"));
+    idx = await VaultVectorIndex.create({ root, dims: 4 });
+  });
+  afterEach(async () => {
+    await idx.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("getContentHash returns stored hash", async () => {
+    await idx.upsert([
+      {
+        id: "m1",
+        project_id: "p1",
+        workspace_id: "ws1",
+        scope: "workspace",
+        author: "u",
+        title: "T",
+        archived: false,
+        content_hash: "h1",
+        vector: [0.1, 0.2, 0.3, 0.4],
+      },
+    ]);
+    expect(await idx.getContentHash("m1")).toBe("h1");
+    expect(await idx.getContentHash("missing")).toBeNull();
+  });
+});
+
 describe("VaultVectorIndex — listEmbeddings + markArchived + upsertMetaOnly", () => {
   let root: string;
   let idx: VaultVectorIndex;

--- a/tests/unit/server-boot.test.ts
+++ b/tests/unit/server-boot.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 
@@ -42,4 +45,56 @@ describe("server module graph loads under Node ESM", () => {
     }
     expect(result.status).toBe(0);
   });
+
+  it(
+    "boots under AGENT_BRAIN_BACKEND=vault with AGENT_BRAIN_VAULT_REMOTE_URL",
+    { timeout: 40_000 },
+    () => {
+      const dir = mkdtempSync(join(tmpdir(), "server-boot-vault-"));
+      const bare = join(dir, "origin.git");
+      const vault = join(dir, "vault");
+      try {
+        // Initialize a bare git repo to act as the remote.
+        const initResult = spawnSync("git", ["init", "--bare", bare], {
+          encoding: "utf8",
+          timeout: 10_000,
+        });
+        if (initResult.status !== 0) {
+          throw new Error(
+            `Failed to init bare repo:\nstderr: ${initResult.stderr}`,
+          );
+        }
+
+        const result = spawnSync(
+          "node",
+          ["--import", "tsx", "-e", "await import('./src/server.js');"],
+          {
+            cwd: repoRoot,
+            encoding: "utf8",
+            timeout: 30_000,
+            env: {
+              ...process.env,
+              CONSOLIDATION_ENABLED: "false",
+              PROJECT_ID: "smoke-test-vault",
+              AGENT_BRAIN_BACKEND: "vault",
+              AGENT_BRAIN_VAULT_ROOT: vault,
+              AGENT_BRAIN_VAULT_REMOTE_URL: bare,
+              EMBEDDING_PROVIDER: "mock",
+            },
+          },
+        );
+
+        if (result.status !== 0) {
+          throw new Error(
+            `Server (vault backend) failed to load (exit ${result.status}):\n` +
+              `stderr:\n${result.stderr}\nstdout:\n${result.stdout}`,
+          );
+        }
+        expect(result.status).toBe(0);
+        expect(result.stderr).not.toMatch(/vault push failed/);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+  );
 });


### PR DESCRIPTION
## Summary

Phase 4b closes the git-sync loop on the vault backend on top of Phase 4a's commit-on-write:

- **Push queue** (debounced 5s, single-flight, `[5s, 30s, 5m, 30m]` retry backoff). Every successful commit triggers a non-blocking debounced push via `GitOps.afterCommit`.
- **Pull on session_start** via `git pull --rebase --autostash`. Changed-path diff reindexes lance rows with Phase 3 `content_hash` short-circuit (no re-embed if body unchanged).
- **Startup reconciliation** — any dirty tracked memory markdown on backend create (e.g. from a crash mid-write in Phase 4a) is collapsed into one `AB-Action: reconcile` commit before serving requests.
- **Envelope meta** — `memory_session_start` now surfaces `offline`, `pull_conflict`, `unpushed_commits`, `parse_errors` through `StorageBackend.sessionStart()`.
- **`AGENT_BRAIN_VAULT_REMOTE_URL`** env var — `ensureRemote` adds `origin` on fresh init; leaves existing origin alone with a warn on mismatch.
- **`alignWithRemote`** — detects divergent bootstrap commits between a fresh second-vault clone and a pre-populated bare origin; resets local `main` to `origin/main` and sets upstream tracking. Error-logged when discarding unrelated history.
- **Two-clone integration test** — bare origin + two `VaultBackend` instances, same process. Covers happy sync, non-conflicting concurrent writes, modify/delete conflict (`pull_conflict: true`), offline mode.

Spec: `docs/superpowers/specs/2026-04-22-vault-backend-phase-4b-git-sync-design.md`
Plan: `docs/superpowers/plans/2026-04-22-vault-backend-phase-4b-git-sync.md`

## Known limitations (tracked for 4c / follow-up)

1. **Hardcoded `main` branch** in both pull + push (`git pull origin main`, `git push --set-upstream origin HEAD:main`). Non-`main` default branches unsupported.
2. **`*.md merge=union` silently merges YAML frontmatter.** Two agents concurrently updating different frontmatter keys on the same memory produce a union-merged file that may become invalid YAML (surfaces as `parse_errors` on next read). The design spec was updated in Task 15 to reflect this; only non-union-resolvable conflicts (modify/delete) produce `pull_conflict: true`. Smart YAML merge driver is Phase 4c.
3. **`alignWithRemote` performs `reset --hard` on unrelated histories.** Intended for fresh-clone bootstrap only. Misconfigured `AGENT_BRAIN_VAULT_REMOTE_URL` on an existing vault with local-only commits will destroy them. Surfaces an `error`-level log before the reset.
4. **Push queue retry is in-process only.** SIGKILL between commit and successful push drops queued work; the next `sessionStart` re-kicks the push. `meta.unpushed_commits` is the recovery signal.
5. **`VaultMemoryRepository.syncPaths`** adds pulled paths to the in-memory index but does not remove deleted paths. Memories deleted remotely and pulled locally remain findable by ID until process restart (`findById` will throw ENOENT on the read).

## Test Plan

- [x] `npm run test:unit` — 474 tests across 51 files, all pass
- [x] `npm run typecheck` — clean
- [x] `tests/integration/vault/two-clone-sync.test.ts` — 4 cases, 3 consecutive runs no flakes
- [x] `tests/unit/server-boot.test.ts` — vault backend boots under `AGENT_BRAIN_BACKEND=vault` + `AGENT_BRAIN_VAULT_REMOTE_URL=<bare>`
- [x] Pre-commit hook (prettier + eslint + tsc + test:unit) green on every commit
- [ ] Manual smoke: configure a real vault against a git remote, run a few memory_create calls, verify commits show up with `AB-*` trailers and push to origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)