### PR TITLE
feat(vault): Phase 4c — audit on git log + smart merge driver

### DIFF
--- a/docs/superpowers/plans/2026-04-23-vault-backend-phase-4c-audit-merge.md
+++ b/docs/superpowers/plans/2026-04-23-vault-backend-phase-4c-audit-merge.md
@@ -1,0 +1,1970 @@
+# Vault Backend Phase 4c — Audit on Git Log + Smart Merge Driver Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move `VaultAuditRepository` onto `git log --grep` + blob re-parse, and replace the Phase 4a `*.md merge=union` `.gitattributes` rule with a field-aware Node CLI merge driver so concurrent frontmatter edits merge cleanly.
+
+**Architecture:** New CLI bin (`src/cli/merge-memory.ts`) registered as a git merge driver via `.git/config` on every bootstrap. `VaultAuditRepository` reimplemented as a pure reader over `git log` output + `git show` blob reads, parsing trailers already written by Phase 4a. Bootstrap swaps `.gitattributes` on first 4c startup; existing Phase 4b vaults migrate transparently via one reconcile commit.
+
+**Tech Stack:** TypeScript + Node built-ins (`node:child_process` for `diff3` invocation, `node:fs/promises` for file IO), `simple-git`, existing `parseMemoryFile` / `serializeMemoryFile`, Vitest, `fast-check` (property tests, optional).
+
+**Spec:** `docs/superpowers/specs/2026-04-23-vault-backend-phase-4c-audit-merge-design.md`
+
+**Related:**
+
+- Phase 4a spec: `docs/superpowers/plans/2026-04-21-vault-backend-phase-4-git-sync.md` (trailer schema)
+- Phase 4b spec: `docs/superpowers/specs/2026-04-22-vault-backend-phase-4b-git-sync-design.md` (push/pull infra this builds on)
+- Issue #38 — orphaned `merged` `AuditAction`, out of scope here
+
+---
+
+## File Structure
+
+### New files
+
+| Path                                                       | Responsibility                                                                                                          |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `src/backend/vault/git/trailer-parser.ts`                  | `parseTrailers(commitMessage): ParsedTrailers \| null` — inverse of `formatTrailers`. No external deps.                 |
+| `src/backend/vault/parser/merge-memory.ts`                 | Pure merge function: `mergeMemoryFiles(ancestor, ours, theirs) → { ok: true, merged } \| { ok: false, reason }`. No IO. |
+| `src/cli/merge-memory.ts`                                  | Node CLI entry. Reads three files from argv, calls `mergeMemoryFiles`, writes `%A`, exits 0/1.                          |
+| `src/backend/vault/git/merge-driver-config.ts`             | Resolves absolute path to the merge-driver CLI and writes `[merge "agent-brain-memory"]` section to `.git/config`.      |
+| `tests/unit/backend/vault/git/trailer-parser.test.ts`      | Unit tests for trailer parsing.                                                                                         |
+| `tests/unit/backend/vault/parser/merge-memory.test.ts`     | Per-field-rule unit tests for the merge function.                                                                       |
+| `tests/unit/cli/merge-memory.test.ts`                      | argv + exit-code tests for the CLI wrapper.                                                                             |
+| `tests/unit/backend/vault/git/merge-driver-config.test.ts` | `.git/config` writer tests.                                                                                             |
+| `tests/integration/vault/merge-driver.test.ts`             | Two-clone concurrent-edit rebase smoke test.                                                                            |
+| `tests/integration/vault/audit-history.test.ts`            | End-to-end `AuditService.getHistory` over real commits.                                                                 |
+
+### Modified files
+
+| Path                                                   | Change                                                                                                                                                                                                                                                                   |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `src/backend/vault/repositories/audit-repository.ts`   | Replace JSONL writer + reader with a git-log-backed reader. `create()` becomes a no-op.                                                                                                                                                                                  |
+| `src/backend/vault/git/bootstrap.ts`                   | Replace `GITATTRIBUTES_RULE = "*.md merge=union"` with three memory-path rules; remove legacy rule on upgrade; drop `_audit/` from `RUNTIME_IGNORES` and add it back as a **cleanup** via `git rm -r _audit/` if present. Call `ensureMergeDriverConfig` after git init. |
+| `src/backend/vault/index.ts`                           | No audit-constructor change (it already reads `root`). Nothing extra — bootstrap handles driver registration.                                                                                                                                                            |
+| `package.json`                                         | Add `"bin": { "agent-brain-merge-memory": "./dist/cli/merge-memory.js" }`. Bump version patch if team convention requires.                                                                                                                                               |
+| `tests/contract/repositories/audit-repository.test.ts` | May need small relaxation if pg stores `updated_at` Date objects in `before`/`after`; vault parsed equivalents must compare equal.                                                                                                                                       |
+
+### Deleted (at the end, after all tests green)
+
+| Path                                | Reason                                          |
+| ----------------------------------- | ----------------------------------------------- |
+| (vault instances) `<root>/_audit/*` | Dev-only; bootstrap cleans on first 4c startup. |
+
+---
+
+## Task 1: Add commit-trailer parser
+
+**Files:**
+
+- Create: `src/backend/vault/git/trailer-parser.ts`
+- Create: `tests/unit/backend/vault/git/trailer-parser.test.ts`
+- Reference (no changes): `src/backend/vault/git/trailers.ts`, `src/backend/vault/git/types.ts`
+
+**Context:** `trailers.ts` writes `AB-Action`, `AB-Memory`, `AB-Workspace`, `AB-Actor`, `AB-Reason` on commit. `AB-Reason` values are LF/CR-escaped via `encode()`. The parser must invert this. A commit is valid only if `AB-Action` is present; otherwise return `null` (non-agent-brain commit).
+
+- [ ] **Step 1.1: Write the failing tests**
+
+```typescript
+// tests/unit/backend/vault/git/trailer-parser.test.ts
+import { describe, it, expect } from "vitest";
+import { parseTrailers } from "../../../../../src/backend/vault/git/trailer-parser.js";
+
+describe("parseTrailers", () => {
+  it("parses a memory-action commit", () => {
+    const msg = [
+      "[agent-brain] update: memory-foo",
+      "",
+      "AB-Action: updated",
+      "AB-Memory: mem-123",
+      "AB-Actor: alice",
+    ].join("\n");
+    expect(parseTrailers(msg)).toEqual({
+      action: "updated",
+      memoryId: "mem-123",
+      actor: "alice",
+      reason: null,
+    });
+  });
+
+  it("parses a workspace_upsert commit", () => {
+    const msg = [
+      "[agent-brain] workspace: ws-1",
+      "",
+      "AB-Action: workspace_upsert",
+      "AB-Workspace: ws-1",
+      "AB-Actor: bob",
+    ].join("\n");
+    expect(parseTrailers(msg)).toEqual({
+      action: "workspace_upsert",
+      workspaceId: "ws-1",
+      actor: "bob",
+      reason: null,
+    });
+  });
+
+  it("parses a reconcile commit (no memory/workspace id)", () => {
+    const msg = "reconcile\n\nAB-Action: reconcile\nAB-Actor: system";
+    expect(parseTrailers(msg)).toEqual({
+      action: "reconcile",
+      actor: "system",
+      reason: null,
+    });
+  });
+
+  it("decodes AB-Reason escapes", () => {
+    const msg = [
+      "archive",
+      "",
+      "AB-Action: archived",
+      "AB-Memory: mem-1",
+      "AB-Actor: alice",
+      "AB-Reason: line-1\\nline-2\\\\tail",
+    ].join("\n");
+    const parsed = parseTrailers(msg);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.reason).toBe("line-1\nline-2\\tail");
+  });
+
+  it("returns null when AB-Action is absent", () => {
+    expect(parseTrailers("random commit")).toBeNull();
+    expect(parseTrailers("")).toBeNull();
+  });
+
+  it("tolerates leading CRLF line endings", () => {
+    const msg =
+      "subject\r\n\r\nAB-Action: created\r\nAB-Memory: mem-1\r\nAB-Actor: a";
+    expect(parseTrailers(msg)?.action).toBe("created");
+  });
+
+  it("returns null for an unknown AB-Action value", () => {
+    expect(parseTrailers("x\n\nAB-Action: nonsense\nAB-Actor: a")).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 1.2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/unit/backend/vault/git/trailer-parser.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 1.3: Implement the parser**
+
+```typescript
+// src/backend/vault/git/trailer-parser.ts
+import type { CommitTrailer, CommitAction } from "./types.js";
+
+export type ParsedTrailers = CommitTrailer;
+
+const KNOWN_ACTIONS: ReadonlySet<CommitAction> = new Set<CommitAction>([
+  "created",
+  "updated",
+  "archived",
+  "verified",
+  "commented",
+  "flagged",
+  "unflagged",
+  "related",
+  "unrelated",
+  "workspace_upsert",
+  "reconcile",
+]);
+
+export function parseTrailers(message: string): ParsedTrailers | null {
+  const fields: Record<string, string> = {};
+  // Normalize to LF so the line iterator works uniformly.
+  for (const raw of message.replace(/\r\n?/g, "\n").split("\n")) {
+    const m = raw.match(/^(AB-[A-Za-z]+):\s?(.*)$/);
+    if (m) fields[m[1]!] = m[2]!;
+  }
+
+  const action = fields["AB-Action"] as CommitAction | undefined;
+  if (!action || !KNOWN_ACTIONS.has(action)) return null;
+
+  const actor = fields["AB-Actor"] ?? "";
+  if (actor === "") return null;
+  const reason = fields["AB-Reason"] ? decode(fields["AB-Reason"]) : null;
+
+  if (action === "workspace_upsert") {
+    const workspaceId = fields["AB-Workspace"] ?? "";
+    if (workspaceId === "") return null;
+    return { action, workspaceId, actor, reason };
+  }
+  if (action === "reconcile") {
+    return { action, actor, reason };
+  }
+  const memoryId = fields["AB-Memory"] ?? "";
+  if (memoryId === "") return null;
+  return { action, memoryId, actor, reason };
+}
+
+function decode(s: string): string {
+  // Inverse of trailers.ts `encode`: \\\\ → \\, \\n → LF, \\r → CR.
+  // Walk the string once so `\\n` (literal backslash + `n`) round-trips.
+  let out = "";
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === "\\" && i + 1 < s.length) {
+      const next = s[i + 1]!;
+      if (next === "\\") {
+        out += "\\";
+        i++;
+        continue;
+      }
+      if (next === "n") {
+        out += "\n";
+        i++;
+        continue;
+      }
+      if (next === "r") {
+        out += "\r";
+        i++;
+        continue;
+      }
+    }
+    out += s[i];
+  }
+  return out;
+}
+```
+
+- [ ] **Step 1.4: Run tests to verify pass**
+
+Run: `npx vitest run tests/unit/backend/vault/git/trailer-parser.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add src/backend/vault/git/trailer-parser.ts tests/unit/backend/vault/git/trailer-parser.test.ts
+git commit -m "feat(vault): add commit trailer parser"
+```
+
+---
+
+## Task 2: Rewrite `VaultAuditRepository` as a git-log reader
+
+**Files:**
+
+- Modify: `src/backend/vault/repositories/audit-repository.ts` (replace)
+- Modify: `src/backend/vault/index.ts` (constructor args)
+- Create: `tests/unit/backend/vault/repositories/audit-repository.test.ts`
+
+**Context:** Current implementation at `src/backend/vault/repositories/audit-repository.ts` writes/reads JSONL under `_audit/<memoryId>.jsonl`. Replace with a reader that:
+
+1. Runs `git log --all --pretty='%H%x1f%aI%x1f%B%x1e' --grep='^AB-Memory: <id>$'` (uses `%x1f` = unit separator, `%x1e` = record separator — safer than newlines since messages contain them).
+2. Parses each record via `parseTrailers`.
+3. For `updated` action, reads parent + current blob via `git show`, parses each, picks five fields, builds `{ before, after }`.
+4. For everything else: `diff = null`.
+5. `create()` is a no-op (kept only so the interface stays compatible).
+
+Injecting `SimpleGit` through the constructor lets tests pass a mocked instance.
+
+- [ ] **Step 2.1: Write the failing tests**
+
+```typescript
+// tests/unit/backend/vault/repositories/audit-repository.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SimpleGit } from "simple-git";
+import { VaultAuditRepository } from "../../../../../src/backend/vault/repositories/audit-repository.js";
+
+const PROJECT_ID = "proj-1";
+
+function fakeGit(stubs: {
+  log?: (args: unknown) => string;
+  show?: (rev: string) => string;
+}): SimpleGit {
+  const raw = vi.fn<(args: string[]) => Promise<string>>(async (args) => {
+    if (args[0] === "log") {
+      if (!stubs.log) throw new Error("unexpected git log call");
+      return stubs.log(args);
+    }
+    if (args[0] === "show") {
+      if (!stubs.show) throw new Error("unexpected git show call");
+      return stubs.show(args[1]!);
+    }
+    throw new Error(`unexpected git args: ${args.join(" ")}`);
+  });
+  return { raw } as unknown as SimpleGit;
+}
+
+const memoryMd = (
+  over: Partial<{
+    title: string;
+    content: string;
+    updated: string;
+    tags: string[];
+  }>,
+) =>
+  [
+    "---",
+    "id: mem-1",
+    `project_id: ${PROJECT_ID}`,
+    "workspace_id: ws-1",
+    `title: ${over.title ?? "hello"}`,
+    "type: fact",
+    "scope: workspace",
+    `tags: ${JSON.stringify(over.tags ?? ["a", "b"])}`,
+    "author: alice",
+    "source: manual",
+    "session_id: null",
+    "metadata: null",
+    "embedding_model: null",
+    "embedding_dimensions: null",
+    "version: 1",
+    "created: 2026-04-01T00:00:00.000Z",
+    `updated: ${over.updated ?? "2026-04-20T10:00:00.000Z"}`,
+    "verified: null",
+    "archived: null",
+    "verified_by: null",
+    "---",
+    "",
+    "# hello",
+    "",
+    over.content ?? "body-text",
+    "",
+  ].join("\n");
+
+describe("VaultAuditRepository (git-log reader)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns [] when git log yields nothing", async () => {
+    const git = fakeGit({ log: () => "" });
+    const repo = new VaultAuditRepository({
+      root: "/tmp/vault",
+      git,
+      projectId: PROJECT_ID,
+    });
+    expect(await repo.findByMemoryId("mem-1")).toEqual([]);
+  });
+
+  it("parses a single created commit — diff is null", async () => {
+    const git = fakeGit({
+      log: () =>
+        [
+          "abc123",
+          "2026-04-01T00:00:00.000Z",
+          "create\n\nAB-Action: created\nAB-Memory: mem-1\nAB-Actor: alice",
+        ].join("\x1f") + "\x1e",
+    });
+    const repo = new VaultAuditRepository({
+      root: "/tmp/vault",
+      git,
+      projectId: PROJECT_ID,
+    });
+    const entries = await repo.findByMemoryId("mem-1");
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      memory_id: "mem-1",
+      action: "created",
+      actor: "alice",
+      reason: null,
+      diff: null,
+    });
+    expect(entries[0]!.created_at).toBeInstanceOf(Date);
+  });
+
+  it("reconstructs { before, after } for an update commit", async () => {
+    const git = fakeGit({
+      log: () =>
+        [
+          "def456",
+          "2026-04-20T10:00:00.000Z",
+          "update\n\nAB-Action: updated\nAB-Memory: mem-1\nAB-Actor: bob",
+        ].join("\x1f") + "\x1e",
+      show: (rev) => {
+        // rev = "def456^:workspaces/ws-1/memories/mem-1.md" or "def456:..."
+        if (rev.startsWith("def456^:"))
+          return memoryMd({ title: "hello", tags: ["a"] });
+        if (rev.startsWith("def456:"))
+          return memoryMd({ title: "hello-v2", tags: ["a", "b"] });
+        throw new Error(`unexpected rev ${rev}`);
+      },
+    });
+    const repo = new VaultAuditRepository({
+      root: "/tmp/vault",
+      git,
+      projectId: PROJECT_ID,
+    });
+    const entries = await repo.findByMemoryId("mem-1");
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.diff).toEqual({
+      before: {
+        content: "body-text",
+        title: "hello",
+        type: "fact",
+        tags: ["a"],
+        metadata: null,
+      },
+      after: {
+        content: "body-text",
+        title: "hello-v2",
+        type: "fact",
+        tags: ["a", "b"],
+        metadata: null,
+      },
+    });
+  });
+
+  it("sorts entries newest-first", async () => {
+    const git = fakeGit({
+      log: () =>
+        [
+          [
+            "aaa",
+            "2026-04-01T00:00:00.000Z",
+            "x\n\nAB-Action: created\nAB-Memory: mem-1\nAB-Actor: a",
+          ].join("\x1f"),
+          [
+            "bbb",
+            "2026-04-02T00:00:00.000Z",
+            "x\n\nAB-Action: archived\nAB-Memory: mem-1\nAB-Actor: a",
+          ].join("\x1f"),
+        ].join("\x1e") + "\x1e",
+    });
+    const repo = new VaultAuditRepository({
+      root: "/tmp/vault",
+      git,
+      projectId: PROJECT_ID,
+    });
+    const entries = await repo.findByMemoryId("mem-1");
+    expect(entries.map((e) => e.action)).toEqual(["archived", "created"]);
+  });
+
+  it("create() is a no-op (returns without throwing, no git calls)", async () => {
+    const git = fakeGit({});
+    const repo = new VaultAuditRepository({
+      root: "/tmp/vault",
+      git,
+      projectId: PROJECT_ID,
+    });
+    await repo.create({
+      id: "a1",
+      project_id: PROJECT_ID,
+      memory_id: "mem-1",
+      action: "created",
+      actor: "alice",
+      reason: null,
+      diff: null,
+      created_at: new Date(),
+    });
+  });
+
+  it("skips commits whose trailer fails to parse", async () => {
+    const git = fakeGit({
+      log: () =>
+        [
+          ["aaa", "2026-04-01T00:00:00.000Z", "garbage-no-trailer"].join(
+            "\x1f",
+          ),
+          [
+            "bbb",
+            "2026-04-02T00:00:00.000Z",
+            "x\n\nAB-Action: created\nAB-Memory: mem-1\nAB-Actor: a",
+          ].join("\x1f"),
+        ].join("\x1e") + "\x1e",
+    });
+    const repo = new VaultAuditRepository({
+      root: "/tmp/vault",
+      git,
+      projectId: PROJECT_ID,
+    });
+    const entries = await repo.findByMemoryId("mem-1");
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.action).toBe("created");
+  });
+});
+```
+
+- [ ] **Step 2.2: Run tests to verify fail**
+
+Run: `npx vitest run tests/unit/backend/vault/repositories/audit-repository.test.ts`
+Expected: FAIL — constructor signature mismatch or behavior mismatch.
+
+- [ ] **Step 2.3: Rewrite the repository**
+
+```typescript
+// src/backend/vault/repositories/audit-repository.ts
+import type { SimpleGit } from "simple-git";
+import type { AuditEntry } from "../../../types/audit.js";
+import type { AuditAction } from "../../../types/audit.js";
+import type { AuditRepository } from "../../../repositories/types.js";
+import { parseTrailers } from "../git/trailer-parser.js";
+import { parseMemoryFile } from "../parser/memory-parser.js";
+import { memoryPath } from "../io/paths.js";
+import type { CommitAction } from "../git/types.js";
+import { logger } from "../../../utils/logger.js";
+
+export interface VaultAuditConfig {
+  root: string;
+  git: SimpleGit;
+  projectId: string;
+}
+
+// Five fields match what MemoryService.update passes to
+// AuditService.logUpdate — keep in sync or the contract test will fail.
+const DIFF_FIELDS = ["content", "title", "type", "tags", "metadata"] as const;
+type DiffFields = Pick<
+  ReturnType<typeof parseMemoryFile>["memory"],
+  (typeof DIFF_FIELDS)[number]
+>;
+
+const UNIT = "\x1f"; // field separator
+const RECORD = "\x1e"; // record separator
+
+const TRAILER_TO_AUDIT: Partial<Record<CommitAction, AuditAction>> = {
+  created: "created",
+  updated: "updated",
+  archived: "archived",
+  commented: "commented",
+  flagged: "flagged",
+};
+
+export class VaultAuditRepository implements AuditRepository {
+  constructor(private readonly cfg: VaultAuditConfig) {}
+
+  // create() still exists on the interface but the vault backend has no
+  // state to write — git commits (with trailers) are the audit log.
+  // Kept as a no-op so existing callers don't break.
+  async create(_entry: AuditEntry): Promise<void> {
+    // intentional no-op
+  }
+
+  async findByMemoryId(memoryId: string): Promise<AuditEntry[]> {
+    // --grep on a fixed-anchored trailer line; --extended-regexp so `^`
+    // and `$` apply per-line (the default is per-message).
+    const raw = await this.cfg.git.raw([
+      "log",
+      "--all",
+      "--extended-regexp",
+      `--grep=^AB-Memory: ${escapeRe(memoryId)}$`,
+      `--pretty=${"%H"}${UNIT}${"%aI"}${UNIT}${"%B"}${RECORD}`,
+    ]);
+
+    const records = raw
+      .split(RECORD)
+      .map((r) => r.trim())
+      .filter((r) => r !== "");
+
+    const entries: AuditEntry[] = [];
+    for (const rec of records) {
+      const [sha, iso, ...rest] = rec.split(UNIT);
+      if (!sha || !iso || rest.length === 0) continue;
+      const message = rest.join(UNIT);
+      const trailers = parseTrailers(message);
+      if (!trailers) continue;
+      if (!("memoryId" in trailers) || trailers.memoryId !== memoryId) continue;
+      const auditAction = TRAILER_TO_AUDIT[trailers.action];
+      if (!auditAction) continue;
+
+      let diff: Record<string, unknown> | null = null;
+      if (auditAction === "updated") {
+        try {
+          diff = await this.reconstructUpdateDiff(sha, memoryId);
+        } catch (err) {
+          logger.warn(
+            `vault audit: failed to reconstruct diff for ${sha} ${memoryId}`,
+            err,
+          );
+        }
+      }
+
+      entries.push({
+        id: sha,
+        project_id: this.cfg.projectId,
+        memory_id: memoryId,
+        action: auditAction,
+        actor: trailers.actor,
+        reason: trailers.reason,
+        diff,
+        created_at: new Date(iso),
+      });
+    }
+
+    return entries.sort(
+      (a, b) => b.created_at.getTime() - a.created_at.getTime(),
+    );
+  }
+
+  private async reconstructUpdateDiff(
+    sha: string,
+    memoryId: string,
+  ): Promise<{ before: DiffFields; after: DiffFields } | null> {
+    // Locate the memory file as of this commit by asking git for the
+    // changed paths. Scope is stable across history (memories don't
+    // move between workspaces today) so we can pick the first matching
+    // memory-layout path.
+    const nameStatus = await this.cfg.git.raw([
+      "show",
+      "--name-only",
+      "--pretty=format:",
+      sha,
+    ]);
+    const path = findMemoryPath(nameStatus, memoryId);
+    if (!path) return null;
+
+    const [beforeRaw, afterRaw] = await Promise.all([
+      this.safeShow(`${sha}^:${path}`),
+      this.safeShow(`${sha}:${path}`),
+    ]);
+    if (beforeRaw === null || afterRaw === null) return null;
+
+    const before = parseMemoryFile(beforeRaw).memory;
+    const after = parseMemoryFile(afterRaw).memory;
+    return {
+      before: pickFields(before),
+      after: pickFields(after),
+    };
+  }
+
+  private async safeShow(rev: string): Promise<string | null> {
+    try {
+      return await this.cfg.git.raw(["show", rev]);
+    } catch {
+      // First commit on a branch has no parent; git show returns
+      // exit 128. Treat as "no parent blob" and skip diff.
+      return null;
+    }
+  }
+}
+
+function pickFields(
+  m: ReturnType<typeof parseMemoryFile>["memory"],
+): DiffFields {
+  return {
+    content: m.content,
+    title: m.title,
+    type: m.type,
+    tags: m.tags,
+    metadata: m.metadata,
+  } as DiffFields;
+}
+
+function findMemoryPath(
+  nameStatusOutput: string,
+  memoryId: string,
+): string | null {
+  for (const line of nameStatusOutput.split("\n")) {
+    const p = line.trim();
+    if (p === "") continue;
+    if (p.endsWith(`/${memoryId}.md`)) return p;
+  }
+  return null;
+}
+
+function escapeRe(s: string): string {
+  // Memory ids are nanoid-ish (alphanumeric-ish) but escape defensively.
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+```
+
+- [ ] **Step 2.4: Wire `git` + `projectId` through `VaultBackend.create`**
+
+```typescript
+// src/backend/vault/index.ts - inside the private constructor
+-    this.auditRepo = new VaultAuditRepository({ root });
++    this.auditRepo = new VaultAuditRepository({
++      root,
++      git: this.git,
++      projectId: "UNKNOWN", // project ids are per-memory; see note below
++    });
+```
+
+Note: `AuditEntry.project_id` in the pg schema is actually the _memory's_ project — pg joins the memory row on write. Vault has no such join; the trailer does not carry project_id. The field is informational; we fill `"UNKNOWN"` until the consumer that cares proves otherwise (`getHistory` has no production caller as of this plan). If the contract test fails on project_id equality, fix forward by fetching the parsed memory's project_id from the same blob read.
+
+- [ ] **Step 2.5: Run the unit tests**
+
+Run: `npx vitest run tests/unit/backend/vault/repositories/audit-repository.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 2.6: Run the existing audit contract test against the vault backend**
+
+Run: `npx vitest run tests/contract/repositories/audit-repository.test.ts`
+Expected: PASS for vault backend. If project_id equality fails, apply the fix-forward from step 2.4 (read from blob).
+
+- [ ] **Step 2.7: Commit**
+
+```bash
+git add src/backend/vault/repositories/audit-repository.ts src/backend/vault/index.ts tests/unit/backend/vault/repositories/audit-repository.test.ts
+git commit -m "feat(vault): rewrite VaultAuditRepository as git-log reader"
+```
+
+---
+
+## Task 3: Drop `_audit/` from runtime ignores + clean up stale JSONL on startup
+
+**Files:**
+
+- Modify: `src/backend/vault/git/bootstrap.ts`
+- Modify: `tests/unit/backend/vault/git/bootstrap.test.ts`
+
+**Context:** `RUNTIME_IGNORES` in `bootstrap.ts:11-18` currently lists `_audit/`. Safe to remove — no writer produces it anymore after Task 2. Also run a one-time cleanup: if `<root>/_audit/` exists at bootstrap, `rm -rf` it. Spec explicitly calls out vault is dev-only, so no migration preservation.
+
+- [ ] **Step 3.1: Write the failing test**
+
+```typescript
+// tests/unit/backend/vault/git/bootstrap.test.ts — append a new describe
+describe("ensureVaultGit — _audit/ cleanup", () => {
+  it("removes an existing _audit/ directory on startup", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vault-"));
+    await mkdir(join(root, "_audit"), { recursive: true });
+    await writeFile(join(root, "_audit", "mem-1.jsonl"), "{}\n", "utf8");
+    await ensureVaultGit({ root, trackUsers: false });
+    await expect(stat(join(root, "_audit"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("does not list _audit/ in the committed .gitignore", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vault-"));
+    await ensureVaultGit({ root, trackUsers: false });
+    const body = await readFile(join(root, ".gitignore"), "utf8");
+    expect(body).not.toMatch(/^_audit\/?$/m);
+  });
+});
+```
+
+(Add the relevant imports at the top if the existing file doesn't have them: `stat`, `mkdir`, `writeFile`, `mkdtemp`, `readFile` from `node:fs/promises`; `tmpdir` from `node:os`.)
+
+- [ ] **Step 3.2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/backend/vault/git/bootstrap.test.ts`
+Expected: FAIL — `_audit/` still listed in ignores and not cleaned up.
+
+- [ ] **Step 3.3: Update `RUNTIME_IGNORES` and add cleanup**
+
+```typescript
+// src/backend/vault/git/bootstrap.ts
+-const RUNTIME_IGNORES = [
+-  ".agent-brain/",
+-  "_sessions/",
+-  "_session-tracking/",
+-  "_scheduler-state.json",
+-  "_audit/",
+-];
++const RUNTIME_IGNORES = [
++  ".agent-brain/",
++  "_sessions/",
++  "_session-tracking/",
++  "_scheduler-state.json",
++];
+```
+
+Add near the top of `ensureVaultGit`, right after `if (!wasRepo) await git.init();`:
+
+```typescript
+// Phase 4c cleanup: _audit/ is no longer produced (audit reads from
+// git log). Remove any leftovers from earlier phases so a stale
+// directory doesn't confuse the user.
+await rmrf(join(opts.root, "_audit"));
+```
+
+And a local helper:
+
+```typescript
+import { rm } from "node:fs/promises";
+
+async function rmrf(path: string): Promise<void> {
+  await rm(path, { recursive: true, force: true });
+}
+```
+
+- [ ] **Step 3.4: Run to verify pass**
+
+Run: `npx vitest run tests/unit/backend/vault/git/bootstrap.test.ts`
+Expected: PASS (all tests in the file).
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add src/backend/vault/git/bootstrap.ts tests/unit/backend/vault/git/bootstrap.test.ts
+git commit -m "feat(vault): drop _audit/ ignore, clean up stale JSONL on startup"
+```
+
+---
+
+## Task 4: Pure merge function
+
+**Files:**
+
+- Create: `src/backend/vault/parser/merge-memory.ts`
+- Create: `tests/unit/backend/vault/parser/merge-memory.test.ts`
+
+**Context:** The driver needs a pure function `mergeMemoryFiles(ancestor, ours, theirs)` that returns either the merged markdown or a machine-readable reason for giving up. All rules from spec §"Per-Field Merge Rules" land here. No IO, no subprocess, no logging.
+
+Body-text diff3 uses `git merge-file` as a subprocess — **exception** to "no IO": we need diff3 semantics and reimplementing diff3 is out of scope. The function accepts an injected `diff3` callback so tests can stub it.
+
+- [ ] **Step 4.1: Write failing tests**
+
+Given the volume, split the test file into sections. One test per rule at minimum. Abbreviated here — write exhaustively against every field in the rules table.
+
+```typescript
+// tests/unit/backend/vault/parser/merge-memory.test.ts
+import { describe, it, expect } from "vitest";
+import { mergeMemoryFiles } from "../../../../../src/backend/vault/parser/merge-memory.js";
+import { parseMemoryFile } from "../../../../../src/backend/vault/parser/memory-parser.js";
+
+const base = (over: Record<string, unknown> = {}) =>
+  [
+    "---",
+    "id: mem-1",
+    "project_id: proj-1",
+    "workspace_id: ws-1",
+    `title: ${over.title ?? "hello"}`,
+    `type: ${over.type ?? "fact"}`,
+    `scope: ${over.scope ?? "workspace"}`,
+    `tags: ${JSON.stringify(over.tags ?? ["a"])}`,
+    `author: ${over.author ?? "alice"}`,
+    "source: null",
+    "session_id: null",
+    `metadata: ${over.metadata === undefined ? "null" : JSON.stringify(over.metadata)}`,
+    "embedding_model: null",
+    "embedding_dimensions: null",
+    `version: ${over.version ?? 1}`,
+    "created: 2026-04-01T00:00:00.000Z",
+    `updated: ${over.updated ?? "2026-04-20T10:00:00.000Z"}`,
+    `verified: ${over.verified ?? "null"}`,
+    `archived: ${over.archived ?? "null"}`,
+    `verified_by: ${over.verified_by ?? "null"}`,
+    "---",
+    "",
+    `# ${over.title ?? "hello"}`,
+    "",
+    `${over.content ?? "body"}`,
+    "",
+  ].join("\n");
+
+const passthroughDiff3 = () => ({ clean: true as const, text: "" });
+
+describe("mergeMemoryFiles", () => {
+  it("returns { ok: true } with union-merged tags", async () => {
+    const a = base({ tags: ["a"] });
+    const o = base({ tags: ["a", "x"] });
+    const t = base({ tags: ["a", "y"] });
+    const res = await mergeMemoryFiles(a, o, t, { diff3: passthroughDiff3 });
+    if (!res.ok) throw new Error(res.reason);
+    const merged = parseMemoryFile(res.merged).memory;
+    expect(merged.tags).toEqual(["a", "x", "y"]);
+  });
+
+  it("picks the side with the later updated_at for LWW fields (title)", async () => {
+    const a = base({ title: "base" });
+    const o = base({ title: "ours", updated: "2026-04-20T10:00:00.000Z" });
+    const t = base({ title: "theirs", updated: "2026-04-20T11:00:00.000Z" });
+    const res = await mergeMemoryFiles(a, o, t, { diff3: passthroughDiff3 });
+    if (!res.ok) throw new Error(res.reason);
+    expect(parseMemoryFile(res.merged).memory.title).toBe("theirs");
+  });
+
+  it("takes max of both updated_at timestamps", async () => {
+    const a = base();
+    const o = base({ updated: "2026-04-20T10:00:00.000Z" });
+    const t = base({ updated: "2026-04-21T00:00:00.000Z" });
+    const res = await mergeMemoryFiles(a, o, t, { diff3: passthroughDiff3 });
+    if (!res.ok) throw new Error(res.reason);
+    expect(parseMemoryFile(res.merged).memory.updated_at.toISOString()).toBe(
+      "2026-04-21T00:00:00.000Z",
+    );
+  });
+
+  it("archived_at: once archived, stays", async () => {
+    const a = base();
+    const o = base({ archived: "2026-04-20T10:00:00.000Z" });
+    const t = base({ archived: "null" });
+    const res = await mergeMemoryFiles(a, o, t, { diff3: passthroughDiff3 });
+    if (!res.ok) throw new Error(res.reason);
+    expect(parseMemoryFile(res.merged).memory.archived_at?.toISOString()).toBe(
+      "2026-04-20T10:00:00.000Z",
+    );
+  });
+
+  it("rejects on immutable-field divergence (project_id)", async () => {
+    const a = base();
+    const o = base();
+    const t = a.replace("project_id: proj-1", "project_id: proj-X");
+    const res = await mergeMemoryFiles(a, o, t, { diff3: passthroughDiff3 });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.reason).toMatch(/project_id/);
+  });
+
+  it("rejects on parse failure of any side", async () => {
+    const res = await mergeMemoryFiles(base(), "not markdown", base(), {
+      diff3: passthroughDiff3,
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("metadata: per-key merge picks the side with later updated_at", async () => {
+    const a = base({ metadata: { keep: 1 } });
+    const o = base({
+      metadata: { keep: 1, ours: "o" },
+      updated: "2026-04-20T10:00:00.000Z",
+    });
+    const t = base({
+      metadata: { keep: 1, theirs: "t" },
+      updated: "2026-04-20T11:00:00.000Z",
+    });
+    const res = await mergeMemoryFiles(a, o, t, { diff3: passthroughDiff3 });
+    if (!res.ok) throw new Error(res.reason);
+    const mergedMeta = parseMemoryFile(res.merged).memory.metadata;
+    expect(mergedMeta).toEqual({ keep: 1, ours: "o", theirs: "t" });
+  });
+
+  it("verified_at/verified_by: take the pair with later verified_at", async () => {
+    const a = base();
+    const o = base({
+      verified: "2026-04-19T00:00:00.000Z",
+      verified_by: "alice",
+    });
+    const t = base({
+      verified: "2026-04-20T00:00:00.000Z",
+      verified_by: "bob",
+    });
+    const res = await mergeMemoryFiles(a, o, t, { diff3: passthroughDiff3 });
+    if (!res.ok) throw new Error(res.reason);
+    const m = parseMemoryFile(res.merged).memory;
+    expect(m.verified_at?.toISOString()).toBe("2026-04-20T00:00:00.000Z");
+    expect(m.verified_by).toBe("bob");
+  });
+
+  it("falls back to LWW when diff3 reports conflict", async () => {
+    const a = base({ content: "base-body" });
+    const o = base({
+      content: "ours-body",
+      updated: "2026-04-20T10:00:00.000Z",
+    });
+    const t = base({
+      content: "theirs-body",
+      updated: "2026-04-21T00:00:00.000Z",
+    });
+    const res = await mergeMemoryFiles(a, o, t, {
+      diff3: () => ({ clean: false as const }),
+    });
+    if (!res.ok) throw new Error(res.reason);
+    expect(parseMemoryFile(res.merged).memory.content.trim()).toBe(
+      "theirs-body",
+    );
+  });
+});
+```
+
+- [ ] **Step 4.2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/backend/vault/parser/merge-memory.test.ts`
+Expected: FAIL — module not defined.
+
+- [ ] **Step 4.3: Implement `mergeMemoryFiles`**
+
+```typescript
+// src/backend/vault/parser/merge-memory.ts
+import { parseMemoryFile, serializeMemoryFile } from "./memory-parser.js";
+import type { ParsedMemoryFile } from "./memory-parser.js";
+import type { Memory } from "../../../types/memory.js";
+
+export type MergeResult =
+  | { ok: true; merged: string }
+  | { ok: false; reason: string };
+
+export interface Diff3Result {
+  clean: boolean;
+  text?: string;
+}
+
+export interface MergeOptions {
+  /**
+   * Three-way diff over body text. Called with (base, ours, theirs) as
+   * raw strings. Returns the clean merged text or { clean: false } on
+   * unresolvable conflict, in which case the caller falls back to LWW.
+   */
+  diff3: (
+    base: string,
+    ours: string,
+    theirs: string,
+  ) => Promise<Diff3Result> | Diff3Result;
+}
+
+export async function mergeMemoryFiles(
+  ancestor: string,
+  ours: string,
+  theirs: string,
+  opts: MergeOptions,
+): Promise<MergeResult> {
+  let a: ParsedMemoryFile, o: ParsedMemoryFile, t: ParsedMemoryFile;
+  try {
+    a = parseMemoryFile(ancestor);
+    o = parseMemoryFile(ours);
+    t = parseMemoryFile(theirs);
+  } catch (err) {
+    return { ok: false, reason: `parse: ${(err as Error).message}` };
+  }
+
+  // Immutable fields — bail if our/theirs disagree.
+  for (const field of ["id", "project_id"] as const) {
+    if (o.memory[field] !== t.memory[field]) {
+      return { ok: false, reason: `immutable field diverged: ${field}` };
+    }
+  }
+  if (o.memory.created_at.getTime() !== t.memory.created_at.getTime()) {
+    return { ok: false, reason: "immutable field diverged: created_at" };
+  }
+
+  const later =
+    o.memory.updated_at.getTime() >= t.memory.updated_at.getTime() ? o : t;
+  const earlier = later === o ? t : o;
+
+  // Body content via diff3, LWW fallback.
+  const bodyResult = await opts.diff3(
+    a.memory.content,
+    o.memory.content,
+    t.memory.content,
+  );
+  const mergedContent =
+    bodyResult.clean && bodyResult.text !== undefined
+      ? bodyResult.text
+      : later.memory.content;
+
+  const merged: Memory = {
+    ...later.memory,
+    content: mergedContent,
+    // Monotonic
+    updated_at: new Date(
+      Math.max(o.memory.updated_at.getTime(), t.memory.updated_at.getTime()),
+    ),
+    archived_at: maxDate(o.memory.archived_at, t.memory.archived_at),
+    verified_at: pickLaterNonNull(o.memory.verified_at, t.memory.verified_at),
+    verified_by: pickLaterNonNull(o.memory.verified_at, t.memory.verified_at)
+      ? o.memory.verified_at !== null &&
+        (t.memory.verified_at === null ||
+          o.memory.verified_at.getTime() >= t.memory.verified_at.getTime())
+        ? o.memory.verified_by
+        : t.memory.verified_by
+      : null,
+    // Union
+    tags: unionSorted(o.memory.tags, t.memory.tags),
+    // Per-key LWW on metadata
+    metadata: mergeMetadata(o.memory, t.memory, later === o),
+    // Derived
+    flag_count: 0, // recomputed by serializer based on merged flags
+    comment_count: 0,
+    relationship_count: 0,
+    last_comment_at: null,
+  };
+
+  // Body subsections: union by id. Comments & flags are append-only;
+  // relationships keyed by (target, type).
+  const comments = unionBy(o.comments, t.comments, (c) => c.id);
+  const flags = unionBy(o.flags, t.flags, (f) => f.id);
+  const relationships = unionBy(
+    o.relationships,
+    t.relationships,
+    (r) => `${r.source_id}|${r.target_id}|${r.type}`,
+  );
+
+  const out: ParsedMemoryFile = {
+    memory: {
+      ...merged,
+      flag_count: flags.filter((f) => f.resolved_at === null).length,
+      comment_count: comments.length,
+      relationship_count: relationships.length,
+      last_comment_at:
+        comments.length === 0
+          ? null
+          : new Date(Math.max(...comments.map((c) => c.created_at.getTime()))),
+    },
+    flags,
+    comments,
+    relationships,
+  };
+
+  return { ok: true, merged: serializeMemoryFile(out) };
+}
+
+function maxDate(a: Date | null, b: Date | null): Date | null {
+  if (a === null) return b;
+  if (b === null) return a;
+  return a.getTime() >= b.getTime() ? a : b;
+}
+
+function pickLaterNonNull(a: Date | null, b: Date | null): Date | null {
+  return maxDate(a, b);
+}
+
+function unionSorted(a: string[] | null, b: string[] | null): string[] | null {
+  if (a === null && b === null) return null;
+  const set = new Set<string>([...(a ?? []), ...(b ?? [])]);
+  return Array.from(set).sort();
+}
+
+function mergeMetadata(
+  a: Memory,
+  b: Memory,
+  aIsLater: boolean,
+): Record<string, unknown> | null {
+  if (a.metadata === null && b.metadata === null) return null;
+  const winner = aIsLater ? a.metadata : b.metadata;
+  const loser = aIsLater ? b.metadata : a.metadata;
+  const out: Record<string, unknown> = { ...(loser ?? {}) };
+  if (winner) for (const [k, v] of Object.entries(winner)) out[k] = v;
+  return out;
+}
+
+function unionBy<T>(a: T[], b: T[], key: (x: T) => string): T[] {
+  const seen = new Map<string, T>();
+  for (const x of a) seen.set(key(x), x);
+  for (const x of b) seen.set(key(x), x); // theirs overwrites on collision
+  return Array.from(seen.values());
+}
+```
+
+- [ ] **Step 4.4: Run to verify pass**
+
+Run: `npx vitest run tests/unit/backend/vault/parser/merge-memory.test.ts`
+Expected: PASS (all tests).
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add src/backend/vault/parser/merge-memory.ts tests/unit/backend/vault/parser/merge-memory.test.ts
+git commit -m "feat(vault): pure mergeMemoryFiles with per-field rules"
+```
+
+---
+
+## Task 5: CLI wrapper — `src/cli/merge-memory.ts`
+
+**Files:**
+
+- Create: `src/cli/merge-memory.ts`
+- Create: `tests/unit/cli/merge-memory.test.ts`
+- Modify: `package.json` (add `"bin"` entry)
+- Modify: `tsconfig.json` if `src/cli/` is not yet covered by includes (verify first)
+
+**Context:** Git invokes the driver as `driver %A %O %B` (our/base/their). Writes merged result to `%A`, exit 0 = clean, exit 1 = conflict. Uses `git merge-file -p --diff3` as the diff3 backend (ships with git, matches git's own behavior for unified-patch output).
+
+- [ ] **Step 5.1: Verify `tsconfig.json` includes `src/**/\*`\*\*
+
+Run: `grep -n '"include"' tsconfig.json`
+Expected: a glob that covers `src/**/*.ts`. If not, amend; but `src/` is already included in this repo per existing `src/server.ts` etc.
+
+- [ ] **Step 5.2: Write failing test**
+
+```typescript
+// tests/unit/cli/merge-memory.test.ts
+import { describe, it, expect } from "vitest";
+import { mkdtemp, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { run } from "../../../src/cli/merge-memory.js";
+
+async function tmp(body: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "merge-"));
+  const p = join(dir, "f.md");
+  await writeFile(p, body, "utf8");
+  return p;
+}
+
+const memoryMd = (title: string) =>
+  [
+    "---",
+    "id: mem-1",
+    "project_id: proj-1",
+    "workspace_id: ws-1",
+    `title: ${title}`,
+    "type: fact",
+    "scope: workspace",
+    'tags: ["a"]',
+    "author: alice",
+    "source: null",
+    "session_id: null",
+    "metadata: null",
+    "embedding_model: null",
+    "embedding_dimensions: null",
+    "version: 1",
+    "created: 2026-04-01T00:00:00.000Z",
+    "updated: 2026-04-20T10:00:00.000Z",
+    "verified: null",
+    "archived: null",
+    "verified_by: null",
+    "---",
+    "",
+    `# ${title}`,
+    "",
+    "body",
+    "",
+  ].join("\n");
+
+describe("merge-memory CLI run()", () => {
+  it("returns 0 and writes merged content to %A", async () => {
+    const A = await tmp(memoryMd("ours"));
+    const O = await tmp(memoryMd("base"));
+    const B = await tmp(memoryMd("theirs"));
+    const code = await run([A, O, B]);
+    expect(code).toBe(0);
+    const out = await readFile(A, "utf8");
+    expect(out).toMatch(/title: /);
+  });
+
+  it("returns 1 on parse failure", async () => {
+    const A = await tmp("not yaml");
+    const O = await tmp(memoryMd("x"));
+    const B = await tmp(memoryMd("y"));
+    expect(await run([A, O, B])).toBe(1);
+  });
+
+  it("returns 1 on immutable-field divergence", async () => {
+    const A = await tmp(memoryMd("ours"));
+    const O = await tmp(memoryMd("base"));
+    const theirs = memoryMd("theirs").replace(
+      "project_id: proj-1",
+      "project_id: proj-X",
+    );
+    const B = await tmp(theirs);
+    expect(await run([A, O, B])).toBe(1);
+  });
+
+  it("prints a parse error to stderr on exit 1 (smoke)", async () => {
+    const A = await tmp("not yaml");
+    const O = await tmp(memoryMd("x"));
+    const B = await tmp(memoryMd("y"));
+    const errs: unknown[] = [];
+    const origErr = console.error;
+    console.error = (...args) => {
+      errs.push(args);
+    };
+    try {
+      await run([A, O, B]);
+    } finally {
+      console.error = origErr;
+    }
+    expect(errs.length).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 5.3: Run to verify failure**
+
+Run: `npx vitest run tests/unit/cli/merge-memory.test.ts`
+Expected: FAIL — module missing.
+
+- [ ] **Step 5.4: Implement CLI**
+
+```typescript
+// src/cli/merge-memory.ts
+#!/usr/bin/env node
+import { readFile, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { mergeMemoryFiles } from "../backend/vault/parser/merge-memory.js";
+import type { Diff3Result } from "../backend/vault/parser/merge-memory.js";
+
+/**
+ * Git merge driver entry point. argv = [%A, %O, %B] (ours, ancestor, theirs)
+ * per the driver spec; we rewrite %A with the merged content.
+ */
+export async function run(argv: readonly string[]): Promise<number> {
+  if (argv.length < 3) {
+    console.error("usage: merge-memory %A %O %B");
+    return 1;
+  }
+  const [ours, ancestor, theirs] = argv as [string, string, string];
+  try {
+    const [oursBody, ancestorBody, theirsBody] = await Promise.all([
+      readFile(ours, "utf8"),
+      readFile(ancestor, "utf8"),
+      readFile(theirs, "utf8"),
+    ]);
+    const res = await mergeMemoryFiles(ancestorBody, oursBody, theirsBody, {
+      diff3: gitMergeFile,
+    });
+    if (!res.ok) {
+      console.error(`agent-brain-merge-memory: ${res.reason}`);
+      return 1;
+    }
+    await writeFile(ours, res.merged, "utf8");
+    return 0;
+  } catch (err) {
+    console.error(`agent-brain-merge-memory: ${(err as Error).message}`);
+    return 1;
+  }
+}
+
+// Uses `git merge-file -p` with three stdin sources delivered as tmp
+// files. Returns clean text on exit 0, { clean: false } on exit 1
+// (conflict). Exit >1 is a real error and escalates.
+async function gitMergeFile(
+  base: string,
+  our: string,
+  their: string,
+): Promise<Diff3Result> {
+  // Round-trip through temp files. git merge-file does not accept
+  // pipes for base/their — only ours is stdin. Easiest path: three tmp
+  // files + `-p` to stream merged result on stdout.
+  const { mkdtemp, writeFile } = await import("node:fs/promises");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const dir = await mkdtemp(join(tmpdir(), "mm-"));
+  const [basePath, ourPath, theirPath] = await Promise.all([
+    writeAndReturn(join(dir, "base"), base),
+    writeAndReturn(join(dir, "ours"), our),
+    writeAndReturn(join(dir, "theirs"), their),
+  ]);
+  return new Promise<Diff3Result>((resolve, reject) => {
+    const child = spawn("git", ["merge-file", "-p", ourPath, basePath, theirPath]);
+    const chunks: Buffer[] = [];
+    child.stdout.on("data", (c: Buffer) => chunks.push(c));
+    child.stderr.on("data", () => {}); // suppress diagnostics
+    child.on("error", reject);
+    child.on("close", (code) => {
+      const text = Buffer.concat(chunks).toString("utf8");
+      if (code === 0) resolve({ clean: true, text });
+      else if (code === 1) resolve({ clean: false });
+      else reject(new Error(`git merge-file exited ${code}`));
+    });
+  });
+
+  async function writeAndReturn(p: string, body: string): Promise<string> {
+    await writeFile(p, body, "utf8");
+    return p;
+  }
+}
+
+// ESM main-module check without top-level `import.meta` globbing.
+if (process.argv[1] && process.argv[1].endsWith("merge-memory.js")) {
+  run(process.argv.slice(2)).then(
+    (code) => process.exit(code),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    },
+  );
+}
+```
+
+- [ ] **Step 5.5: Add `"bin"` entry to `package.json`**
+
+```json
+  "bin": {
+    "agent-brain-merge-memory": "./dist/cli/merge-memory.js"
+  },
+```
+
+Verify the build pipeline already emits to `dist/cli/`:
+
+Run: `npm run build && ls dist/cli/merge-memory.js`
+Expected: file exists after build.
+
+- [ ] **Step 5.6: Run to verify pass**
+
+Run: `npx vitest run tests/unit/cli/merge-memory.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5.7: Commit**
+
+```bash
+git add src/cli/merge-memory.ts tests/unit/cli/merge-memory.test.ts package.json
+git commit -m "feat(vault): add agent-brain-merge-memory git merge driver CLI"
+```
+
+---
+
+## Task 6: Write `[merge "agent-brain-memory"]` driver config on bootstrap
+
+**Files:**
+
+- Create: `src/backend/vault/git/merge-driver-config.ts`
+- Create: `tests/unit/backend/vault/git/merge-driver-config.test.ts`
+- Modify: `src/backend/vault/git/bootstrap.ts` (call it)
+- Modify: `tests/unit/backend/vault/git/bootstrap.test.ts` (assert config written)
+
+**Context:** Every `VaultBackend.create` writes (idempotently) a `[merge "agent-brain-memory"]` section to `<root>/.git/config` with an absolute path to `dist/cli/merge-memory.js`. Absolute path resolution uses `require.resolve` so it works with npm-installed, npx-linked, and in-repo development installs.
+
+- [ ] **Step 6.1: Write failing test**
+
+```typescript
+// tests/unit/backend/vault/git/merge-driver-config.test.ts
+import { describe, it, expect } from "vitest";
+import { simpleGit } from "simple-git";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ensureMergeDriverConfig } from "../../../../../src/backend/vault/git/merge-driver-config.js";
+import { scrubGitEnv } from "../../../../../src/backend/vault/git/env.js";
+
+describe("ensureMergeDriverConfig", () => {
+  it("writes driver name + path to .git/config", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mdc-"));
+    const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+    await git.init();
+    await ensureMergeDriverConfig({ git, driverPath: "/abs/merge-memory.js" });
+    const name = await git.raw([
+      "config",
+      "--local",
+      "merge.agent-brain-memory.name",
+    ]);
+    const driver = await git.raw([
+      "config",
+      "--local",
+      "merge.agent-brain-memory.driver",
+    ]);
+    expect(name.trim()).toBe("agent-brain memory-file merge");
+    expect(driver.trim()).toBe('node "/abs/merge-memory.js" %A %O %B');
+  });
+
+  it("rewrites driver path on each call (self-heals)", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mdc-"));
+    const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+    await git.init();
+    await ensureMergeDriverConfig({ git, driverPath: "/abs/old.js" });
+    await ensureMergeDriverConfig({ git, driverPath: "/abs/new.js" });
+    const driver = await git.raw([
+      "config",
+      "--local",
+      "merge.agent-brain-memory.driver",
+    ]);
+    expect(driver.trim()).toBe('node "/abs/new.js" %A %O %B');
+  });
+});
+```
+
+- [ ] **Step 6.2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/backend/vault/git/merge-driver-config.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 6.3: Implement config writer**
+
+```typescript
+// src/backend/vault/git/merge-driver-config.ts
+import type { SimpleGit } from "simple-git";
+
+export interface EnsureMergeDriverConfigOptions {
+  git: SimpleGit;
+  driverPath: string; // absolute path to dist/cli/merge-memory.js
+}
+
+export async function ensureMergeDriverConfig(
+  opts: EnsureMergeDriverConfigOptions,
+): Promise<void> {
+  // Quote the driver path so spaces in the install location don't
+  // break the merge subprocess. %A %O %B are substituted by git.
+  const command = `node "${opts.driverPath}" %A %O %B`;
+  // `config --local --replace-all` is the idempotent form; plain
+  // `--add` would append duplicates across bootstraps.
+  await opts.git.raw([
+    "config",
+    "--local",
+    "--replace-all",
+    "merge.agent-brain-memory.name",
+    "agent-brain memory-file merge",
+  ]);
+  await opts.git.raw([
+    "config",
+    "--local",
+    "--replace-all",
+    "merge.agent-brain-memory.driver",
+    command,
+  ]);
+}
+
+/**
+ * Resolves the absolute path to the compiled merge driver. Prefers the
+ * installed package entry; falls back to the repo-local dist/ for
+ * development clones.
+ */
+export function resolveDriverPath(): string {
+  try {
+    // Newer node has require.resolve available as a side channel via
+    // createRequire; use that so this module stays ESM-clean.
+    return createRequireSafe().resolve("agent-brain/dist/cli/merge-memory.js");
+  } catch {
+    // Dev fallback: assume the caller's dist/ sits next to this file's
+    // compiled location (src/backend/vault/git/ → dist/backend/vault/git/).
+    // That path is two ../s up then into cli/.
+    // This is only used in-repo; production always resolves via the first branch.
+    const url = new URL("../../../../cli/merge-memory.js", import.meta.url);
+    return url.pathname;
+  }
+}
+
+function createRequireSafe() {
+  // Wrapped in a function so the test harness can stub it if needed.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { createRequire } =
+    require("node:module") as typeof import("node:module");
+  return createRequire(import.meta.url);
+}
+```
+
+- [ ] **Step 6.4: Wire `ensureMergeDriverConfig` into bootstrap**
+
+```typescript
+// src/backend/vault/git/bootstrap.ts - after git.init() / user.identity setup
++import { ensureMergeDriverConfig, resolveDriverPath } from "./merge-driver-config.js";
+...
+   await ensureIdentity(git);
++  await ensureMergeDriverConfig({ git, driverPath: resolveDriverPath() });
+   const ignoreChanged = await ensureGitignore(opts.root, opts.trackUsers);
+```
+
+- [ ] **Step 6.5: Add bootstrap test assertion**
+
+```typescript
+// tests/unit/backend/vault/git/bootstrap.test.ts — new case
+it("writes the merge driver config on bootstrap", async () => {
+  const root = await mkdtemp(join(tmpdir(), "vault-"));
+  await ensureVaultGit({ root, trackUsers: false });
+  const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+  const driver = await git.raw([
+    "config",
+    "--local",
+    "merge.agent-brain-memory.driver",
+  ]);
+  expect(driver).toMatch(/node ".+merge-memory\.js" %A %O %B/);
+});
+```
+
+- [ ] **Step 6.6: Run to verify pass**
+
+Run: `npx vitest run tests/unit/backend/vault/git/merge-driver-config.test.ts tests/unit/backend/vault/git/bootstrap.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6.7: Commit**
+
+```bash
+git add src/backend/vault/git/merge-driver-config.ts src/backend/vault/git/bootstrap.ts tests/unit/backend/vault/git/merge-driver-config.test.ts tests/unit/backend/vault/git/bootstrap.test.ts
+git commit -m "feat(vault): register agent-brain-memory merge driver in .git/config"
+```
+
+---
+
+## Task 7: Swap `.gitattributes` from `*.md merge=union` to path-specific rules
+
+**Files:**
+
+- Modify: `src/backend/vault/git/bootstrap.ts`
+- Modify: `tests/unit/backend/vault/git/bootstrap.test.ts`
+
+**Context:** Replace the single union rule with three memory-path rules. Handle the upgrade path from Phase 4b vaults: if a committed `.gitattributes` already has `*.md merge=union`, the bootstrap rewrites it and commits via the existing `commitBootstrap` path.
+
+- [ ] **Step 7.1: Write failing tests**
+
+```typescript
+// tests/unit/backend/vault/git/bootstrap.test.ts — append
+it("writes the three memory-path merge=agent-brain-memory rules", async () => {
+  const root = await mkdtemp(join(tmpdir(), "vault-"));
+  await ensureVaultGit({ root, trackUsers: true });
+  const body = await readFile(join(root, ".gitattributes"), "utf8");
+  expect(body).toMatch(
+    /^workspaces\/\*\*\/memories\/\*\.md merge=agent-brain-memory$/m,
+  );
+  expect(body).toMatch(/^project\/memories\/\*\.md merge=agent-brain-memory$/m);
+  expect(body).toMatch(
+    /^users\/\*\*\/memories\/\*\.md merge=agent-brain-memory$/m,
+  );
+  expect(body).not.toMatch(/^\*\.md merge=union$/m);
+});
+
+it("migrates a Phase 4b vault by replacing *.md merge=union", async () => {
+  const root = await mkdtemp(join(tmpdir(), "vault-"));
+  // Simulate a Phase 4b bootstrap
+  await writeFile(join(root, ".gitattributes"), "*.md merge=union\n", "utf8");
+  const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+  await git.init();
+  await git.addConfig("user.email", "t@t");
+  await git.addConfig("user.name", "t");
+  await git.add([".gitattributes"]);
+  await git.commit("seed");
+
+  await ensureVaultGit({ root, trackUsers: false });
+  const body = await readFile(join(root, ".gitattributes"), "utf8");
+  expect(body).not.toMatch(/merge=union/);
+  expect(body).toMatch(/merge=agent-brain-memory/);
+});
+```
+
+- [ ] **Step 7.2: Run to verify failure**
+
+Expected: FAIL — old rule still written.
+
+- [ ] **Step 7.3: Update rule table + writer**
+
+```typescript
+// src/backend/vault/git/bootstrap.ts
+-const GITATTRIBUTES_RULE = "*.md merge=union";
++const LEGACY_ATTR_RULE = "*.md merge=union";
++const GITATTRIBUTES_RULES = [
++  "workspaces/**/memories/*.md merge=agent-brain-memory",
++  "project/memories/*.md merge=agent-brain-memory",
++  "users/**/memories/*.md merge=agent-brain-memory",
++];
+```
+
+Replace `ensureGitattributes` with an add-missing + remove-legacy implementation:
+
+```typescript
+async function ensureGitattributes(root: string): Promise<boolean> {
+  const path = join(root, ".gitattributes");
+  const existing = await readOrEmpty(path);
+  const lines = existing.split(/\r?\n/);
+  let changed = false;
+
+  // Drop any active `*.md merge=union` line (ignore commented-out).
+  const kept = lines.filter((line) => {
+    const trimmed = line.trim();
+    if (trimmed === LEGACY_ATTR_RULE) {
+      changed = true;
+      return false;
+    }
+    return true;
+  });
+
+  // Add each required rule if not already present as a live rule.
+  const activeSet = new Set(
+    kept.map((l) => l.trim()).filter((l) => l !== "" && !l.startsWith("#")),
+  );
+  const toAppend: string[] = [];
+  for (const rule of GITATTRIBUTES_RULES) {
+    if (!activeSet.has(rule)) {
+      toAppend.push(rule);
+      changed = true;
+    }
+  }
+
+  if (!changed) return false;
+  // Normalize trailing newline before appending.
+  const trimmed = kept.join("\n").replace(/\n+$/, "");
+  const body =
+    (trimmed === "" ? "" : trimmed + "\n") +
+    toAppend.join("\n") +
+    (toAppend.length ? "\n" : "");
+  await writeFile(path, body, "utf8");
+  return true;
+}
+```
+
+Update `assertRequiredRules` to assert each of the three new rules:
+
+```typescript
+async function assertRequiredRules(
+  root: string,
+  trackUsers: boolean,
+): Promise<void> {
+  const ignoreBody = await readOrEmpty(join(root, ".gitignore"));
+  const ignoreLines = new Set(ignoreBody.split(/\r?\n/).map((l) => l.trim()));
+  const required = trackUsers
+    ? RUNTIME_IGNORES
+    : [...RUNTIME_IGNORES, "users/"];
+  for (const rule of required) {
+    if (!ignoreLines.has(rule)) {
+      throw new DomainError(
+        `vault bootstrap failed: .gitignore is missing rule '${rule}'`,
+        "VAULT_BOOTSTRAP_FAILED",
+        500,
+      );
+    }
+  }
+  const attrBody = await readOrEmpty(join(root, ".gitattributes"));
+  for (const rule of GITATTRIBUTES_RULES) {
+    if (!hasActiveRule(attrBody, rule)) {
+      throw new DomainError(
+        `vault bootstrap failed: .gitattributes is missing rule '${rule}'`,
+        "VAULT_BOOTSTRAP_FAILED",
+        500,
+      );
+    }
+  }
+  if (hasActiveRule(attrBody, LEGACY_ATTR_RULE)) {
+    throw new DomainError(
+      `vault bootstrap failed: legacy '${LEGACY_ATTR_RULE}' still active`,
+      "VAULT_BOOTSTRAP_FAILED",
+      500,
+    );
+  }
+}
+```
+
+- [ ] **Step 7.4: Run tests**
+
+Run: `npx vitest run tests/unit/backend/vault/git/bootstrap.test.ts`
+Expected: PASS (all).
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add src/backend/vault/git/bootstrap.ts tests/unit/backend/vault/git/bootstrap.test.ts
+git commit -m "feat(vault): swap .gitattributes to path-specific merge=agent-brain-memory"
+```
+
+---
+
+## Task 8: Integration — two-clone concurrent-edit merge smoke
+
+**Files:**
+
+- Create: `tests/integration/vault/merge-driver.test.ts`
+- Reference (no changes): `tests/contract/repositories/_git-helpers.ts`
+
+**Context:** Uses existing `setupBareAndTwoVaults`. Both clones edit the same memory's frontmatter concurrently (different tags added). Push A; B pulls. Assert: rebase succeeds (no `pull_conflict`), merged memory has **both sides' tag additions**, `git log` shows a single rebase commit on top of shared base. Also confirms the compiled CLI at `dist/cli/merge-memory.js` is actually invoked.
+
+- [ ] **Step 8.1: Ensure build produces `dist/cli/merge-memory.js` for the integration test**
+
+Integration tests run under `vitest` and rely on `tsx`/compiled output depending on the test config. Inspect `vitest.config.ts` to understand how the CLI will be resolved:
+
+Run: `grep -n 'alias\|dist\|include' vitest.config.ts`
+
+If the CLI is expected to run pre-build, adjust `resolveDriverPath()` fallback to use `tsx` or a loader; otherwise add a pre-test `npm run build` step for this one spec. Document this in the test's comment.
+
+- [ ] **Step 8.2: Write the failing test**
+
+```typescript
+// tests/integration/vault/merge-driver.test.ts
+import { describe, it, expect } from "vitest";
+import { simpleGit } from "simple-git";
+import { setupBareAndTwoVaults } from "../../contract/repositories/_git-helpers.js";
+import { scrubGitEnv } from "../../../src/backend/vault/git/env.js";
+import { VaultBackend } from "../../../src/backend/vault/index.js";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+describe("merge driver — concurrent frontmatter edits", () => {
+  it("merges tag additions from both sides without conflict", async () => {
+    const { origin, a: pathA, b: pathB } = await setupBareAndTwoVaults();
+
+    const backendA = await VaultBackend.create({
+      root: pathA,
+      embeddingDimensions: 32,
+      remoteUrl: origin,
+    });
+    const backendB = await VaultBackend.create({
+      root: pathB,
+      embeddingDimensions: 32,
+      remoteUrl: origin,
+    });
+
+    // Seed a memory from A, push.
+    await backendA.workspaceRepo.upsert({ id: "ws-1", title: "WS" });
+    const mem = await backendA.memoryRepo.create({
+      content: "body",
+      title: "t",
+      type: "fact",
+      scope: "workspace",
+      workspace_id: "ws-1",
+      user_id: "alice",
+      tags: ["shared"],
+    });
+    await backendA.flushPushes();
+    await backendB.pullFromRemote();
+
+    // Concurrent edits: A adds tag "ours", B adds tag "theirs".
+    await backendA.memoryRepo.update(mem.id, mem.version, {
+      tags: ["shared", "ours"],
+      actor: "alice",
+    });
+    await backendB.memoryRepo.update(mem.id, mem.version, {
+      tags: ["shared", "theirs"],
+      actor: "bob",
+    });
+
+    // Push A, pull B — B's pull should trigger the merge driver.
+    await backendA.flushPushes();
+    const pulled = await backendB.pullFromRemote();
+    expect(pulled.conflict).toBe(false);
+
+    const path = `workspaces/ws-1/memories/${mem.id}.md`;
+    const body = await readFile(join(pathB, path), "utf8");
+    expect(body).toMatch(/tags:.*shared/);
+    expect(body).toMatch(/tags:.*ours/);
+    expect(body).toMatch(/tags:.*theirs/);
+
+    await backendA.close();
+    await backendB.close();
+  }, 60_000);
+});
+```
+
+Note: the test uses public methods that may not exist on `VaultBackend` today (`flushPushes`, `pullFromRemote`). If these are not already exposed, expose thin wrappers here:
+
+```typescript
+// src/backend/vault/index.ts - add near the other public methods
+async flushPushes(): Promise<void> {
+  await this.pushQueue.flush();
+}
+
+async pullFromRemote(): Promise<{ conflict: boolean }> {
+  const { syncFromRemote } = await import("./git/pull.js");
+  const res = await syncFromRemote({ git: this.git });
+  return { conflict: res.conflict };
+}
+```
+
+If `PushQueue.flush()` and `syncFromRemote` don't match these signatures, adjust to what Phase 4b already exposes — do not invent new infra.
+
+- [ ] **Step 8.3: Run to verify failure, iterate**
+
+Run: `npx vitest run tests/integration/vault/merge-driver.test.ts`
+Expected: initial FAIL — either module-wiring or driver-not-invoked. Common fixes:
+
+- `.git/config` driver path resolves to a `dist/cli/merge-memory.js` that doesn't exist yet → `npm run build` first.
+- `resolveDriverPath()` returns a path outside the worktree in dev → temporarily set `AGENT_BRAIN_MERGE_DRIVER_PATH` env override (add as an optional config path if needed).
+
+- [ ] **Step 8.4: Run to verify pass**
+
+Run: `npm run build && npx vitest run tests/integration/vault/merge-driver.test.ts`
+Expected: PASS.
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add tests/integration/vault/merge-driver.test.ts src/backend/vault/index.ts
+git commit -m "test(vault): two-clone merge-driver integration smoke"
+```
+
+---
+
+## Task 9: Integration — `AuditService.getHistory` over real commits
+
+**Files:**
+
+- Create: `tests/integration/vault/audit-history.test.ts`
+
+**Context:** End-to-end test that create + update + archive through `MemoryService` produce an audit history via the new git-log reader. Exercises trailer emission, the `git log --grep` query, and the `git show` blob re-parse path for the `updated` diff.
+
+- [ ] **Step 9.1: Write the failing test**
+
+```typescript
+// tests/integration/vault/audit-history.test.ts
+import { describe, it, expect } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { VaultBackend } from "../../../src/backend/vault/index.js";
+import { AuditService } from "../../../src/services/audit-service.js";
+
+describe("vault AuditService.getHistory", () => {
+  it("returns create/update/archive entries with correct shapes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "audit-"));
+    const backend = await VaultBackend.create({
+      root,
+      embeddingDimensions: 32,
+    });
+    const audit = new AuditService(backend.auditRepo, "proj-1");
+
+    await backend.workspaceRepo.upsert({ id: "ws-1", title: "WS" });
+    const mem = await backend.memoryRepo.create({
+      content: "initial",
+      title: "t",
+      type: "fact",
+      scope: "workspace",
+      workspace_id: "ws-1",
+      user_id: "alice",
+      tags: ["x"],
+    });
+    await backend.memoryRepo.update(mem.id, mem.version, {
+      content: "updated",
+      tags: ["x", "y"],
+      actor: "alice",
+    });
+    await backend.memoryRepo.archive([mem.id]);
+
+    const entries = await audit.getHistory(mem.id);
+    expect(entries.map((e) => e.action)).toEqual([
+      "archived",
+      "updated",
+      "created",
+    ]);
+
+    const updated = entries.find((e) => e.action === "updated")!;
+    expect(updated.diff).not.toBeNull();
+    expect(updated.diff).toMatchObject({
+      before: { content: "initial", tags: ["x"] },
+      after: { content: "updated", tags: ["x", "y"] },
+    });
+
+    const created = entries.find((e) => e.action === "created")!;
+    expect(created.diff).toBeNull();
+
+    await backend.close();
+  });
+});
+```
+
+- [ ] **Step 9.2: Run to verify fail**
+
+Run: `npx vitest run tests/integration/vault/audit-history.test.ts`
+Expected: failures that surface real integration bugs (argv, path derivation, etc). Iterate.
+
+- [ ] **Step 9.3: Run to verify pass**
+
+Expected: PASS.
+
+- [ ] **Step 9.4: Commit**
+
+```bash
+git add tests/integration/vault/audit-history.test.ts
+git commit -m "test(vault): integration for AuditService.getHistory over git log"
+```
+
+---
+
+## Task 10: Full suite, lint, typecheck, + final cleanup
+
+- [ ] **Step 10.1: Run the whole suite**
+
+Run: `npm test`
+Expected: all green.
+
+- [ ] **Step 10.2: Run contract tests against both backends**
+
+Run: `npx vitest run tests/contract/repositories/audit-repository.test.ts`
+Expected: all green. If a pg-only test case fails because pg stored a Date where vault re-parses a Date, it's a test fixture drift issue — fix by normalizing the two sides in the test itself, not by changing vault behavior.
+
+- [ ] **Step 10.3: Lint + typecheck**
+
+Run: `npm run lint && npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 10.4: Check for leftovers**
+
+Run: `grep -rn "_audit/\|JSONL" src/ tests/` to ensure nothing still references the removed storage.
+
+- [ ] **Step 10.5: Commit any tidy-ups, then open the PR**
+
+```bash
+git push -u origin feat/vault-backend-phase-4c-audit-merge
+gh pr create --title "feat(vault): Phase 4c — audit on git log + smart merge driver" --body "$(cat <<'EOF'
+## Summary
+- `VaultAuditRepository` now reads from `git log --grep='^AB-Memory:' + git show` for `{before, after}` diffs; no more JSONL.
+- New `agent-brain-memory` git merge driver (`src/cli/merge-memory.ts`) replaces `*.md merge=union` on memory-file paths. Per-field rules: set union (tags), monotonic max (updated_at, archived_at, verified_*), LWW by updated_at (title/content/etc), per-key merge (metadata).
+- Bootstrap writes `.git/config` driver registration on every startup (self-heals install path).
+- Phase 4b vaults migrate transparently via one reconcile commit on first 4c boot.
+
+## Test plan
+- [ ] Unit — `tests/unit/backend/vault/git/trailer-parser.test.ts`
+- [ ] Unit — `tests/unit/backend/vault/repositories/audit-repository.test.ts`
+- [ ] Unit — `tests/unit/backend/vault/parser/merge-memory.test.ts`
+- [ ] Unit — `tests/unit/cli/merge-memory.test.ts`
+- [ ] Unit — `tests/unit/backend/vault/git/merge-driver-config.test.ts`
+- [ ] Unit — `tests/unit/backend/vault/git/bootstrap.test.ts`
+- [ ] Contract — `tests/contract/repositories/audit-repository.test.ts` (both backends)
+- [ ] Integration — `tests/integration/vault/merge-driver.test.ts`
+- [ ] Integration — `tests/integration/vault/audit-history.test.ts`
+- [ ] Full suite — `npm test`
+
+Spec: `docs/superpowers/specs/2026-04-23-vault-backend-phase-4c-audit-merge-design.md`
+Plan: `docs/superpowers/plans/2026-04-23-vault-backend-phase-4c-audit-merge.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-review checklist
+
+Before handing this plan off, verify:
+
+- [ ] Every spec "Decisions" row maps to at least one task.
+- [ ] No "TBD" / "implement later" / "add error handling" placeholders.
+- [ ] Every task's TDD steps include actual test code + actual implementation code.
+- [ ] Function signatures referenced in later tasks match what earlier tasks define (`mergeMemoryFiles`, `parseTrailers`, `ensureMergeDriverConfig`).
+- [ ] Paths referenced in `Files:` blocks match what the task actually creates.

--- a/docs/superpowers/specs/2026-04-21-vault-backend-design.md
+++ b/docs/superpowers/specs/2026-04-21-vault-backend-design.md
@@ -445,16 +445,19 @@ Forces behavioral parity; divergence = test failure.
 
 ## Phased rollout
 
-| Phase | Deliverable                                                                                                                               |
-| ----- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| 0     | `StorageBackend` interface extraction. Move existing drizzle repos behind factory. No behavior change. Green tests.                       |
-| 1     | Vault parser + serializer (pure). Roundtrip property tests for all entity types.                                                          |
-| 2     | Vault repositories against a local directory (no git, no vector). Parameterized repo contract tests pass against both backends.           |
-| 3     | LanceDB index integration. Vector parity tests.                                                                                           |
-| 4     | Git sync layer. Commit-on-write, pull-on-session_start, conflict handling. Two-clone integration test. **Done — 4a (#34), 4b (this PR).** |
-| 5     | Chokidar watcher. External edit E2E.                                                                                                      |
-| 6     | Migration CLI + reverse migration.                                                                                                        |
-| 7     | Docs, recommended Obsidian vault template (Dataview, Tasks plugins), README updates.                                                      |
+| Phase | Deliverable                                                                                                                            |
+| ----- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| 0     | `StorageBackend` interface extraction. Move existing drizzle repos behind factory. No behavior change. Green tests.                    |
+| 1     | Vault parser + serializer (pure). Roundtrip property tests for all entity types.                                                       |
+| 2     | Vault repositories against a local directory (no git, no vector). Parameterized repo contract tests pass against both backends.        |
+| 3     | LanceDB index integration. Vector parity tests.                                                                                        |
+| 4a    | Git write path: commit-on-write, `AB-*` trailers, bootstrap `.gitignore`/`.gitattributes`, `users/` privacy invariant. **Done — #34.** |
+| 4b    | Push queue + pull-on-session_start. Debounced push, rebase pull, diff-driven reindex, conflict/offline meta. **Done — #37.**           |
+| 4c    | `VaultAuditRepository` on git log + smart YAML merge driver (`agent-brain-memory`). **Done — #39.**                                    |
+| 4d    | Surface `parse_errors` as per-memory flags (consolidation producer) + write-path perf budget verification under load.                  |
+| 5     | Chokidar watcher. External edit E2E.                                                                                                   |
+| 6     | Migration CLI + reverse migration.                                                                                                     |
+| 7     | Docs, recommended Obsidian vault template (Dataview, Tasks plugins), README updates.                                                   |
 
 ## Open questions
 

--- a/docs/superpowers/specs/2026-04-23-vault-backend-phase-4c-audit-merge-design.md
+++ b/docs/superpowers/specs/2026-04-23-vault-backend-phase-4c-audit-merge-design.md
@@ -1,0 +1,264 @@
+# Vault Backend Phase 4c — Audit on Git Log + Smart Merge Driver Design
+
+## Context
+
+Phase 4b (merged as `243dc36`) closed the sync layer: debounced push queue, `pull --rebase --autostash` on `memory_session_start`, diff-driven LanceDB reindex, and a `*.md merge=union` `.gitattributes` rule that keeps body text merges from blocking rebases. YAML-frontmatter conflicts still abort the rebase and surface `pull_conflict: true`; `VaultAuditRepository` still writes JSONL files under `_audit/`.
+
+Phase 4c removes both remaining storage affordances that duplicate what git already gives us. The audit repository moves onto `git log`; `merge=union` is replaced with a field-aware memory merge driver. Phase 4d will pick up the remaining scope from the Phase 4b handoff (per-memory `parse_errors` flags and a full write-path perf budget).
+
+## Goals
+
+1. `VaultAuditRepository.findByMemoryId(id)` returns the same `AuditEntry[]` shape pg returns, reconstructed from `git log --grep='^AB-Memory: <id>$'` + blob reads — with no writes to `_audit/`.
+2. Concurrent edits to memory frontmatter on two clones no longer abort the rebase with YAML-collision conflicts: a custom merge driver parses both sides, merges per documented field rules, and writes a clean result.
+3. Any input the driver cannot safely merge (immutable-field divergence, parse failure) exits non-zero → rebase conflict → existing Phase 4b `pull_conflict: true` surface. No silent data loss.
+4. Bootstrap is idempotent: every `VaultBackend.create` rewrites the local `.git/config` merge-driver path; first 4c startup on a Phase 4b vault removes `*.md merge=union`, adds the three path-specific rules, and commits via the existing reconcile path.
+
+## Non-Goals (Phase 4d)
+
+- Surface `parse_errors` as per-memory flags (consolidation producer).
+- Write-path perf budget verification under load.
+- Revive `"merged"` `AuditAction` (orphaned enum — see issue #38). Deferred until memory consolidation feature lands.
+- Chokidar watcher (Phase 5).
+- Migration / backfill of existing `_audit/*.jsonl` — vault backend is dev-only; no deployed installs.
+
+## Decisions
+
+| Area                              | Decision                                                                                                                                                                                                                                                                                                                                                 |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Phase scope split                 | Phase 4c = audit + merge driver (touch commit format + `.gitattributes`). Phase 4d = parse_errors flags + perf (consolidation/observability).                                                                                                                                                                                                            |
+| Audit query method                | Single `git log --all --grep='^AB-Memory: <id>$' --pretty=format:...` call, parsed in-process. Matches pg behavior (includes comments/flags on the memory, not just mutations).                                                                                                                                                                          |
+| Audit diff shape                  | `{ before, after }` structured object — **not** raw patch text. Matches pg contract so the parameterized `audit-repository.test.ts` stays cross-backend.                                                                                                                                                                                                 |
+| Audit diff reconstruction         | Per `updated` commit: `git show <sha>^:<path>` (parent blob) + `git show <sha>:<path>` (this blob); `parseMemoryFile` each; produce `{before, after}` each containing only `{content, title, type, tags, metadata}` — matches the exact shape `MemoryService.update` passes to `logUpdate` in pg-backed code (`src/services/memory-service.ts:701-720`). |
+| Audit diff for non-update actions | `created`, `archived`, `commented`, `flagged`: `diff = null`. Matches pg behavior where these code paths pass no `diff` to `AuditService.log`.                                                                                                                                                                                                           |
+| `_audit/` JSONL                   | Removed — writer deleted, directory gitignored on upgrade, no read fallback. Justified by dev-only status (no production installs).                                                                                                                                                                                                                      |
+| Merge driver scope                | Full field-aware: parse both sides + base, apply per-field rules, re-serialize. Body text three-way diff3 with LWW-by-`updated_at` fallback on unresolvable hunks.                                                                                                                                                                                       |
+| Merge driver packaging            | `package.json` `bin: { "agent-brain-merge-memory": "./dist/cli/merge-memory.js" }`. `.git/config` `[merge "agent-brain-memory"]` driver path resolved via `require.resolve` at every bootstrap.                                                                                                                                                          |
+| Merge driver conflict surface     | Exit 1 on immutable-field divergence, parse error, or unknown schema version → git leaves file unmerged → Phase 4b's existing `pull_conflict: true` envelope field fires.                                                                                                                                                                                |
+| `.gitattributes` rules            | Remove `*.md merge=union`; add three path-specific rules (`workspaces/**/memories/*.md`, `project/memories/*.md`, `users/**/memories/*.md`) all pointing at `merge=agent-brain-memory`. Non-memory `.md` (READMEs) falls through to git default.                                                                                                         |
+| `.git/config` idempotency         | Rewritten every `VaultBackend.create`. Self-heals when `agent-brain` install path changes (e.g. version upgrade, `npm install -g` vs local).                                                                                                                                                                                                             |
+| Migration from Phase 4b vaults    | First 4c startup: bootstrap detects `*.md merge=union`, edits `.gitattributes`, stages + commits as `AB-Action: reconcile`.                                                                                                                                                                                                                              |
+
+## Per-Field Merge Rules
+
+Applied in order by `src/cli/merge-memory.ts` after parsing ancestor, current ("ours"), and other ("theirs") via `parseMemoryFile`.
+
+### Immutable — conflict on divergence
+
+If any of these differ between ours and theirs (regardless of ancestor), driver exits 1:
+
+- `id`
+- `project_id`
+- `created_at`
+
+Rationale: these never change post-create in a well-behaved flow. Divergence indicates an id collision or corrupted frontmatter; silent pick would mask the problem.
+
+### Monotonic — max of both, null-aware
+
+- `updated_at` → `max(ours.updated_at, theirs.updated_at)`
+- `archived_at` → `max` of non-null values; null only if both sides null
+- `verified_at` + `verified_by` → treated as a pair; take the pair from whichever side has the later non-null `verified_at`
+
+### Last-writer-wins by `updated_at`
+
+One side's value wins wholesale; winner is the side with the greater `updated_at` (tie → ours):
+
+- `title`, `content` (body text, see below), `type`, `scope`, `workspace_id`, `author`, `source`, `session_id`, `embedding_model`, `embedding_dimensions`, `version`
+
+### Set union
+
+- `tags` → `Array.from(new Set([...ours.tags ?? [], ...theirs.tags ?? []])).sort()`
+
+### Per-key merge (metadata)
+
+- `metadata` (arbitrary object) → shallow merge: for each key appearing in either side, pick the value from the side with the greater `updated_at`. Deep merge is out of scope — `metadata` is per-memory free-form; shallow is predictable.
+
+### Body subsections — parsed from markdown, not frontmatter
+
+Memory body is split by `splitBody()` into `{ content, relationshipSection, commentSection }`. After parsing, the driver merges each section:
+
+- `## Comments` — append-only list merged by `id`; chronological ascending preserved.
+- `## Relationships` — union by `(source_id, target_id, type)` tuple; on collision take the entry with the greater `updated_at`.
+- Inline flags (frontmatter `flags: []` block) — union by `id`; on collision take the greater `updated_at` entry.
+
+### Body text (`content`) merge
+
+diff3 against the ancestor:
+
+1. If diff3 produces no conflict markers → use that result.
+2. If diff3 produces markers → fall back to LWW-by-`updated_at` (whole content from the winning side).
+
+Rationale: Markdown body is semi-structured; silent marker injection is worse than consistent LWW since markers would break `parseMemoryFile` on subsequent reads.
+
+### Derived — recompute after merge
+
+Read from the merged body, not the sides' frontmatter:
+
+- `flag_count` = merged unresolved flags count
+- `comment_count` = merged comments count
+- `relationship_count` = merged relationships count
+- `last_comment_at` = max `created_at` across merged comments (null if none)
+
+## Architecture
+
+### New files
+
+```
+src/cli/
+└── merge-memory.ts              # argv = [%A, %O, %B], reads three files,
+                                  # applies per-field rules, writes merged
+                                  # to %A, exit 0 | 1
+
+src/backend/vault/
+└── repositories/
+    └── audit-repository.ts      # REWRITE — git log + blob-reparse reader;
+                                  # create() becomes a no-op (delete when
+                                  # AuditService loses its last vault caller).
+```
+
+### Deleted files
+
+```
+src/backend/vault/repositories/audit-repository.ts  # old JSONL reader, replaced
+(_audit/*.jsonl on disk)                             # dev-only; not migrated
+```
+
+### Modified files
+
+```
+src/backend/vault/git/bootstrap.ts
+  - GITATTRIBUTES_RULE = "*.md merge=union"
+  + GITATTRIBUTES_RULES = [
+  +   "workspaces/**/memories/*.md merge=agent-brain-memory",
+  +   "project/memories/*.md merge=agent-brain-memory",
+  +   "users/**/memories/*.md merge=agent-brain-memory",
+  + ]
+  + removeActiveRule(body, "*.md merge=union")   // upgrade path
+  + ensureGitConfig({ driverAbsolutePath })       // [merge "agent-brain-memory"]
+
+src/backend/vault/index.ts
+  VaultBackend.create:
+    after ensureVaultGit({ root, trackUsers })
+      writes .git/config merge driver section with resolved driver path
+    auditRepo built from the new git-log-backed reader
+
+src/services/audit-service.ts
+  No changes — interface-compatible swap.
+
+src/backend/vault/git/trailers.ts
+src/backend/vault/git/types.ts
+  No schema additions; existing `AB-Memory:`, `AB-Action:`, `AB-Actor:`,
+  `AB-Reason:` trailers contain everything `findByMemoryId` needs.
+
+package.json
+  "bin": { "agent-brain-merge-memory": "./dist/cli/merge-memory.js" }
+```
+
+### Data flow — `findByMemoryId`
+
+```
+AuditService.getHistory(memoryId)
+  └─ VaultAuditRepository.findByMemoryId(memoryId)
+      ├─ git log --all --pretty='%H%x00%aI%x00%B%x00' --grep='^AB-Memory: <id>$'
+      │    returns N commits, each with sha + iso timestamp + full message
+      │    (trailers parsed from message body)
+      ├─ for each commit:
+      │    ├─ parse trailers → { action, memoryId, actor, reason }
+      │    ├─ derive file path from trailer + repo layout
+      │    ├─ if action === "updated":
+      │    │    git show <sha>^:<path>   → parent blob
+      │    │    git show <sha>:<path>    → this blob
+      │    │    parseMemoryFile each
+      │    │    diff = { before: pick(parsed, FIELDS), after: pick(parsed, FIELDS) }
+      │    │    where FIELDS = ["content","title","type","tags","metadata"]
+      │    └─ else ("created" | "archived" | "commented" | "flagged" | ...):
+      │         diff = null  // matches pg, which logs these without a diff
+      ├─ map trailer action → AuditAction (drop vault-only trailers)
+      └─ sort desc by created_at
+```
+
+### Data flow — merge during `pull --rebase`
+
+```
+git pull --rebase (Phase 4b syncFromRemote)
+  └─ git invokes merge driver on conflicting memories/*.md
+      └─ node <abs>/dist/cli/merge-memory.js %A %O %B
+          ├─ read all three files
+          ├─ parseMemoryFile(ancestor), parseMemoryFile(ours), parseMemoryFile(theirs)
+          │    parse failure on any side → exit 1
+          ├─ assert immutable fields agree (id, project_id, created_at)
+          │    mismatch → exit 1
+          ├─ merge per field rules
+          ├─ serializeMemoryFile(merged) → write to %A
+          └─ exit 0
+  ├─ exit 0 → rebase continues; Phase 4b's reindex picks up the path
+  └─ exit 1 → rebase aborts → pull_conflict: true in envelope meta
+```
+
+## Trailer → `AuditAction` mapping
+
+The trailer schema (`CommitAction`) is wider than `AuditAction`. Reader drops what doesn't map:
+
+| `AB-Action` trailer | `AuditAction` result                |
+| ------------------- | ----------------------------------- |
+| `created`           | `created`                           |
+| `updated`           | `updated`                           |
+| `archived`          | `archived`                          |
+| `commented`         | `commented`                         |
+| `flagged`           | `flagged`                           |
+| `verified`          | (dropped, no AuditAction value)     |
+| `unflagged`         | (dropped)                           |
+| `related`           | (dropped — relationship-only event) |
+| `unrelated`         | (dropped)                           |
+| `workspace_upsert`  | (dropped — not memory-scoped)       |
+| `reconcile`         | (dropped)                           |
+
+Dropped actions would only appear under `findByMemoryId` if someone manually constructs a commit with `AB-Memory:` + one of these trailers, which no code path does today. Defensive to ignore rather than throw.
+
+## Privacy invariant
+
+Phase 4a's `assertUsersIgnored` continues to run on every mutation. The new merge driver does not change it: `users/**/*.md` files match a merge rule but are gitignored at the repo layer, so git will never hand them to the driver during a pull. Private content stays out of the remote regardless of driver behavior.
+
+## Error handling
+
+| Failure                                                    | Where        | Behavior                                                                       |
+| ---------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------ |
+| `git log --grep` returns no commits                        | audit reader | return `[]`                                                                    |
+| Parent blob missing (first commit, or amended pre-history) | audit reader | treat as `created`: `before = null`                                            |
+| Blob parse fails                                           | audit reader | skip that entry, log warn; sibling entries still returned                      |
+| Unknown `AB-Action` value                                  | audit reader | skip entry, log debug                                                          |
+| Merge driver parse fails on any side                       | merge driver | exit 1 → rebase conflict → `pull_conflict: true`                               |
+| Merge driver immutable-field mismatch                      | merge driver | exit 1 → rebase conflict → `pull_conflict: true`                               |
+| Merge driver unknown schema version                        | merge driver | exit 1 → rebase conflict → `pull_conflict: true`                               |
+| `.git/config` write fails during bootstrap                 | bootstrap    | propagates; `VaultBackend.create` fails. Next start retries.                   |
+| `.gitattributes` commit fails during upgrade               | bootstrap    | dirty tree → Phase 4b reconcile path runs on next start, completes the commit. |
+
+## Testing
+
+**Unit (majority):**
+
+- `src/backend/vault/parser/merge.test.ts` — pure-function field-merge tests against fixture markdown triples (ancestor, ours, theirs). One test per field rule + one per edge case (null metadata, empty tags, archived collision).
+- `src/backend/vault/repositories/audit-repository.test.ts` — mock `simple-git` `log` and blob-read output; assert parse + diff reconstruction. Pg-parity assertions for `{before, after}` shape.
+- `src/cli/merge-memory.test.ts` — argv-based invocation, reads/writes tmp files, asserts exit code and `%A` contents. Covers immutable-field conflict, parse error, successful merge paths.
+
+**Contract (existing parameterized):**
+
+- `tests/contract/repositories/audit-repository.test.ts` — stays green against both pg and vault. The `diff` contract is narrow: `null` for all actions except `updated`; for `updated`, `{ before, after }` each containing exactly the five fields the caller passes (`content`, `title`, `type`, `tags`, `metadata`). No derived counts (`flag_count`, `comment_count`, etc.) are in this subset, so the vault recompute strategy does not leak into the contract.
+
+**Integration (smoke):**
+
+- `tests/integration/vault/merge-driver.test.ts` — uses `tests/contract/repositories/_git-helpers.ts:setupBareAndTwoVaults`. Clone A and Clone B edit the same memory's frontmatter concurrently; push A; B pulls. Assert: clean rebase, merged frontmatter contains both sides' tag additions, single commit on top of shared base.
+- `tests/integration/vault/audit-history.test.ts` — create + update + archive a memory through `AuditService`, call `getHistory`, assert shape matches pg behavior.
+
+**Property (optional, add if time):**
+
+- `tests/unit/backend/vault/parser/merge.property.test.ts` — fast-check generates random valid memory triples, asserts merge is commutative for tag/metadata fields and idempotent for monotonic fields.
+
+## Open questions
+
+None. All decisions locked above. Implementation-level choices (exact glob for the `git log --grep` regex, exact `diff3` invocation flags, exact `require.resolve` fallback order) are plan-time details for `writing-plans`.
+
+## Handoff to Phase 4d
+
+- Surface `parse_errors` as per-memory flags (consolidation producer reads `AB-Action: ` entries where blob parse failed and emits a `verify` flag).
+- Write-path perf budget verification on commit + push under load.
+- Revive `merged` `AuditAction` + add `merged` to `CommitAction` if memory-consolidation feature lands (#38).

--- a/docs/superpowers/specs/2026-04-23-vault-backend-phase-4c-audit-merge-design.md
+++ b/docs/superpowers/specs/2026-04-23-vault-backend-phase-4c-audit-merge-design.md
@@ -77,8 +77,8 @@ One side's value wins wholesale; winner is the side with the greater `updated_at
 Memory body is split by `splitBody()` into `{ content, relationshipSection, commentSection }`. After parsing, the driver merges each section:
 
 - `## Comments` — append-only list merged by `id`; chronological ascending preserved.
-- `## Relationships` — union by `(source_id, target_id, type)` tuple; on collision take the entry with the greater `updated_at`.
-- Inline flags (frontmatter `flags: []` block) — union by `id`; on collision take the greater `updated_at` entry.
+- `## Relationships` — union by `(source_id, target_id, type)` tuple; on collision take the entry from the 'theirs' side. Rationale: `Relationship` has only `created_at`, not `updated_at`; until the schema carries an update timestamp, deterministic 'theirs wins' is the best we can do. Collisions are rare in practice — relationships are typically append-only from each clone.
+- Inline flags (frontmatter `flags: []` block) — union by `id`; on collision take the entry from the 'theirs' side; `Flag` also lacks `updated_at`.
 
 ### Body text (`content`) merge
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "type": "module",
   "description": "A long-term memory system for AI agents, exposed as an MCP server",
+  "bin": {
+    "agent-brain-merge-memory": "./dist/src/cli/merge-memory.js"
+  },
   "scripts": {
     "dev": "docker compose up -d --wait && npx drizzle-kit migrate && EMBEDDING_PROVIDER=ollama EMBEDDING_DIMENSIONS=768 OLLAMA_BASE_URL=http://localhost:11434 tsx watch src/server.ts",
     "start": "tsx src/server.ts",

--- a/src/backend/vault/git/bootstrap.ts
+++ b/src/backend/vault/git/bootstrap.ts
@@ -4,6 +4,10 @@ import { simpleGit, type SimpleGit } from "simple-git";
 import { DomainError } from "../../../utils/errors.js";
 import { mergeGitignore } from "./gitignore-merge.js";
 import { scrubGitEnv } from "./env.js";
+import {
+  ensureMergeDriverConfig,
+  resolveDriverPath,
+} from "./merge-driver-config.js";
 
 export interface EnsureVaultGitOptions {
   root: string;
@@ -36,6 +40,10 @@ export async function ensureVaultGit(
   // every stageAndCommit fail silently. Set repo-local fallbacks but
   // never override an operator-configured identity.
   await ensureIdentity(git);
+  await ensureMergeDriverConfig({
+    root: opts.root,
+    driverPath: resolveDriverPath(),
+  });
   const ignoreChanged = await ensureGitignore(opts.root, opts.trackUsers);
   const attrChanged = await ensureGitattributes(opts.root);
   await assertRequiredRules(opts.root, opts.trackUsers);

--- a/src/backend/vault/git/bootstrap.ts
+++ b/src/backend/vault/git/bootstrap.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile } from "node:fs/promises";
+import { readFile, writeFile, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { simpleGit, type SimpleGit } from "simple-git";
 import { DomainError } from "../../../utils/errors.js";
@@ -15,7 +15,6 @@ const RUNTIME_IGNORES = [
   "_sessions/",
   "_session-tracking/",
   "_scheduler-state.json",
-  "_audit/",
 ];
 
 const GITATTRIBUTES_RULE = "*.md merge=union";
@@ -28,6 +27,10 @@ export async function ensureVaultGit(
   if (!wasRepo) {
     await git.init();
   }
+  // Phase 4c cleanup: _audit/ is no longer produced (audit reads from
+  // git log). Remove any leftovers from earlier phases so a stale
+  // directory doesn't confuse the user.
+  await rmrf(join(opts.root, "_audit"));
   // Commits need a user.email/user.name pair. On docker, CI, or a
   // fresh dev machine neither may be set globally, which would make
   // every stageAndCommit fail silently. Set repo-local fallbacks but
@@ -148,4 +151,8 @@ async function readOrEmpty(path: string): Promise<string> {
     if ((err as { code?: string }).code === "ENOENT") return "";
     throw err;
   }
+}
+
+async function rmrf(path: string): Promise<void> {
+  await rm(path, { recursive: true, force: true });
 }

--- a/src/backend/vault/git/bootstrap.ts
+++ b/src/backend/vault/git/bootstrap.ts
@@ -21,7 +21,12 @@ const RUNTIME_IGNORES = [
   "_scheduler-state.json",
 ];
 
-const GITATTRIBUTES_RULE = "*.md merge=union";
+const LEGACY_ATTR_RULE = "*.md merge=union";
+const GITATTRIBUTES_RULES = [
+  "workspaces/**/memories/*.md merge=agent-brain-memory",
+  "project/memories/*.md merge=agent-brain-memory",
+  "users/**/memories/*.md merge=agent-brain-memory",
+];
 
 export async function ensureVaultGit(
   opts: EnsureVaultGitOptions,
@@ -92,11 +97,39 @@ async function ensureGitignore(
 async function ensureGitattributes(root: string): Promise<boolean> {
   const path = join(root, ".gitattributes");
   const existing = await readOrEmpty(path);
-  if (hasActiveRule(existing, GITATTRIBUTES_RULE)) return false;
-  const trailingNewline =
-    existing === "" || existing.endsWith("\n") ? "" : "\n";
-  const merged = existing + trailingNewline + `${GITATTRIBUTES_RULE}\n`;
-  await writeFile(path, merged, "utf8");
+  const lines = existing.split(/\r?\n/);
+  let changed = false;
+
+  // Drop any active `*.md merge=union` line (ignore commented-out).
+  const kept = lines.filter((line) => {
+    const trimmed = line.trim();
+    if (trimmed === LEGACY_ATTR_RULE) {
+      changed = true;
+      return false;
+    }
+    return true;
+  });
+
+  // Add each required rule if not already present as a live rule.
+  const activeSet = new Set(
+    kept.map((l) => l.trim()).filter((l) => l !== "" && !l.startsWith("#")),
+  );
+  const toAppend: string[] = [];
+  for (const rule of GITATTRIBUTES_RULES) {
+    if (!activeSet.has(rule)) {
+      toAppend.push(rule);
+      changed = true;
+    }
+  }
+
+  if (!changed) return false;
+  // Normalize trailing newline before appending.
+  const trimmed = kept.join("\n").replace(/\n+$/, "");
+  const body =
+    (trimmed === "" ? "" : trimmed + "\n") +
+    toAppend.join("\n") +
+    (toAppend.length ? "\n" : "");
+  await writeFile(path, body, "utf8");
   return true;
 }
 
@@ -133,9 +166,18 @@ async function assertRequiredRules(
     }
   }
   const attrBody = await readOrEmpty(join(root, ".gitattributes"));
-  if (!hasActiveRule(attrBody, GITATTRIBUTES_RULE)) {
+  for (const rule of GITATTRIBUTES_RULES) {
+    if (!hasActiveRule(attrBody, rule)) {
+      throw new DomainError(
+        `vault bootstrap failed: .gitattributes is missing rule '${rule}'`,
+        "VAULT_BOOTSTRAP_FAILED",
+        500,
+      );
+    }
+  }
+  if (hasActiveRule(attrBody, LEGACY_ATTR_RULE)) {
     throw new DomainError(
-      `vault bootstrap failed: .gitattributes is missing rule '${GITATTRIBUTES_RULE}'`,
+      `vault bootstrap failed: legacy '${LEGACY_ATTR_RULE}' still active`,
       "VAULT_BOOTSTRAP_FAILED",
       500,
     );

--- a/src/backend/vault/git/merge-driver-config.ts
+++ b/src/backend/vault/git/merge-driver-config.ts
@@ -47,6 +47,14 @@ export async function ensureMergeDriverConfig(
  * Resolves the absolute path to the compiled merge driver. Prefers the
  * installed package entry; falls back to the repo-local dist/ for
  * development clones.
+ *
+ * The dev fallback handles two execution contexts:
+ *  - Compiled JS (dist/):  this file is at dist/src/backend/vault/git/…
+ *    → ../../../cli/merge-memory.js resolves to dist/src/cli/merge-memory.js ✓
+ *  - TypeScript source (src/, via tsx / vitest):  import.meta.url ends in
+ *    .ts and this file is at src/backend/vault/git/… so the same relative
+ *    path would land in src/cli/merge-memory.js (a .ts file, not a Node
+ *    subprocess).  Detect the .ts suffix and add one extra dist/ segment.
  */
 export function resolveDriverPath(): string {
   try {
@@ -54,11 +62,19 @@ export function resolveDriverPath(): string {
     const require = createRequire(import.meta.url);
     return require.resolve("agent-brain/dist/src/cli/merge-memory.js");
   } catch {
-    // Dev fallback: resolve relative to this compiled module's location.
-    // At runtime this file lives at `<...>/dist/src/backend/vault/git/merge-driver-config.js`.
-    // The CLI lives at `<...>/dist/src/cli/merge-memory.js`, so ../../../cli/merge-memory.js.
-    return fileURLToPath(
-      new URL("../../../cli/merge-memory.js", import.meta.url),
-    );
+    // Dev fallback.
+    const thisUrl = import.meta.url;
+    if (thisUrl.endsWith(".ts")) {
+      // Running under tsx/vitest from TypeScript sources.
+      // This file: <project>/src/backend/vault/git/merge-driver-config.ts
+      // CLI target: <project>/dist/src/cli/merge-memory.js
+      // Go up 4 levels (git/ → vault/ → backend/ → src/) then into dist/src/cli/.
+      return fileURLToPath(
+        new URL("../../../../dist/src/cli/merge-memory.js", thisUrl),
+      );
+    }
+    // Compiled JS: this file lives at dist/src/backend/vault/git/…
+    // CLI lives at dist/src/cli/merge-memory.js → go up 3 levels.
+    return fileURLToPath(new URL("../../../cli/merge-memory.js", thisUrl));
   }
 }

--- a/src/backend/vault/git/merge-driver-config.ts
+++ b/src/backend/vault/git/merge-driver-config.ts
@@ -1,0 +1,64 @@
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { simpleGit } from "simple-git";
+import { scrubGitEnv } from "./env.js";
+
+export interface EnsureMergeDriverConfigOptions {
+  /** Absolute path to the vault root (the directory containing `.git/`). */
+  root: string;
+  driverPath: string; // absolute path to the compiled merge-memory CLI
+}
+
+export async function ensureMergeDriverConfig(
+  opts: EnsureMergeDriverConfigOptions,
+): Promise<void> {
+  // simple-git's security plugin blocks `merge.*.driver` writes unless
+  // `unsafe.allowUnsafeMergeDriver` is explicitly opted in.  This is a
+  // legitimate use-case (we are the ones installing the driver), so we
+  // create a private git instance with that flag set rather than
+  // requiring all callers to do so.
+  const git = simpleGit({
+    baseDir: opts.root,
+    unsafe: { allowUnsafeMergeDriver: true },
+  }).env(scrubGitEnv());
+
+  // Quote the driver path so spaces in the install location don't
+  // break the merge subprocess. %A %O %B are substituted by git.
+  const command = `node "${opts.driverPath}" %A %O %B`;
+  // `config --local --replace-all` is the idempotent form; plain
+  // `--add` would append duplicates across bootstraps.
+  await git.raw([
+    "config",
+    "--local",
+    "--replace-all",
+    "merge.agent-brain-memory.name",
+    "agent-brain memory-file merge",
+  ]);
+  await git.raw([
+    "config",
+    "--local",
+    "--replace-all",
+    "merge.agent-brain-memory.driver",
+    command,
+  ]);
+}
+
+/**
+ * Resolves the absolute path to the compiled merge driver. Prefers the
+ * installed package entry; falls back to the repo-local dist/ for
+ * development clones.
+ */
+export function resolveDriverPath(): string {
+  try {
+    // `agent-brain` bin path: dist/src/cli/merge-memory.js (per Task 5 emit layout).
+    const require = createRequire(import.meta.url);
+    return require.resolve("agent-brain/dist/src/cli/merge-memory.js");
+  } catch {
+    // Dev fallback: resolve relative to this compiled module's location.
+    // At runtime this file lives at `<...>/dist/src/backend/vault/git/merge-driver-config.js`.
+    // The CLI lives at `<...>/dist/src/cli/merge-memory.js`, so ../../../cli/merge-memory.js.
+    return fileURLToPath(
+      new URL("../../../cli/merge-memory.js", import.meta.url),
+    );
+  }
+}

--- a/src/backend/vault/git/trailer-parser.ts
+++ b/src/backend/vault/git/trailer-parser.ts
@@ -1,0 +1,73 @@
+import type { CommitTrailer, CommitAction } from "./types.js";
+
+export type ParsedTrailers = CommitTrailer;
+
+const KNOWN_ACTIONS: ReadonlySet<CommitAction> = new Set<CommitAction>([
+  "created",
+  "updated",
+  "archived",
+  "verified",
+  "commented",
+  "flagged",
+  "unflagged",
+  "related",
+  "unrelated",
+  "workspace_upsert",
+  "reconcile",
+]);
+
+export function parseTrailers(message: string): ParsedTrailers | null {
+  const fields: Record<string, string> = {};
+  // Normalize to LF so the line iterator works uniformly.
+  for (const raw of message.replace(/\r\n?/g, "\n").split("\n")) {
+    const m = raw.match(/^(AB-[A-Za-z]+):\s?(.*)$/);
+    if (m) fields[m[1]!] = m[2]!;
+  }
+
+  const action = fields["AB-Action"] as CommitAction | undefined;
+  if (!action || !KNOWN_ACTIONS.has(action)) return null;
+
+  const actor = fields["AB-Actor"] ?? "";
+  if (actor === "") return null;
+  const reason = fields["AB-Reason"] ? decode(fields["AB-Reason"]) : null;
+
+  if (action === "workspace_upsert") {
+    const workspaceId = fields["AB-Workspace"] ?? "";
+    if (workspaceId === "") return null;
+    return { action, workspaceId, actor, reason };
+  }
+  if (action === "reconcile") {
+    return { action, actor, reason };
+  }
+  const memoryId = fields["AB-Memory"] ?? "";
+  if (memoryId === "") return null;
+  return { action, memoryId, actor, reason };
+}
+
+function decode(s: string): string {
+  // Inverse of trailers.ts `encode`: \\\\ → \\, \\n → LF, \\r → CR.
+  // Walk the string once so `\\n` (literal backslash + `n`) round-trips.
+  let out = "";
+  for (let i = 0; i < s.length; i++) {
+    if (s[i] === "\\" && i + 1 < s.length) {
+      const next = s[i + 1]!;
+      if (next === "\\") {
+        out += "\\";
+        i++;
+        continue;
+      }
+      if (next === "n") {
+        out += "\n";
+        i++;
+        continue;
+      }
+      if (next === "r") {
+        out += "\r";
+        i++;
+        continue;
+      }
+    }
+    out += s[i];
+  }
+  return out;
+}

--- a/src/backend/vault/git/trailer-parser.ts
+++ b/src/backend/vault/git/trailer-parser.ts
@@ -21,7 +21,7 @@ export function parseTrailers(message: string): ParsedTrailers | null {
   // Normalize to LF so the line iterator works uniformly.
   for (const raw of message.replace(/\r\n?/g, "\n").split("\n")) {
     const m = raw.match(/^(AB-[A-Za-z]+):\s?(.*)$/);
-    if (m) fields[m[1]!] = m[2]!;
+    if (m) fields[m[1]!] = m[2]!.trim();
   }
 
   const action = fields["AB-Action"] as CommitAction | undefined;

--- a/src/backend/vault/index.ts
+++ b/src/backend/vault/index.ts
@@ -187,6 +187,37 @@ export class VaultBackend implements StorageBackend {
     await this.vectorIndex.close();
   }
 
+  /**
+   * Waits until all pending pushes have landed on the remote.
+   * Polls git until `@{u}..HEAD` is empty (no unpushed commits).
+   * Used by integration tests to synchronise after a write.
+   */
+  async flushPushes(): Promise<void> {
+    for (let i = 0; i < 200; i++) {
+      try {
+        await this.git.raw(["rev-parse", "@{u}"]);
+        const out = await this.git.raw(["rev-list", "--count", "@{u}..HEAD"]);
+        if (Number(out.trim()) === 0) return;
+      } catch {
+        // @{u} not yet set — first push hasn't landed. Keep polling.
+      }
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    throw new Error(
+      "flushPushes: timed out waiting for push to settle (@{u} set + 0 unpushed)",
+    );
+  }
+
+  /** Pulls from remote. Returns `{ conflict: true }` on merge conflict. */
+  async pullFromRemote(): Promise<{ conflict: boolean }> {
+    const res = await syncFromRemote({ git: this.git });
+    if (res.kind === "ok") {
+      // Notify path-index of pulled changes so findById stays accurate.
+      this.vaultMemoryRepo.syncPaths(res.changedPaths);
+    }
+    return { conflict: res.kind === "conflict" };
+  }
+
   async sessionStart(): Promise<BackendSessionStartMeta> {
     const meta = await runSessionStart({
       root: this.root,

--- a/src/backend/vault/index.ts
+++ b/src/backend/vault/index.ts
@@ -208,14 +208,22 @@ export class VaultBackend implements StorageBackend {
     );
   }
 
-  /** Pulls from remote. Returns `{ conflict: true }` on merge conflict. */
-  async pullFromRemote(): Promise<{ conflict: boolean }> {
+  /**
+   * Pulls from remote.
+   * - `conflict`: true when a rebase conflict could not be auto-resolved.
+   * - `offline`: true when the remote was unreachable (network/auth); the
+   *   local state is unchanged and the caller can continue serving local data.
+   */
+  async pullFromRemote(): Promise<{ conflict: boolean; offline: boolean }> {
     const res = await syncFromRemote({ git: this.git });
     if (res.kind === "ok") {
       // Notify path-index of pulled changes so findById stays accurate.
       this.vaultMemoryRepo.syncPaths(res.changedPaths);
     }
-    return { conflict: res.kind === "conflict" };
+    return {
+      conflict: res.kind === "conflict",
+      offline: res.kind === "offline",
+    };
   }
 
   async sessionStart(): Promise<BackendSessionStartMeta> {

--- a/src/backend/vault/index.ts
+++ b/src/backend/vault/index.ts
@@ -91,7 +91,11 @@ export class VaultBackend implements StorageBackend {
     });
     this.sessionRepo = new VaultSessionTrackingRepository({ root });
     this.sessionLifecycleRepo = new VaultSessionRepository({ root });
-    this.auditRepo = new VaultAuditRepository({ root });
+    this.auditRepo = new VaultAuditRepository({
+      root,
+      git: this.git,
+      projectId: "UNKNOWN", // project ids are per-memory; vault reads from git log
+    });
     this.flagRepo = new VaultFlagRepository({
       root,
       gitOps,

--- a/src/backend/vault/index.ts
+++ b/src/backend/vault/index.ts
@@ -94,7 +94,6 @@ export class VaultBackend implements StorageBackend {
     this.auditRepo = new VaultAuditRepository({
       root,
       git: this.git,
-      projectId: "UNKNOWN", // project ids are per-memory; vault reads from git log
     });
     this.flagRepo = new VaultFlagRepository({
       root,

--- a/src/backend/vault/parser/merge-memory.ts
+++ b/src/backend/vault/parser/merge-memory.ts
@@ -1,0 +1,201 @@
+import { parseMemoryFile, serializeMemoryFile } from "./memory-parser.js";
+import type { ParsedMemoryFile } from "./memory-parser.js";
+import type { Memory } from "../../../types/memory.js";
+
+export type MergeResult =
+  | { ok: true; merged: string }
+  | { ok: false; reason: string };
+
+export interface Diff3Result {
+  clean: boolean;
+  text?: string;
+}
+
+export interface MergeOptions {
+  /**
+   * Three-way diff over body text. Called with (base, ours, theirs) as
+   * raw strings. Returns the clean merged text or { clean: false } on
+   * unresolvable conflict, in which case the caller falls back to LWW.
+   */
+  diff3: (
+    base: string,
+    ours: string,
+    theirs: string,
+  ) => Promise<Diff3Result> | Diff3Result;
+}
+
+export async function mergeMemoryFiles(
+  ancestor: string,
+  ours: string,
+  theirs: string,
+  opts: MergeOptions,
+): Promise<MergeResult> {
+  let a: ParsedMemoryFile, o: ParsedMemoryFile, t: ParsedMemoryFile;
+  try {
+    a = parseMemoryFile(ancestor);
+    o = parseMemoryFile(ours);
+    t = parseMemoryFile(theirs);
+  } catch (err) {
+    return { ok: false, reason: `parse: ${(err as Error).message}` };
+  }
+
+  // Immutable fields — bail if ours/theirs disagree.
+  for (const field of ["id", "project_id"] as const) {
+    if (o.memory[field] !== t.memory[field]) {
+      return { ok: false, reason: `immutable field diverged: ${field}` };
+    }
+  }
+  if (o.memory.created_at.getTime() !== t.memory.created_at.getTime()) {
+    return { ok: false, reason: "immutable field diverged: created_at" };
+  }
+
+  // Determine which side is "later" for LWW resolution.
+  const oTime = o.memory.updated_at.getTime();
+  const tTime = t.memory.updated_at.getTime();
+  const later = oTime >= tTime ? o : t;
+
+  // Body content via diff3, LWW fallback.
+  const bodyResult = await opts.diff3(
+    a.memory.content,
+    o.memory.content,
+    t.memory.content,
+  );
+  const mergedContent =
+    bodyResult.clean && bodyResult.text !== undefined
+      ? bodyResult.text
+      : later.memory.content;
+
+  // verified_at/verified_by: take the pair with the later verified_at.
+  const { verified_at: mergedVerifiedAt, verified_by: mergedVerifiedBy } =
+    mergeVerified(o.memory, t.memory);
+
+  const mergedMemory: Memory = {
+    // Start from the later side for all LWW fields.
+    ...later.memory,
+    // Body text (three-way or LWW fallback).
+    content: mergedContent,
+    // updated_at is always max of both sides.
+    updated_at: new Date(Math.max(oTime, tTime)),
+    // archived_at is sticky: once set, never unset (take max non-null).
+    archived_at: maxDate(o.memory.archived_at, t.memory.archived_at),
+    // verified pair.
+    verified_at: mergedVerifiedAt,
+    verified_by: mergedVerifiedBy,
+    // tags: union (sorted for determinism).
+    tags: unionSorted(o.memory.tags, t.memory.tags),
+    // metadata: per-key LWW — later side wins per key, missing keys from
+    // earlier side are filled in.
+    metadata: mergeMetadata(o.memory, t.memory, oTime >= tTime),
+    // Derived counts are recomputed below from the merged body sections.
+    flag_count: 0,
+    comment_count: 0,
+    relationship_count: 0,
+    last_comment_at: null,
+  };
+
+  // Body sub-sections: union by stable key.
+  const comments = unionBy(o.comments, t.comments, (c) => c.id);
+  const flags = unionBy(o.flags, t.flags, (f) => f.id);
+  const relationships = unionBy(
+    o.relationships,
+    t.relationships,
+    (r) => `${r.source_id}|${r.target_id}|${r.type}`,
+  );
+
+  const out: ParsedMemoryFile = {
+    memory: {
+      ...mergedMemory,
+      flag_count: flags.filter((f) => f.resolved_at === null).length,
+      comment_count: comments.length,
+      relationship_count: relationships.length,
+      last_comment_at:
+        comments.length === 0
+          ? null
+          : new Date(Math.max(...comments.map((c) => c.created_at.getTime()))),
+    },
+    flags,
+    comments,
+    relationships,
+  };
+
+  return { ok: true, merged: serializeMemoryFile(out) };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function maxDate(a: Date | null, b: Date | null): Date | null {
+  if (a === null) return b;
+  if (b === null) return a;
+  return a.getTime() >= b.getTime() ? a : b;
+}
+
+/**
+ * Pick the verified_at/verified_by pair with the later verified_at.
+ * If one side is null and the other is not, take the non-null side.
+ * If both are null, result is null/null.
+ */
+function mergeVerified(
+  a: Memory,
+  b: Memory,
+): { verified_at: Date | null; verified_by: string | null } {
+  if (a.verified_at === null && b.verified_at === null) {
+    return { verified_at: null, verified_by: null };
+  }
+  if (a.verified_at === null) {
+    return { verified_at: b.verified_at, verified_by: b.verified_by };
+  }
+  if (b.verified_at === null) {
+    return { verified_at: a.verified_at, verified_by: a.verified_by };
+  }
+  // Both non-null: pick the later one.
+  if (a.verified_at.getTime() >= b.verified_at.getTime()) {
+    return { verified_at: a.verified_at, verified_by: a.verified_by };
+  }
+  return { verified_at: b.verified_at, verified_by: b.verified_by };
+}
+
+/**
+ * Union of two nullable tag arrays. Returns null only when both inputs are null.
+ * Result is sorted for determinism.
+ */
+function unionSorted(a: string[] | null, b: string[] | null): string[] | null {
+  if (a === null && b === null) return null;
+  const set = new Set<string>([...(a ?? []), ...(b ?? [])]);
+  return Array.from(set).sort();
+}
+
+/**
+ * Per-key LWW merge of metadata objects.
+ * The "later" side wins on key collisions; keys present only on the
+ * earlier side are included (union of keys).
+ */
+function mergeMetadata(
+  a: Memory,
+  b: Memory,
+  aIsLater: boolean,
+): Record<string, unknown> | null {
+  if (a.metadata === null && b.metadata === null) return null;
+  const winner = aIsLater ? a.metadata : b.metadata;
+  const loser = aIsLater ? b.metadata : a.metadata;
+  const out: Record<string, unknown> = { ...(loser ?? {}) };
+  if (winner !== null) {
+    for (const [k, v] of Object.entries(winner)) {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+/**
+ * Union two arrays by a stable key function. When both sides have an
+ * entry for the same key, the entry from `b` (theirs) takes precedence —
+ * consistent with "later side wins" for append-only sections.
+ */
+function unionBy<T>(a: T[], b: T[], key: (x: T) => string): T[] {
+  const seen = new Map<string, T>();
+  for (const x of a) seen.set(key(x), x);
+  for (const x of b) seen.set(key(x), x); // b overwrites on collision
+  return Array.from(seen.values());
+}

--- a/src/backend/vault/parser/merge-memory.ts
+++ b/src/backend/vault/parser/merge-memory.ts
@@ -6,10 +6,7 @@ export type MergeResult =
   | { ok: true; merged: string }
   | { ok: false; reason: string };
 
-export interface Diff3Result {
-  clean: boolean;
-  text?: string;
-}
+export type Diff3Result = { clean: true; text: string } | { clean: false };
 
 export interface MergeOptions {
   /**
@@ -60,18 +57,22 @@ export async function mergeMemoryFiles(
     o.memory.content,
     t.memory.content,
   );
-  const mergedContent =
-    bodyResult.clean && bodyResult.text !== undefined
-      ? bodyResult.text
-      : later.memory.content;
+  const mergedContent = bodyResult.clean
+    ? bodyResult.text
+    : later.memory.content;
 
   // verified_at/verified_by: take the pair with the later verified_at.
   const { verified_at: mergedVerifiedAt, verified_by: mergedVerifiedBy } =
-    mergeVerified(o.memory, t.memory);
+    mergeVerified(
+      o.memory.verified_at,
+      o.memory.verified_by,
+      t.memory.verified_at,
+      t.memory.verified_by,
+    );
 
   const mergedMemory: Memory = {
     // Start from the later side for all LWW fields.
-    ...later.memory,
+    ...later.memory, // version: LWW from later side; post-merge bump is caller's responsibility
     // Body text (three-way or LWW fallback).
     content: mergedContent,
     // updated_at is always max of both sides.
@@ -85,7 +86,11 @@ export async function mergeMemoryFiles(
     tags: unionSorted(o.memory.tags, t.memory.tags),
     // metadata: per-key LWW — later side wins per key, missing keys from
     // earlier side are filled in.
-    metadata: mergeMetadata(o.memory, t.memory, oTime >= tTime),
+    metadata: mergeMetadata(
+      o.memory.metadata,
+      t.memory.metadata,
+      oTime >= tTime,
+    ),
     // Derived counts are recomputed below from the merged body sections.
     flag_count: 0,
     comment_count: 0,
@@ -100,7 +105,9 @@ export async function mergeMemoryFiles(
   // extended with an update timestamp, deterministic 'theirs wins' is the best
   // we can do without risking silent data loss. Collisions are rare in practice
   // since these sections are append-only from each clone.
-  const comments = unionBy(o.comments, t.comments, (c) => c.id);
+  const comments = unionBy(o.comments, t.comments, (c) => c.id).sort(
+    (a, b) => a.created_at.getTime() - b.created_at.getTime(),
+  );
   const flags = unionBy(o.flags, t.flags, (f) => f.id);
   const relationships = unionBy(
     o.relationships,
@@ -143,23 +150,25 @@ function maxDate(a: Date | null, b: Date | null): Date | null {
  * If both are null, result is null/null.
  */
 function mergeVerified(
-  a: Memory,
-  b: Memory,
+  oVerifiedAt: Date | null,
+  oVerifiedBy: string | null,
+  tVerifiedAt: Date | null,
+  tVerifiedBy: string | null,
 ): { verified_at: Date | null; verified_by: string | null } {
-  if (a.verified_at === null && b.verified_at === null) {
+  if (oVerifiedAt === null && tVerifiedAt === null) {
     return { verified_at: null, verified_by: null };
   }
-  if (a.verified_at === null) {
-    return { verified_at: b.verified_at, verified_by: b.verified_by };
+  if (oVerifiedAt === null) {
+    return { verified_at: tVerifiedAt, verified_by: tVerifiedBy };
   }
-  if (b.verified_at === null) {
-    return { verified_at: a.verified_at, verified_by: a.verified_by };
+  if (tVerifiedAt === null) {
+    return { verified_at: oVerifiedAt, verified_by: oVerifiedBy };
   }
   // Both non-null: pick the later one.
-  if (a.verified_at.getTime() >= b.verified_at.getTime()) {
-    return { verified_at: a.verified_at, verified_by: a.verified_by };
+  if (oVerifiedAt.getTime() >= tVerifiedAt.getTime()) {
+    return { verified_at: oVerifiedAt, verified_by: oVerifiedBy };
   }
-  return { verified_at: b.verified_at, verified_by: b.verified_by };
+  return { verified_at: tVerifiedAt, verified_by: tVerifiedBy };
 }
 
 /**
@@ -178,13 +187,13 @@ function unionSorted(a: string[] | null, b: string[] | null): string[] | null {
  * earlier side are included (union of keys).
  */
 function mergeMetadata(
-  a: Memory,
-  b: Memory,
+  a: Record<string, unknown> | null,
+  b: Record<string, unknown> | null,
   aIsLater: boolean,
 ): Record<string, unknown> | null {
-  if (a.metadata === null && b.metadata === null) return null;
-  const winner = aIsLater ? a.metadata : b.metadata;
-  const loser = aIsLater ? b.metadata : a.metadata;
+  if (a === null && b === null) return null;
+  const winner = aIsLater ? a : b;
+  const loser = aIsLater ? b : a;
   const out: Record<string, unknown> = { ...(loser ?? {}) };
   if (winner !== null) {
     for (const [k, v] of Object.entries(winner)) {

--- a/src/backend/vault/parser/merge-memory.ts
+++ b/src/backend/vault/parser/merge-memory.ts
@@ -94,6 +94,12 @@ export async function mergeMemoryFiles(
   };
 
   // Body sub-sections: union by stable key.
+  // Collision policy: 'theirs wins' (b overwrites a in unionBy).
+  // NOTE: This is NOT LWW-by-updated_at. Neither Flag nor Relationship carries
+  // an updated_at field — both have only created_at. Until the schema is
+  // extended with an update timestamp, deterministic 'theirs wins' is the best
+  // we can do without risking silent data loss. Collisions are rare in practice
+  // since these sections are append-only from each clone.
   const comments = unionBy(o.comments, t.comments, (c) => c.id);
   const flags = unionBy(o.flags, t.flags, (f) => f.id);
   const relationships = unionBy(

--- a/src/backend/vault/repositories/audit-repository.ts
+++ b/src/backend/vault/repositories/audit-repository.ts
@@ -128,6 +128,12 @@ export class VaultAuditRepository implements AuditRepository {
   // Produce candidate blob paths for a memory id. We use `git diff-tree`
   // (not `git show --name-only`) so the "show" mock in tests only ever
   // receives blob-like rev arguments.
+  //
+  // If diff-tree fails or returns no matching path we return [] and let
+  // reconstructUpdateDiff emit diff:null. We deliberately do NOT fall back
+  // to a hardcoded heuristic path — workspace-scoped and user-scoped memories
+  // live under different prefixes, so a wrong guess silently produces null
+  // anyway but hides the real failure from logs.
   private async guessCandidatePaths(
     sha: string,
     memoryId: string,
@@ -148,12 +154,17 @@ export class VaultAuditRepository implements AuditRepository {
         if (p.endsWith(`/${memoryId}.md`)) paths.push(p);
       }
       if (paths.length > 0) return paths;
-    } catch {
-      // diff-tree unavailable (e.g. root commit) — fall through to heuristic
+      // diff-tree succeeded but found no matching path for this memory id.
+      logger.warn(
+        `vault audit: diff-tree returned no path matching ${memoryId}.md for ${sha}`,
+      );
+      return [];
+    } catch (err) {
+      // diff-tree unavailable (e.g. root commit) — log and return empty so
+      // the caller emits diff:null rather than guessing a wrong path.
+      logger.warn(`vault audit: diff-tree failed for ${sha} ${memoryId}`, err);
+      return [];
     }
-    // Heuristic fallback: return a wildcard-ish set of patterns so
-    // safeShow probing works for common layouts.
-    return [`project/memories/${memoryId}.md`];
   }
 
   private async safeShow(rev: string): Promise<string | null> {

--- a/src/backend/vault/repositories/audit-repository.ts
+++ b/src/backend/vault/repositories/audit-repository.ts
@@ -151,26 +151,19 @@ export class VaultAuditRepository implements AuditRepository {
   // Uses diff-tree to find the actual path, then git show to read the blob.
   // Returns "" on any parse failure (clearly-invalid sentinel, unambiguous).
   private async readProjectId(sha: string, memoryId: string): Promise<string> {
-    try {
-      const candidatePaths = await this.guessCandidatePaths(sha, memoryId);
-      for (const path of candidatePaths) {
-        const raw = await this.safeShow(`${sha}:${path}`);
-        if (raw === null) continue;
-        try {
-          const parsed = parseMemoryFile(raw);
-          return parsed.memory.project_id;
-        } catch {
-          logger.warn(
-            `vault audit: failed to parse memory blob for ${sha}:${path}`,
-          );
-          return "";
-        }
+    const candidatePaths = await this.guessCandidatePaths(sha, memoryId);
+    for (const path of candidatePaths) {
+      const raw = await this.safeShow(`${sha}:${path}`);
+      if (raw === null) continue;
+      try {
+        const parsed = parseMemoryFile(raw);
+        return parsed.memory.project_id;
+      } catch {
+        logger.warn(
+          `vault audit: failed to parse memory blob for ${sha}:${path}`,
+        );
+        return "";
       }
-    } catch (err) {
-      logger.warn(
-        `vault audit: failed to read project_id for ${sha} ${memoryId}`,
-        err,
-      );
     }
     return "";
   }

--- a/src/backend/vault/repositories/audit-repository.ts
+++ b/src/backend/vault/repositories/audit-repository.ts
@@ -11,11 +11,11 @@ import { logger } from "../../../utils/logger.js";
 export interface VaultAuditConfig {
   root: string;
   git: SimpleGit;
-  projectId: string;
 }
 
-// Five fields match what MemoryService.update passes to
-// AuditService.logUpdate — keep in sync or the contract test will fail.
+// How MemoryService.update constructs its diff argument — `logUpdate` takes
+// opaque `Record<string, unknown>`, so the constraint really lives at the
+// call site, not in AuditService.logUpdate's signature.
 type DiffFields = Pick<
   ReturnType<typeof parseMemoryFile>["memory"],
   "content" | "title" | "type" | "tags" | "metadata"
@@ -71,27 +71,40 @@ export class VaultAuditRepository implements AuditRepository {
       const auditAction = TRAILER_TO_AUDIT[trailers.action];
       if (!auditAction) continue;
 
+      const createdAt = new Date(iso);
+      if (Number.isNaN(createdAt.getTime())) {
+        logger.warn(
+          `vault audit: skipping ${sha} with invalid created_at: ${iso}`,
+        );
+        continue;
+      }
+
       let diff: Record<string, unknown> | null = null;
+      let projectId = "";
       if (auditAction === "updated") {
         try {
-          diff = await this.reconstructUpdateDiff(sha, memoryId);
+          const result = await this.reconstructUpdateDiff(sha, memoryId);
+          diff = result?.diffFields ?? null;
+          projectId = result?.projectId ?? "";
         } catch (err) {
           logger.warn(
             `vault audit: failed to reconstruct diff for ${sha} ${memoryId}`,
             err,
           );
         }
+      } else {
+        projectId = await this.readProjectId(sha, memoryId);
       }
 
       entries.push({
         id: sha,
-        project_id: this.cfg.projectId,
+        project_id: projectId,
         memory_id: memoryId,
         action: auditAction,
         actor: trailers.actor,
         reason: trailers.reason ?? null,
         diff,
-        created_at: new Date(iso),
+        created_at: createdAt,
       });
     }
 
@@ -103,7 +116,10 @@ export class VaultAuditRepository implements AuditRepository {
   private async reconstructUpdateDiff(
     sha: string,
     memoryId: string,
-  ): Promise<{ before: DiffFields; after: DiffFields } | null> {
+  ): Promise<{
+    diffFields: { before: DiffFields; after: DiffFields };
+    projectId: string;
+  } | null> {
     // Read the "after" blob first to determine the memory's scope and
     // workspace — we need the path to then read the "before" blob.
     // We probe the three known layout patterns; the first successful read wins.
@@ -113,16 +129,50 @@ export class VaultAuditRepository implements AuditRepository {
       if (afterRaw === null) continue;
 
       const beforeRaw = await this.safeShow(`${sha}^:${path}`);
+      // No parent blob at this path means this is an update commit where the
+      // file was first introduced on this branch (git shallow clone or orphan
+      // lineage); skip the before/after reconstruction.
       if (beforeRaw === null) return null;
 
       const before = parseMemoryFile(beforeRaw).memory;
       const after = parseMemoryFile(afterRaw).memory;
       return {
-        before: pickFields(before),
-        after: pickFields(after),
+        diffFields: {
+          before: pickFields(before),
+          after: pickFields(after),
+        },
+        projectId: after.project_id,
       };
     }
     return null;
+  }
+
+  // Read the project_id from the blob for the given memory at the given commit.
+  // Uses diff-tree to find the actual path, then git show to read the blob.
+  // Returns "" on any parse failure (clearly-invalid sentinel, unambiguous).
+  private async readProjectId(sha: string, memoryId: string): Promise<string> {
+    try {
+      const candidatePaths = await this.guessCandidatePaths(sha, memoryId);
+      for (const path of candidatePaths) {
+        const raw = await this.safeShow(`${sha}:${path}`);
+        if (raw === null) continue;
+        try {
+          const parsed = parseMemoryFile(raw);
+          return parsed.memory.project_id;
+        } catch {
+          logger.warn(
+            `vault audit: failed to parse memory blob for ${sha}:${path}`,
+          );
+          return "";
+        }
+      }
+    } catch (err) {
+      logger.warn(
+        `vault audit: failed to read project_id for ${sha} ${memoryId}`,
+        err,
+      );
+    }
+    return "";
   }
 
   // Produce candidate blob paths for a memory id. We use `git diff-tree`
@@ -187,7 +237,7 @@ function pickFields(
     type: m.type,
     tags: m.tags,
     metadata: m.metadata,
-  } as DiffFields;
+  } satisfies DiffFields;
 }
 
 function escapeRe(s: string): string {

--- a/src/backend/vault/repositories/audit-repository.ts
+++ b/src/backend/vault/repositories/audit-repository.ts
@@ -1,78 +1,185 @@
-import { join } from "node:path";
+import type { SimpleGit } from "simple-git";
 import type { AuditEntry } from "../../../types/audit.js";
+import type { AuditAction } from "../../../types/audit.js";
 import type { AuditRepository } from "../../../repositories/types.js";
-import { withFileLock } from "../io/lock.js";
-import { appendJsonLine, readJsonLines } from "../io/json-fs.js";
-import { ensureParentDir } from "../io/vault-fs.js";
+import { parseTrailers } from "../git/trailer-parser.js";
+import { parseMemoryFile } from "../parser/memory-parser.js";
 import { safeSegment } from "../io/paths.js";
+import type { CommitAction } from "../git/types.js";
+import { logger } from "../../../utils/logger.js";
 
 export interface VaultAuditConfig {
   root: string;
+  git: SimpleGit;
+  projectId: string;
 }
 
-interface AuditRecord {
-  id: string;
-  project_id: string;
-  memory_id: string;
-  action: AuditEntry["action"];
-  actor: string;
-  reason: string | null;
-  diff: Record<string, unknown> | null;
-  created_at: string;
-}
+// Five fields match what MemoryService.update passes to
+// AuditService.logUpdate — keep in sync or the contract test will fail.
+type DiffFields = Pick<
+  ReturnType<typeof parseMemoryFile>["memory"],
+  "content" | "title" | "type" | "tags" | "metadata"
+>;
+
+const UNIT = "\x1f"; // field separator
+const RECORD = "\x1e"; // record separator
+
+const TRAILER_TO_AUDIT: Partial<Record<CommitAction, AuditAction>> = {
+  created: "created",
+  updated: "updated",
+  archived: "archived",
+  commented: "commented",
+  flagged: "flagged",
+};
 
 export class VaultAuditRepository implements AuditRepository {
   constructor(private readonly cfg: VaultAuditConfig) {}
 
-  async create(entry: AuditEntry): Promise<void> {
-    const rel = auditPath(entry.memory_id);
-    const abs = join(this.cfg.root, rel);
-    // Lock serializes concurrent writers cross-platform; don't rely
-    // on O_APPEND atomicity (which only holds below PIPE_BUF on POSIX).
-    await ensureParentDir(abs);
-    await withFileLock(abs, async () => {
-      const record: AuditRecord = {
-        id: entry.id,
-        project_id: entry.project_id,
-        memory_id: entry.memory_id,
-        action: entry.action,
-        actor: entry.actor,
-        reason: entry.reason,
-        diff: entry.diff,
-        created_at: entry.created_at.toISOString(),
-      };
-      await appendJsonLine(this.cfg.root, rel, record);
-    });
+  // create() still exists on the interface but the vault backend has no
+  // state to write — git commits (with trailers) are the audit log.
+  // Kept as a no-op so existing callers don't break.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async create(_entry: AuditEntry): Promise<void> {
+    // intentional no-op
   }
 
   async findByMemoryId(memoryId: string): Promise<AuditEntry[]> {
-    const records = await readJsonLines<AuditRecord>(
-      this.cfg.root,
-      auditPath(memoryId),
-    );
-    const entries = records.map((r) => {
-      const created = new Date(r.created_at);
-      if (Number.isNaN(created.getTime()))
-        throw new Error(
-          `audit entry ${r.id} has invalid created_at: ${r.created_at}`,
-        );
-      return {
-        id: r.id,
-        project_id: r.project_id,
-        memory_id: r.memory_id,
-        action: r.action,
-        actor: r.actor,
-        reason: r.reason,
-        diff: r.diff,
-        created_at: created,
-      } satisfies AuditEntry;
-    });
+    safeSegment(memoryId, "memory_id");
+    // --grep on a fixed-anchored trailer line; --extended-regexp so `^`
+    // and `$` apply per-line (the default is per-message).
+    const raw = await this.cfg.git.raw([
+      "log",
+      "--all",
+      "--extended-regexp",
+      `--grep=^AB-Memory: ${escapeRe(memoryId)}$`,
+      `--pretty=${"%H"}${UNIT}${"%aI"}${UNIT}${"%B"}${RECORD}`,
+    ]);
+
+    const records = raw
+      .split(RECORD)
+      .map((r) => r.trim())
+      .filter((r) => r !== "");
+
+    const entries: AuditEntry[] = [];
+    for (const rec of records) {
+      const [sha, iso, ...rest] = rec.split(UNIT);
+      if (!sha || !iso || rest.length === 0) continue;
+      const message = rest.join(UNIT);
+      const trailers = parseTrailers(message);
+      if (!trailers) continue;
+      if (!("memoryId" in trailers) || trailers.memoryId !== memoryId) continue;
+      const auditAction = TRAILER_TO_AUDIT[trailers.action];
+      if (!auditAction) continue;
+
+      let diff: Record<string, unknown> | null = null;
+      if (auditAction === "updated") {
+        try {
+          diff = await this.reconstructUpdateDiff(sha, memoryId);
+        } catch (err) {
+          logger.warn(
+            `vault audit: failed to reconstruct diff for ${sha} ${memoryId}`,
+            err,
+          );
+        }
+      }
+
+      entries.push({
+        id: sha,
+        project_id: this.cfg.projectId,
+        memory_id: memoryId,
+        action: auditAction,
+        actor: trailers.actor,
+        reason: trailers.reason ?? null,
+        diff,
+        created_at: new Date(iso),
+      });
+    }
+
     return entries.sort(
       (a, b) => b.created_at.getTime() - a.created_at.getTime(),
     );
   }
+
+  private async reconstructUpdateDiff(
+    sha: string,
+    memoryId: string,
+  ): Promise<{ before: DiffFields; after: DiffFields } | null> {
+    // Read the "after" blob first to determine the memory's scope and
+    // workspace — we need the path to then read the "before" blob.
+    // We probe the three known layout patterns; the first successful read wins.
+    const candidatePaths = await this.guessCandidatePaths(sha, memoryId);
+    for (const path of candidatePaths) {
+      const afterRaw = await this.safeShow(`${sha}:${path}`);
+      if (afterRaw === null) continue;
+
+      const beforeRaw = await this.safeShow(`${sha}^:${path}`);
+      if (beforeRaw === null) return null;
+
+      const before = parseMemoryFile(beforeRaw).memory;
+      const after = parseMemoryFile(afterRaw).memory;
+      return {
+        before: pickFields(before),
+        after: pickFields(after),
+      };
+    }
+    return null;
+  }
+
+  // Produce candidate blob paths for a memory id. We use `git diff-tree`
+  // (not `git show --name-only`) so the "show" mock in tests only ever
+  // receives blob-like rev arguments.
+  private async guessCandidatePaths(
+    sha: string,
+    memoryId: string,
+  ): Promise<string[]> {
+    try {
+      // diff-tree lists paths changed by this commit. We pick any path
+      // that ends with `/<memoryId>.md`.
+      const out = await this.cfg.git.raw([
+        "diff-tree",
+        "--no-commit-id",
+        "-r",
+        "--name-only",
+        sha,
+      ]);
+      const paths: string[] = [];
+      for (const line of out.split("\n")) {
+        const p = line.trim();
+        if (p.endsWith(`/${memoryId}.md`)) paths.push(p);
+      }
+      if (paths.length > 0) return paths;
+    } catch {
+      // diff-tree unavailable (e.g. root commit) — fall through to heuristic
+    }
+    // Heuristic fallback: return a wildcard-ish set of patterns so
+    // safeShow probing works for common layouts.
+    return [`project/memories/${memoryId}.md`];
+  }
+
+  private async safeShow(rev: string): Promise<string | null> {
+    try {
+      return await this.cfg.git.raw(["show", rev]);
+    } catch {
+      // First commit on a branch has no parent; git show returns
+      // exit 128. Treat as "no parent blob" and skip diff.
+      return null;
+    }
+  }
 }
 
-function auditPath(memoryId: string): string {
-  return `_audit/${safeSegment(memoryId, "memory_id")}.jsonl`;
+function pickFields(
+  m: ReturnType<typeof parseMemoryFile>["memory"],
+): DiffFields {
+  return {
+    content: m.content,
+    title: m.title,
+    type: m.type,
+    tags: m.tags,
+    metadata: m.metadata,
+  } as DiffFields;
+}
+
+function escapeRe(s: string): string {
+  // Memory ids are nanoid-ish (alphanumeric-ish) but escape defensively.
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/src/cli/merge-memory.ts
+++ b/src/cli/merge-memory.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+import { readFile, writeFile, mkdtemp } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mergeMemoryFiles } from "../backend/vault/parser/merge-memory.js";
+import type { Diff3Result } from "../backend/vault/parser/merge-memory.js";
+
+/**
+ * Git merge driver entry point. argv = [%A, %O, %B] (ours, ancestor, theirs)
+ * per the driver spec; we rewrite %A with the merged content.
+ *
+ * Returns 0 on clean merge, 1 on conflict or parse failure.
+ */
+export async function run(argv: readonly string[]): Promise<number> {
+  if (argv.length < 3) {
+    console.error("usage: merge-memory %A %O %B");
+    return 1;
+  }
+  const [ours, ancestor, theirs] = argv as [string, string, string];
+  try {
+    const [oursBody, ancestorBody, theirsBody] = await Promise.all([
+      readFile(ours, "utf8"),
+      readFile(ancestor, "utf8"),
+      readFile(theirs, "utf8"),
+    ]);
+    const res = await mergeMemoryFiles(ancestorBody, oursBody, theirsBody, {
+      diff3: gitMergeFile,
+    });
+    if (!res.ok) {
+      console.error(`agent-brain-merge-memory: ${res.reason}`);
+      return 1;
+    }
+    await writeFile(ours, res.merged, "utf8");
+    return 0;
+  } catch (err) {
+    console.error(`agent-brain-merge-memory: ${(err as Error).message}`);
+    return 1;
+  }
+}
+
+/**
+ * Uses `git merge-file -p` to perform a three-way diff over body text.
+ * Returns { clean: true, text } on exit 0 (clean merge),
+ *         { clean: false } on exit 1 (conflict markers in output).
+ * Throws on exit code > 1 (real error from git).
+ */
+async function gitMergeFile(
+  base: string,
+  our: string,
+  their: string,
+): Promise<Diff3Result> {
+  const dir = await mkdtemp(join(tmpdir(), "mm-"));
+  const [basePath, ourPath, theirPath] = await Promise.all([
+    writeAndReturn(join(dir, "base"), base),
+    writeAndReturn(join(dir, "ours"), our),
+    writeAndReturn(join(dir, "theirs"), their),
+  ]);
+
+  return new Promise<Diff3Result>((resolve, reject) => {
+    const child = spawn("git", [
+      "merge-file",
+      "-p",
+      ourPath,
+      basePath,
+      theirPath,
+    ]);
+    const chunks: Buffer[] = [];
+    child.stdout.on("data", (c: Buffer) => chunks.push(c));
+    child.stderr.on("data", () => {}); // suppress git diagnostics
+    child.on("error", reject);
+    child.on("close", (code) => {
+      const text = Buffer.concat(chunks).toString("utf8");
+      if (code === 0) resolve({ clean: true, text });
+      else if (code === 1) resolve({ clean: false });
+      else reject(new Error(`git merge-file exited ${String(code)}`));
+    });
+  });
+}
+
+async function writeAndReturn(p: string, body: string): Promise<string> {
+  await writeFile(p, body, "utf8");
+  return p;
+}
+
+// ESM main-module guard: run when invoked directly as the CLI entry point.
+if (process.argv[1] && process.argv[1].endsWith("merge-memory.js")) {
+  run(process.argv.slice(2)).then(
+    (code) => process.exit(code),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    },
+  );
+}

--- a/src/cli/merge-memory.ts
+++ b/src/cli/merge-memory.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { readFile, writeFile, mkdtemp } from "node:fs/promises";
+import { readFile, writeFile, mkdtemp, rm } from "node:fs/promises";
 import { spawn } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -51,31 +51,35 @@ async function gitMergeFile(
   their: string,
 ): Promise<Diff3Result> {
   const dir = await mkdtemp(join(tmpdir(), "mm-"));
-  const [basePath, ourPath, theirPath] = await Promise.all([
-    writeAndReturn(join(dir, "base"), base),
-    writeAndReturn(join(dir, "ours"), our),
-    writeAndReturn(join(dir, "theirs"), their),
-  ]);
-
-  return new Promise<Diff3Result>((resolve, reject) => {
-    const child = spawn("git", [
-      "merge-file",
-      "-p",
-      ourPath,
-      basePath,
-      theirPath,
+  try {
+    const [basePath, ourPath, theirPath] = await Promise.all([
+      writeAndReturn(join(dir, "base"), base),
+      writeAndReturn(join(dir, "ours"), our),
+      writeAndReturn(join(dir, "theirs"), their),
     ]);
-    const chunks: Buffer[] = [];
-    child.stdout.on("data", (c: Buffer) => chunks.push(c));
-    child.stderr.on("data", () => {}); // suppress git diagnostics
-    child.on("error", reject);
-    child.on("close", (code) => {
-      const text = Buffer.concat(chunks).toString("utf8");
-      if (code === 0) resolve({ clean: true, text });
-      else if (code === 1) resolve({ clean: false });
-      else reject(new Error(`git merge-file exited ${String(code)}`));
+
+    return await new Promise<Diff3Result>((resolve, reject) => {
+      const child = spawn("git", [
+        "merge-file",
+        "-p",
+        ourPath,
+        basePath,
+        theirPath,
+      ]);
+      const chunks: Buffer[] = [];
+      child.stdout.on("data", (c: Buffer) => chunks.push(c));
+      child.stderr.on("data", () => {}); // suppress git diagnostics
+      child.on("error", reject);
+      child.on("close", (code) => {
+        const text = Buffer.concat(chunks).toString("utf8");
+        if (code === 0) resolve({ clean: true, text });
+        else if (code === 1) resolve({ clean: false });
+        else reject(new Error(`git merge-file exited ${String(code)}`));
+      });
     });
-  });
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
 }
 
 async function writeAndReturn(p: string, body: string): Promise<string> {

--- a/src/services/memory-service.ts
+++ b/src/services/memory-service.ts
@@ -1080,9 +1080,12 @@ export class MemoryService {
 
     const timing = Date.now() - start;
 
-    // Backend contract already strips zero/false before returning, so
-    // spreading preserves the "absent = healthy" invariant.
-    const backendMetaFields: BackendSessionStartMeta = { ...backendMeta };
+    // Defense in depth for the "absent = healthy" invariant: backend contract
+    // strips zero/false, but re-filter here so a buggy backend can't surface
+    // a false-positive signal (e.g. unpushed_commits=0) to clients.
+    const backendMetaFields = Object.fromEntries(
+      Object.entries(backendMeta).filter(([, v]) => Boolean(v)),
+    ) as BackendSessionStartMeta;
 
     return {
       data: result.data,

--- a/tests/contract/backend.test.ts
+++ b/tests/contract/backend.test.ts
@@ -186,7 +186,18 @@ describe.each(cases)("StorageBackend assembly — $name", (c) => {
       created_at: new Date("2026-04-21T10:00:00.000Z"),
     });
     const audits = await backend.auditRepo.findByMemoryId("m1");
-    expect(audits).toHaveLength(1);
+    if (c.name === "vault") {
+      // Under vault, findByMemoryId reads git log — every mutation that touched
+      // m1 via a repo that commits (memory create, comment, flag) appears as an
+      // entry. The explicit create() above is a no-op. We assert the audit log
+      // reflects the real mutation history, not just the explicit create.
+      // Actions that don't map through TRAILER_TO_AUDIT (unflagged, related)
+      // are filtered out, so only created/commented/flagged surface.
+      const actions = audits.map((a) => a.action).sort();
+      expect(actions).toEqual(["commented", "created", "flagged"]);
+    } else {
+      expect(audits).toHaveLength(1);
+    }
 
     const now = new Date("2026-04-21T11:00:00.000Z");
     await backend.schedulerStateRepo.recordRun("consolidation", now);

--- a/tests/contract/repositories/_factories.ts
+++ b/tests/contract/repositories/_factories.ts
@@ -103,7 +103,15 @@ export const vaultFactory: Factory = {
       gitOps,
     });
     const workspaceRepo = new VaultWorkspaceRepository({ root, gitOps });
-    const git = simpleGit({ baseDir: root });
+    // VaultAuditRepository reads git log, so it needs an actual git repo
+    // even when other repos use NOOP_GIT_OPS. A bare `git init` (no commits)
+    // is sufficient: `git log` on an empty repo returns "" → findByMemoryId
+    // returns [] for all IDs, which is correct for the one contract test that
+    // runs against vault ("findByMemoryId returns empty array for unknown memory").
+    const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+    await git.init();
+    await git.addConfig("user.email", "contract@example.com");
+    await git.addConfig("user.name", "Contract Test");
     const auditRepo = new VaultAuditRepository({ root, git, projectId: "p1" });
     const schedulerStateRepo = new VaultSchedulerStateRepository({ root });
     const sessionTrackingRepo = new VaultSessionTrackingRepository({ root });

--- a/tests/contract/repositories/_factories.ts
+++ b/tests/contract/repositories/_factories.ts
@@ -103,7 +103,8 @@ export const vaultFactory: Factory = {
       gitOps,
     });
     const workspaceRepo = new VaultWorkspaceRepository({ root, gitOps });
-    const auditRepo = new VaultAuditRepository({ root });
+    const git = simpleGit({ baseDir: root });
+    const auditRepo = new VaultAuditRepository({ root, git, projectId: "p1" });
     const schedulerStateRepo = new VaultSchedulerStateRepository({ root });
     const sessionTrackingRepo = new VaultSessionTrackingRepository({ root });
     const sessionRepo = new VaultSessionRepository({ root });
@@ -158,7 +159,11 @@ export function makeVaultGitFactory(
         trackUsersInGit,
       });
       const workspaceRepo = new VaultWorkspaceRepository({ root, gitOps });
-      const auditRepo = new VaultAuditRepository({ root });
+      const auditRepo = new VaultAuditRepository({
+        root,
+        git: cfgGit,
+        projectId: "p1",
+      });
       const schedulerStateRepo = new VaultSchedulerStateRepository({ root });
       const sessionTrackingRepo = new VaultSessionTrackingRepository({ root });
       const sessionRepo = new VaultSessionRepository({ root });

--- a/tests/contract/repositories/_factories.ts
+++ b/tests/contract/repositories/_factories.ts
@@ -112,7 +112,7 @@ export const vaultFactory: Factory = {
     await git.init();
     await git.addConfig("user.email", "contract@example.com");
     await git.addConfig("user.name", "Contract Test");
-    const auditRepo = new VaultAuditRepository({ root, git, projectId: "p1" });
+    const auditRepo = new VaultAuditRepository({ root, git });
     const schedulerStateRepo = new VaultSchedulerStateRepository({ root });
     const sessionTrackingRepo = new VaultSessionTrackingRepository({ root });
     const sessionRepo = new VaultSessionRepository({ root });
@@ -170,7 +170,6 @@ export function makeVaultGitFactory(
       const auditRepo = new VaultAuditRepository({
         root,
         git: cfgGit,
-        projectId: "p1",
       });
       const schedulerStateRepo = new VaultSchedulerStateRepository({ root });
       const sessionTrackingRepo = new VaultSessionTrackingRepository({ root });

--- a/tests/contract/repositories/audit-repository.test.ts
+++ b/tests/contract/repositories/audit-repository.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { factories, type TestBackend } from "./_factories.js";
+import { pgFactory, type TestBackend } from "./_factories.js";
+
+// Vault's audit log is derived from git history — create() is a no-op and
+// findByMemoryId reads git log. Round-trip contract tests (create → find)
+// are not applicable. Vault audit behavior is covered by the unit tests at
+// tests/unit/backend/vault/repositories/audit-repository.test.ts.
+const factories = [pgFactory];
 import type { AuditEntry } from "../../../src/types/audit.js";
 import type { Memory } from "../../../src/types/memory.js";
 

--- a/tests/contract/repositories/audit-repository.test.ts
+++ b/tests/contract/repositories/audit-repository.test.ts
@@ -1,11 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { pgFactory, type TestBackend } from "./_factories.js";
-
-// Vault's audit log is derived from git history — create() is a no-op and
-// findByMemoryId reads git log. Round-trip contract tests (create → find)
-// are not applicable. Vault audit behavior is covered by the unit tests at
-// tests/unit/backend/vault/repositories/audit-repository.test.ts.
-const factories = [pgFactory];
+import { factories, type TestBackend } from "./_factories.js";
 import type { AuditEntry } from "../../../src/types/audit.js";
 import type { Memory } from "../../../src/types/memory.js";
 
@@ -58,6 +52,14 @@ function makeMemory(overrides: Partial<Memory> = {}): Memory {
 
 describe.each(factories)("AuditRepository contract — $name", (factory) => {
   let backend: TestBackend;
+  // Vault derives its audit log from git history: create() is a no-op and
+  // findByMemoryId reads git log. Round-trip tests (create → find) are
+  // structurally impossible against vault and are covered in the unit tests at
+  // tests/unit/backend/vault/repositories/audit-repository.test.ts.
+  // Only "unknown memory → []" can run against vault, which exercises
+  // the empty-git-log path and validates interface compliance.
+  const isVault = factory.name === "vault";
+
   beforeEach(async () => {
     backend = await factory.create();
     // pg enforces FK audit_log.memory_id → memories.id — seed a memory
@@ -69,7 +71,9 @@ describe.each(factories)("AuditRepository contract — $name", (factory) => {
     await backend.close();
   });
 
-  it("create + findByMemoryId returns the entry", async () => {
+  // Roundtrip tests require create() to persist entries; vault's create()
+  // is intentionally a no-op (git commits are the audit log).
+  it.skipIf(isVault)("create + findByMemoryId returns the entry", async () => {
     await backend.auditRepo.create(makeEntry());
     const found = await backend.auditRepo.findByMemoryId("m1");
     expect(found).toHaveLength(1);
@@ -77,44 +81,55 @@ describe.each(factories)("AuditRepository contract — $name", (factory) => {
     expect(found[0]!.actor).toBe("chris");
   });
 
+  // This test does NOT require create() — it verifies the empty-result path,
+  // which vault supports by returning [] when git log finds no matching commits.
   it("findByMemoryId returns empty array for unknown memory", async () => {
     expect(await backend.auditRepo.findByMemoryId("nope")).toEqual([]);
   });
 
-  it("findByMemoryId returns entries ordered by created_at desc", async () => {
-    const base = new Date("2026-04-21T00:00:00.000Z").getTime();
-    await backend.auditRepo.create(
-      makeEntry({ id: "a1", created_at: new Date(base) }),
-    );
-    await backend.auditRepo.create(
-      makeEntry({ id: "a2", created_at: new Date(base + 1000) }),
-    );
-    await backend.auditRepo.create(
-      makeEntry({ id: "a3", created_at: new Date(base + 500) }),
-    );
-    const found = await backend.auditRepo.findByMemoryId("m1");
-    expect(found.map((e) => e.id)).toEqual(["a2", "a3", "a1"]);
-  });
+  it.skipIf(isVault)(
+    "findByMemoryId returns entries ordered by created_at desc",
+    async () => {
+      const base = new Date("2026-04-21T00:00:00.000Z").getTime();
+      await backend.auditRepo.create(
+        makeEntry({ id: "a1", created_at: new Date(base) }),
+      );
+      await backend.auditRepo.create(
+        makeEntry({ id: "a2", created_at: new Date(base + 1000) }),
+      );
+      await backend.auditRepo.create(
+        makeEntry({ id: "a3", created_at: new Date(base + 500) }),
+      );
+      const found = await backend.auditRepo.findByMemoryId("m1");
+      expect(found.map((e) => e.id)).toEqual(["a2", "a3", "a1"]);
+    },
+  );
 
-  it("preserves diff and reason payloads across roundtrip", async () => {
-    const diff = { content: ["old", "new"], tags: [["x"], ["x", "y"]] };
-    await backend.auditRepo.create(
-      makeEntry({
-        action: "updated",
-        reason: "refactor",
-        diff,
-      }),
-    );
-    const [entry] = await backend.auditRepo.findByMemoryId("m1");
-    expect(entry?.reason).toBe("refactor");
-    expect(entry?.diff).toEqual(diff);
-    expect(entry?.action).toBe("updated");
-  });
+  it.skipIf(isVault)(
+    "preserves diff and reason payloads across roundtrip",
+    async () => {
+      const diff = { content: ["old", "new"], tags: [["x"], ["x", "y"]] };
+      await backend.auditRepo.create(
+        makeEntry({
+          action: "updated",
+          reason: "refactor",
+          diff,
+        }),
+      );
+      const [entry] = await backend.auditRepo.findByMemoryId("m1");
+      expect(entry?.reason).toBe("refactor");
+      expect(entry?.diff).toEqual(diff);
+      expect(entry?.action).toBe("updated");
+    },
+  );
 
-  it("preserves caller-supplied created_at byte-for-byte", async () => {
-    const iso = "2020-01-01T00:00:00.000Z";
-    await backend.auditRepo.create(makeEntry({ created_at: new Date(iso) }));
-    const [entry] = await backend.auditRepo.findByMemoryId("m1");
-    expect(entry?.created_at.toISOString()).toBe(iso);
-  });
+  it.skipIf(isVault)(
+    "preserves caller-supplied created_at byte-for-byte",
+    async () => {
+      const iso = "2020-01-01T00:00:00.000Z";
+      await backend.auditRepo.create(makeEntry({ created_at: new Date(iso) }));
+      const [entry] = await backend.auditRepo.findByMemoryId("m1");
+      expect(entry?.created_at.toISOString()).toBe(iso);
+    },
+  );
 });

--- a/tests/integration/vault/audit-history.test.ts
+++ b/tests/integration/vault/audit-history.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { VaultBackend } from "../../../src/backend/vault/index.js";
+import { AuditService } from "../../../src/services/audit-service.js";
+import { generateId } from "../../../src/utils/id.js";
+import type { Memory } from "../../../src/types/memory.js";
+
+const DIMS = 32;
+
+function makeMemory(
+  overrides: Partial<Memory> & Pick<Memory, "id" | "workspace_id">,
+): Memory & { embedding: number[] } {
+  const now = new Date();
+  return {
+    project_id: "proj-1",
+    content: "initial",
+    title: "t",
+    type: "fact",
+    scope: "workspace",
+    tags: ["x"],
+    author: "alice",
+    source: null,
+    session_id: null,
+    metadata: null,
+    embedding_model: null,
+    embedding_dimensions: DIMS,
+    version: 1,
+    created_at: now,
+    updated_at: now,
+    verified_at: null,
+    archived_at: null,
+    comment_count: 0,
+    flag_count: 0,
+    relationship_count: 0,
+    last_comment_at: null,
+    verified_by: null,
+    ...overrides,
+    embedding: new Array(DIMS).fill(0.01),
+  };
+}
+
+describe("vault AuditService.getHistory", () => {
+  it("returns create/update/archive entries with correct shapes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "audit-"));
+    const backend = await VaultBackend.create({
+      root,
+      embeddingDimensions: DIMS,
+    });
+    const audit = new AuditService(backend.auditRepo, "proj-1");
+
+    // Set up workspace so the path resolves correctly.
+    await backend.workspaceRepo.findOrCreate("ws-1");
+
+    const memId = generateId();
+    const mem = await backend.memoryRepo.create(
+      makeMemory({ id: memId, workspace_id: "ws-1" }),
+    );
+
+    const updated = await backend.memoryRepo.update(mem.id, mem.version, {
+      content: "updated",
+      tags: ["x", "y"],
+    });
+
+    await backend.memoryRepo.archive([updated.id]);
+
+    const entries = await audit.getHistory(mem.id);
+    expect(entries.map((e) => e.action)).toEqual([
+      "archived",
+      "updated",
+      "created",
+    ]);
+
+    const updatedEntry = entries.find((e) => e.action === "updated")!;
+    expect(updatedEntry.diff).not.toBeNull();
+    expect(updatedEntry.diff).toMatchObject({
+      before: { content: "initial", tags: ["x"] },
+      after: { content: "updated", tags: ["x", "y"] },
+    });
+
+    const createdEntry = entries.find((e) => e.action === "created")!;
+    expect(createdEntry.diff).toBeNull();
+
+    await backend.close();
+  }, 30_000);
+});

--- a/tests/integration/vault/merge-driver.test.ts
+++ b/tests/integration/vault/merge-driver.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import { stat, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { setupBareAndTwoVaults } from "../../contract/repositories/_git-helpers.js";
+import { VaultBackend } from "../../../src/backend/vault/index.js";
+
+const DIMS = 32;
+
+async function ensureCliBuilt(): Promise<void> {
+  // Anchor on process.cwd() (the repo root) so this check works whether
+  // the test runs from the TypeScript source (vitest) or the compiled
+  // dist/ copy — both execute with cwd at the project root.
+  const expectedPath = join(
+    process.cwd(),
+    "dist",
+    "src",
+    "cli",
+    "merge-memory.js",
+  );
+  try {
+    await stat(expectedPath);
+  } catch {
+    throw new Error(
+      `Expected compiled CLI at ${expectedPath}. Run \`npx tsc\` before running integration tests.`,
+    );
+  }
+}
+
+function fakeEmbed(): (text: string) => Promise<number[]> {
+  return async () => new Array(DIMS).fill(0.01);
+}
+
+async function createBackend(
+  root: string,
+  remoteUrl: string,
+): Promise<VaultBackend> {
+  return VaultBackend.create({
+    root,
+    embeddingDimensions: DIMS,
+    remoteUrl,
+    pushDebounceMs: 10,
+    pushBackoffMs: [50, 200],
+    embed: fakeEmbed(),
+  });
+}
+
+describe("merge driver — concurrent frontmatter edits", () => {
+  it("merges tag additions from both sides without conflict", async () => {
+    await ensureCliBuilt();
+
+    const { bare, vaultA, vaultB, cleanup } = await setupBareAndTwoVaults();
+    try {
+      const backendA = await createBackend(vaultA, bare);
+
+      // Seed workspace on A.
+      await backendA.workspaceRepo.findOrCreate("ws-1");
+
+      // Seed a memory on A with a shared tag, then push.
+      const mem = await backendA.memoryRepo.create({
+        id: "merge-smoke-1",
+        project_id: "p1",
+        workspace_id: "ws-1",
+        content: "body",
+        title: "merge-smoke",
+        type: "fact",
+        scope: "workspace",
+        author: "alice",
+        source: null,
+        session_id: null,
+        metadata: null,
+        tags: ["shared"],
+        embedding_model: null,
+        embedding_dimensions: DIMS,
+        version: 1,
+        created_at: new Date("2026-04-22T00:00:00Z"),
+        updated_at: new Date("2026-04-22T00:00:00Z"),
+        verified_at: null,
+        archived_at: null,
+        comment_count: 0,
+        flag_count: 0,
+        relationship_count: 0,
+        last_comment_at: null,
+        verified_by: null,
+        embedding: new Array(DIMS).fill(0.01),
+      });
+
+      await backendA.flushPushes();
+
+      // Create B only after A has pushed so B's alignWithRemote resets
+      // to A's history (unrelated-history bootstrap path), giving both
+      // clones the same base commit.
+      const backendB = await createBackend(vaultB, bare);
+
+      // B pulls — now both clones share the same base commit.
+      await backendB.pullFromRemote();
+
+      // Concurrent edits: A adds "ours", B adds "theirs".
+      // Both start from the same version so the commits diverge.
+      await backendA.memoryRepo.update(mem.id, mem.version, {
+        tags: ["shared", "ours"],
+      });
+      await backendB.memoryRepo.update(mem.id, mem.version, {
+        tags: ["shared", "theirs"],
+      });
+
+      // A pushes first (lands on origin).
+      await backendA.flushPushes();
+
+      // B pulls — should rebase B's commit on top of A's via the
+      // agent-brain-memory merge driver, producing a clean merge
+      // of both tag lists.
+      const pulled = await backendB.pullFromRemote();
+      expect(pulled.conflict).toBe(false);
+
+      // Both tags must appear in B's local file.
+      const path = join(
+        vaultB,
+        "workspaces",
+        "ws-1",
+        "memories",
+        "merge-smoke-1.md",
+      );
+      const body = await readFile(path, "utf8");
+      expect(body).toContain("- shared");
+      expect(body).toContain("- ours");
+      expect(body).toContain("- theirs");
+
+      await backendA.close();
+      await backendB.close();
+    } finally {
+      await cleanup();
+    }
+  }, 60_000);
+});

--- a/tests/integration/vault/merge-driver.test.ts
+++ b/tests/integration/vault/merge-driver.test.ts
@@ -3,6 +3,7 @@ import { stat, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { setupBareAndTwoVaults } from "../../contract/repositories/_git-helpers.js";
 import { VaultBackend } from "../../../src/backend/vault/index.js";
+import { parseMemoryFile } from "../../../src/backend/vault/parser/memory-parser.js";
 
 const DIMS = 32;
 
@@ -94,13 +95,16 @@ describe("merge driver — concurrent frontmatter edits", () => {
       // B pulls — now both clones share the same base commit.
       await backendB.pullFromRemote();
 
-      // Concurrent edits: A adds "ours", B adds "theirs".
-      // Both start from the same version so the commits diverge.
+      // Concurrent edits: A adds "zebra" (sorts last), B adds "alpha" (sorts
+      // first). Plain text merge would preserve insertion order and produce
+      // ["shared", "zebra", "alpha"]; our custom driver calls unionSorted
+      // which sorts the union, giving ["alpha", "shared", "zebra"]. This
+      // distinguishes driver-fired from plain-text-merge.
       await backendA.memoryRepo.update(mem.id, mem.version, {
-        tags: ["shared", "ours"],
+        tags: ["shared", "zebra"],
       });
       await backendB.memoryRepo.update(mem.id, mem.version, {
-        tags: ["shared", "theirs"],
+        tags: ["shared", "alpha"],
       });
 
       // A pushes first (lands on origin).
@@ -112,7 +116,10 @@ describe("merge driver — concurrent frontmatter edits", () => {
       const pulled = await backendB.pullFromRemote();
       expect(pulled.conflict).toBe(false);
 
-      // Both tags must appear in B's local file.
+      // Parse B's merged file and assert the custom driver ran.
+      // Our driver calls unionSorted → Array.from(new Set([...])).sort(),
+      // giving ["alpha", "shared", "zebra"]. Plain text merge would instead
+      // preserve insertion order, e.g. ["shared", "zebra", "alpha"].
       const path = join(
         vaultB,
         "workspaces",
@@ -121,9 +128,8 @@ describe("merge driver — concurrent frontmatter edits", () => {
         "merge-smoke-1.md",
       );
       const body = await readFile(path, "utf8");
-      expect(body).toContain("- shared");
-      expect(body).toContain("- ours");
-      expect(body).toContain("- theirs");
+      const merged = parseMemoryFile(body).memory;
+      expect(merged.tags).toEqual(["alpha", "shared", "zebra"]);
 
       await backendA.close();
       await backendB.close();

--- a/tests/unit/backend/vault/git/bootstrap.test.ts
+++ b/tests/unit/backend/vault/git/bootstrap.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, rm, readFile, writeFile } from "node:fs/promises";
+import {
+  mkdtemp,
+  rm,
+  readFile,
+  writeFile,
+  mkdir,
+  stat,
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { simpleGit } from "simple-git";
@@ -105,5 +112,30 @@ describe("ensureVaultGit", () => {
     await ensureVaultGit({ root, trackUsers: false });
     const headAfter = (await git.log()).latest?.hash;
     expect(headAfter).toBe(headBefore);
+  });
+});
+
+describe("ensureVaultGit — _audit/ cleanup", () => {
+  let root: string;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "vault-"));
+  });
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("removes an existing _audit/ directory on startup", async () => {
+    await mkdir(join(root, "_audit"), { recursive: true });
+    await writeFile(join(root, "_audit", "mem-1.jsonl"), "{}\n", "utf8");
+    await ensureVaultGit({ root, trackUsers: false });
+    await expect(stat(join(root, "_audit"))).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+
+  it("does not list _audit/ in the committed .gitignore", async () => {
+    await ensureVaultGit({ root, trackUsers: false });
+    const body = await readFile(join(root, ".gitignore"), "utf8");
+    expect(body).not.toMatch(/^_audit\/?$/m);
   });
 });

--- a/tests/unit/backend/vault/git/bootstrap.test.ts
+++ b/tests/unit/backend/vault/git/bootstrap.test.ts
@@ -113,6 +113,18 @@ describe("ensureVaultGit", () => {
     const headAfter = (await git.log()).latest?.hash;
     expect(headAfter).toBe(headBefore);
   });
+
+  it("writes the merge driver config on bootstrap", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vault-"));
+    await ensureVaultGit({ root, trackUsers: false });
+    const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+    const driver = await git.raw([
+      "config",
+      "--local",
+      "merge.agent-brain-memory.driver",
+    ]);
+    expect(driver).toMatch(/node ".+merge-memory\.js" %A %O %B/);
+  });
 });
 
 describe("ensureVaultGit — _audit/ cleanup", () => {

--- a/tests/unit/backend/vault/git/bootstrap.test.ts
+++ b/tests/unit/backend/vault/git/bootstrap.test.ts
@@ -30,7 +30,8 @@ describe("ensureVaultGit", () => {
     expect(ignore).toContain(".agent-brain/");
     expect(ignore).toContain("users/");
     const attrs = await readFile(join(root, ".gitattributes"), "utf8");
-    expect(attrs).toContain("*.md merge=union");
+    expect(attrs).toContain("merge=agent-brain-memory");
+    expect(attrs).not.toContain("*.md merge=union");
   });
 
   it("omits users/ from .gitignore when trackUsers=true", async () => {
@@ -50,15 +51,16 @@ describe("ensureVaultGit", () => {
     expect(usersCount).toBe(1);
   });
 
-  it("appends *.md merge=union to an existing .gitattributes, preserving prior rules", async () => {
+  it("appends path-specific merge=agent-brain-memory rules to an existing .gitattributes, preserving prior rules", async () => {
     await writeFile(join(root, ".gitattributes"), "*.json binary\n", "utf8");
     await ensureVaultGit({ root, trackUsers: false });
     const attrs = await readFile(join(root, ".gitattributes"), "utf8");
     expect(attrs).toContain("*.json binary");
-    expect(attrs).toContain("*.md merge=union");
+    expect(attrs).toContain("merge=agent-brain-memory");
+    expect(attrs).not.toContain("*.md merge=union");
   });
 
-  it("throws VAULT_BOOTSTRAP_FAILED if the required rule is only inside a comment", async () => {
+  it("appends path-specific rules even when a comment mentions an old rule", async () => {
     await writeFile(
       join(root, ".gitattributes"),
       "# reminder: *.md merge=union\n",
@@ -66,13 +68,18 @@ describe("ensureVaultGit", () => {
     );
     await ensureVaultGit({ root, trackUsers: false });
     // hasActiveRule is line-based, so the comment should not count as
-    // present — bootstrap must append the real rule.
+    // present — bootstrap must append the real rules.
     const attrs = await readFile(join(root, ".gitattributes"), "utf8");
     const active = attrs
       .split("\n")
       .map((l) => l.trim())
       .filter((l) => l !== "" && !l.startsWith("#"));
-    expect(active).toContain("*.md merge=union");
+    expect(active).toContain(
+      "workspaces/**/memories/*.md merge=agent-brain-memory",
+    );
+    expect(active).toContain("project/memories/*.md merge=agent-brain-memory");
+    expect(active).toContain("users/**/memories/*.md merge=agent-brain-memory");
+    expect(active).not.toContain("*.md merge=union");
   });
 
   it("is idempotent: second call produces byte-identical files", async () => {
@@ -124,6 +131,39 @@ describe("ensureVaultGit", () => {
       "merge.agent-brain-memory.driver",
     ]);
     expect(driver).toMatch(/node ".+merge-memory\.js" %A %O %B/);
+  });
+
+  it("writes the three memory-path merge=agent-brain-memory rules", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vault-"));
+    await ensureVaultGit({ root, trackUsers: true });
+    const body = await readFile(join(root, ".gitattributes"), "utf8");
+    expect(body).toMatch(
+      /^workspaces\/\*\*\/memories\/\*\.md merge=agent-brain-memory$/m,
+    );
+    expect(body).toMatch(
+      /^project\/memories\/\*\.md merge=agent-brain-memory$/m,
+    );
+    expect(body).toMatch(
+      /^users\/\*\*\/memories\/\*\.md merge=agent-brain-memory$/m,
+    );
+    expect(body).not.toMatch(/^\*\.md merge=union$/m);
+  });
+
+  it("migrates a Phase 4b vault by replacing *.md merge=union", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vault-"));
+    // Simulate a Phase 4b bootstrap
+    await writeFile(join(root, ".gitattributes"), "*.md merge=union\n", "utf8");
+    const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+    await git.init();
+    await git.addConfig("user.email", "t@t");
+    await git.addConfig("user.name", "t");
+    await git.add([".gitattributes"]);
+    await git.commit("seed");
+
+    await ensureVaultGit({ root, trackUsers: false });
+    const body = await readFile(join(root, ".gitattributes"), "utf8");
+    expect(body).not.toMatch(/merge=union/);
+    expect(body).toMatch(/merge=agent-brain-memory/);
   });
 });
 

--- a/tests/unit/backend/vault/git/merge-driver-config.test.ts
+++ b/tests/unit/backend/vault/git/merge-driver-config.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { simpleGit } from "simple-git";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ensureMergeDriverConfig } from "../../../../../src/backend/vault/git/merge-driver-config.js";
+import { scrubGitEnv } from "../../../../../src/backend/vault/git/env.js";
+
+describe("ensureMergeDriverConfig", () => {
+  it("writes driver name + path to .git/config", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mdc-"));
+    const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+    await git.init();
+    await ensureMergeDriverConfig({ root, driverPath: "/abs/merge-memory.js" });
+    const name = await git.raw([
+      "config",
+      "--local",
+      "merge.agent-brain-memory.name",
+    ]);
+    const driver = await git.raw([
+      "config",
+      "--local",
+      "merge.agent-brain-memory.driver",
+    ]);
+    expect(name.trim()).toBe("agent-brain memory-file merge");
+    expect(driver.trim()).toBe('node "/abs/merge-memory.js" %A %O %B');
+  });
+
+  it("rewrites driver path on each call (self-heals)", async () => {
+    const root = await mkdtemp(join(tmpdir(), "mdc-"));
+    const git = simpleGit({ baseDir: root }).env(scrubGitEnv());
+    await git.init();
+    await ensureMergeDriverConfig({ root, driverPath: "/abs/old.js" });
+    await ensureMergeDriverConfig({ root, driverPath: "/abs/new.js" });
+    const driver = await git.raw([
+      "config",
+      "--local",
+      "merge.agent-brain-memory.driver",
+    ]);
+    expect(driver.trim()).toBe('node "/abs/new.js" %A %O %B');
+  });
+});

--- a/tests/unit/backend/vault/git/trailer-parser.test.ts
+++ b/tests/unit/backend/vault/git/trailer-parser.test.ts
@@ -71,4 +71,10 @@ describe("parseTrailers", () => {
   it("returns null for an unknown AB-Action value", () => {
     expect(parseTrailers("x\n\nAB-Action: nonsense\nAB-Actor: a")).toBeNull();
   });
+
+  it("returns null when AB-Actor is absent", () => {
+    expect(
+      parseTrailers("x\n\nAB-Action: updated\nAB-Memory: mem-1"),
+    ).toBeNull();
+  });
 });

--- a/tests/unit/backend/vault/git/trailer-parser.test.ts
+++ b/tests/unit/backend/vault/git/trailer-parser.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { parseTrailers } from "../../../../../src/backend/vault/git/trailer-parser.js";
+
+describe("parseTrailers", () => {
+  it("parses a memory-action commit", () => {
+    const msg = [
+      "[agent-brain] update: memory-foo",
+      "",
+      "AB-Action: updated",
+      "AB-Memory: mem-123",
+      "AB-Actor: alice",
+    ].join("\n");
+    expect(parseTrailers(msg)).toEqual({
+      action: "updated",
+      memoryId: "mem-123",
+      actor: "alice",
+      reason: null,
+    });
+  });
+
+  it("parses a workspace_upsert commit", () => {
+    const msg = [
+      "[agent-brain] workspace: ws-1",
+      "",
+      "AB-Action: workspace_upsert",
+      "AB-Workspace: ws-1",
+      "AB-Actor: bob",
+    ].join("\n");
+    expect(parseTrailers(msg)).toEqual({
+      action: "workspace_upsert",
+      workspaceId: "ws-1",
+      actor: "bob",
+      reason: null,
+    });
+  });
+
+  it("parses a reconcile commit (no memory/workspace id)", () => {
+    const msg = "reconcile\n\nAB-Action: reconcile\nAB-Actor: system";
+    expect(parseTrailers(msg)).toEqual({
+      action: "reconcile",
+      actor: "system",
+      reason: null,
+    });
+  });
+
+  it("decodes AB-Reason escapes", () => {
+    const msg = [
+      "archive",
+      "",
+      "AB-Action: archived",
+      "AB-Memory: mem-1",
+      "AB-Actor: alice",
+      "AB-Reason: line-1\\nline-2\\\\tail",
+    ].join("\n");
+    const parsed = parseTrailers(msg);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.reason).toBe("line-1\nline-2\\tail");
+  });
+
+  it("returns null when AB-Action is absent", () => {
+    expect(parseTrailers("random commit")).toBeNull();
+    expect(parseTrailers("")).toBeNull();
+  });
+
+  it("tolerates leading CRLF line endings", () => {
+    const msg =
+      "subject\r\n\r\nAB-Action: created\r\nAB-Memory: mem-1\r\nAB-Actor: a";
+    expect(parseTrailers(msg)?.action).toBe("created");
+  });
+
+  it("returns null for an unknown AB-Action value", () => {
+    expect(parseTrailers("x\n\nAB-Action: nonsense\nAB-Actor: a")).toBeNull();
+  });
+});

--- a/tests/unit/backend/vault/parser/merge-memory.test.ts
+++ b/tests/unit/backend/vault/parser/merge-memory.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import { mergeMemoryFiles } from "../../../../../src/backend/vault/parser/merge-memory.js";
+import { parseMemoryFile } from "../../../../../src/backend/vault/parser/memory-parser.js";
+
+/**
+ * Build a minimal valid memory file markdown string.
+ * Dates are single-quoted so gray-matter parses them as strings,
+ * matching what isoDate() expects. (Bare ISO timestamps are parsed
+ * by gray-matter as Date objects, which fails the string type-check.)
+ */
+const base = (over: Record<string, unknown> = {}) =>
+  [
+    "---",
+    "id: mem-1",
+    "project_id: proj-1",
+    "workspace_id: ws-1",
+    `title: ${over.title ?? "hello"}`,
+    `type: ${over.type ?? "fact"}`,
+    `scope: ${over.scope ?? "workspace"}`,
+    `tags: ${JSON.stringify(over.tags ?? ["a"])}`,
+    `author: ${over.author ?? "alice"}`,
+    "source: null",
+    "session_id: null",
+    `metadata: ${over.metadata === undefined ? "null" : JSON.stringify(over.metadata)}`,
+    "embedding_model: null",
+    "embedding_dimensions: null",
+    `version: ${over.version ?? 1}`,
+    `created: '2026-04-01T00:00:00.000Z'`,
+    `updated: '${over.updated ?? "2026-04-20T10:00:00.000Z"}'`,
+    `verified: ${over.verified && over.verified !== "null" ? `'${String(over.verified)}'` : "null"}`,
+    `archived: ${over.archived && over.archived !== "null" ? `'${String(over.archived)}'` : "null"}`,
+    `verified_by: ${over.verified_by ? String(over.verified_by) : "null"}`,
+    "flags: []",
+    "---",
+    "",
+    `# ${over.title ?? "hello"}`,
+    "",
+    `${over.content ?? "body"}`,
+    "",
+  ].join("\n");
+
+const passthroughDiff3 = () => ({ clean: true as const, text: "" });
+
+describe("mergeMemoryFiles", () => {
+  it("returns { ok: true } with union-merged tags", async () => {
+    const a = base({ tags: ["a"] });
+    const o = base({ tags: ["a", "x"] });
+    const t = base({ tags: ["a", "y"] });
+    const res = await mergeMemoryFiles(a, o, t, { diff3: passthroughDiff3 });
+    if (!res.ok) throw new Error(res.reason);
+    const merged = parseMemoryFile(res.merged).memory;
+    expect(merged.tags).toEqual(["a", "x", "y"]);
+  });
+
+  it("picks the side with the later updated_at for LWW fields (title)", async () => {
+    const a = base({ title: "base" });
+    const o = base({ title: "ours", updated: "2026-04-20T10:00:00.000Z" });
+    const t = base({ title: "theirs", updated: "2026-04-20T11:00:00.000Z" });
+    const res = await mergeMemoryFiles(a, o, t, { diff3: passthroughDiff3 });
+    if (!res.ok) throw new Error(res.reason);
+    expect(parseMemoryFile(res.merged).memory.title).toBe("theirs");
+  });
+
+  it("takes max of both updated_at timestamps", async () => {
+    const a = base();
+    const o = base({ updated: "2026-04-20T10:00:00.000Z" });
+    const t = base({ updated: "2026-04-21T00:00:00.000Z" });
+    const res = await mergeMemoryFiles(a, o, t, { diff3: passthroughDiff3 });
+    if (!res.ok) throw new Error(res.reason);
+    expect(parseMemoryFile(res.merged).memory.updated_at.toISOString()).toBe(
+      "2026-04-21T00:00:00.000Z",
+    );
+  });
+
+  it("archived_at: once archived, stays", async () => {
+    const a = base();
+    const o = base({ archived: "2026-04-20T10:00:00.000Z" });
+    const t = base({ archived: "null" });
+    const res = await mergeMemoryFiles(a, o, t, { diff3: passthroughDiff3 });
+    if (!res.ok) throw new Error(res.reason);
+    expect(parseMemoryFile(res.merged).memory.archived_at?.toISOString()).toBe(
+      "2026-04-20T10:00:00.000Z",
+    );
+  });
+
+  it("rejects on immutable-field divergence (project_id)", async () => {
+    const a = base();
+    const o = base();
+    const t = a.replace("project_id: proj-1", "project_id: proj-X");
+    const res = await mergeMemoryFiles(a, o, t, { diff3: passthroughDiff3 });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.reason).toMatch(/project_id/);
+  });
+
+  it("rejects on parse failure of any side", async () => {
+    const res = await mergeMemoryFiles(base(), "not markdown", base(), {
+      diff3: passthroughDiff3,
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("metadata: per-key merge picks the side with later updated_at", async () => {
+    const a = base({ metadata: { keep: 1 } });
+    const o = base({
+      metadata: { keep: 1, ours: "o" },
+      updated: "2026-04-20T10:00:00.000Z",
+    });
+    const t = base({
+      metadata: { keep: 1, theirs: "t" },
+      updated: "2026-04-20T11:00:00.000Z",
+    });
+    const res = await mergeMemoryFiles(a, o, t, { diff3: passthroughDiff3 });
+    if (!res.ok) throw new Error(res.reason);
+    const mergedMeta = parseMemoryFile(res.merged).memory.metadata;
+    expect(mergedMeta).toEqual({ keep: 1, ours: "o", theirs: "t" });
+  });
+
+  it("verified_at/verified_by: take the pair with later verified_at", async () => {
+    const a = base();
+    const o = base({
+      verified: "2026-04-19T00:00:00.000Z",
+      verified_by: "alice",
+    });
+    const t = base({
+      verified: "2026-04-20T00:00:00.000Z",
+      verified_by: "bob",
+    });
+    const res = await mergeMemoryFiles(a, o, t, { diff3: passthroughDiff3 });
+    if (!res.ok) throw new Error(res.reason);
+    const m = parseMemoryFile(res.merged).memory;
+    expect(m.verified_at?.toISOString()).toBe("2026-04-20T00:00:00.000Z");
+    expect(m.verified_by).toBe("bob");
+  });
+
+  it("falls back to LWW when diff3 reports conflict", async () => {
+    const a = base({ content: "base-body" });
+    const o = base({
+      content: "ours-body",
+      updated: "2026-04-20T10:00:00.000Z",
+    });
+    const t = base({
+      content: "theirs-body",
+      updated: "2026-04-21T00:00:00.000Z",
+    });
+    const res = await mergeMemoryFiles(a, o, t, {
+      diff3: () => ({ clean: false as const }),
+    });
+    if (!res.ok) throw new Error(res.reason);
+    expect(parseMemoryFile(res.merged).memory.content.trim()).toBe(
+      "theirs-body",
+    );
+  });
+});

--- a/tests/unit/backend/vault/parser/merge-memory.test.ts
+++ b/tests/unit/backend/vault/parser/merge-memory.test.ts
@@ -340,6 +340,43 @@ describe("mergeMemoryFiles", () => {
       expect(merged).toHaveLength(1);
       expect(merged[0]!.content).toBe("theirs version");
     });
+
+    it("comments sorted ascending by created_at even when theirs has an older comment than ours", async () => {
+      // Regression: unionBy preserves insertion order (ours first, then theirs).
+      // If theirs has an older comment, it would appear after ours without an explicit sort.
+      const comOurs = {
+        id: "com-newer",
+        author: "alice",
+        ts: "2026-04-20T12:00:00.000Z",
+        text: "newer comment added on ours",
+      };
+      const comTheirs = {
+        id: "com-older",
+        author: "bob",
+        ts: "2026-04-10T08:00:00.000Z",
+        text: "older comment added on theirs",
+      };
+
+      const ancestor = base();
+      const ours = base({ body: ["body", "", commentBlock([comOurs]), ""] });
+      const theirs = base({
+        body: ["body", "", commentBlock([comTheirs]), ""],
+      });
+
+      const res = await mergeMemoryFiles(ancestor, ours, theirs, {
+        diff3: passthroughDiff3,
+      });
+      if (!res.ok) throw new Error(res.reason);
+
+      const { comments: merged } = parseMemoryFile(res.merged);
+      expect(merged).toHaveLength(2);
+      // Must be in chronological ascending order regardless of which side each came from
+      expect(merged[0]!.id).toBe("com-older");
+      expect(merged[1]!.id).toBe("com-newer");
+      expect(merged[0]!.created_at.getTime()).toBeLessThan(
+        merged[1]!.created_at.getTime(),
+      );
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -434,6 +471,7 @@ describe("mergeMemoryFiles", () => {
 
       const { relationships: merged } = parseMemoryFile(res.merged);
       // Collision on (source_id=mem-1, target_id=mem-2, type=overrides) → theirs wins
+      // source_id comes from id: mem-1 in the base() fixture (composite key relies on it)
       expect(merged).toHaveLength(1);
       expect(merged[0]!.id).toBe("rel-theirs");
       expect(merged[0]!.confidence).toBeCloseTo(0.95);

--- a/tests/unit/backend/vault/parser/merge-memory.test.ts
+++ b/tests/unit/backend/vault/parser/merge-memory.test.ts
@@ -7,9 +7,21 @@ import { parseMemoryFile } from "../../../../../src/backend/vault/parser/memory-
  * Dates are single-quoted so gray-matter parses them as strings,
  * matching what isoDate() expects. (Bare ISO timestamps are parsed
  * by gray-matter as Date objects, which fails the string type-check.)
+ *
+ * Optional overrides:
+ *   flags    — raw YAML array string to embed verbatim in frontmatter
+ *   body     — raw markdown lines to append after the title line (replaces
+ *              the default "body" paragraph and any ## sections)
  */
-const base = (over: Record<string, unknown> = {}) =>
-  [
+const base = (over: Record<string, unknown> = {}) => {
+  const flagsYaml = over.flags !== undefined ? String(over.flags) : "flags: []";
+
+  const bodyLines: string[] =
+    over.body !== undefined
+      ? (over.body as string[])
+      : [`${over.content ?? "body"}`, ""];
+
+  return [
     "---",
     "id: mem-1",
     "project_id: proj-1",
@@ -30,16 +42,25 @@ const base = (over: Record<string, unknown> = {}) =>
     `verified: ${over.verified && over.verified !== "null" ? `'${String(over.verified)}'` : "null"}`,
     `archived: ${over.archived && over.archived !== "null" ? `'${String(over.archived)}'` : "null"}`,
     `verified_by: ${over.verified_by ? String(over.verified_by) : "null"}`,
-    "flags: []",
+    flagsYaml,
     "---",
     "",
     `# ${over.title ?? "hello"}`,
     "",
-    `${over.content ?? "body"}`,
-    "",
+    ...bodyLines,
   ].join("\n");
+};
 
-const passthroughDiff3 = () => ({ clean: true as const, text: "" });
+/**
+ * passthroughDiff3: returns the "ours" text unchanged so the clean-diff3
+ * path writes the actual content rather than an empty string. This lets
+ * tests that don't care about body text pass through cleanly, while the
+ * body-content test can verify the returned text is used.
+ */
+const passthroughDiff3 = (_base: string, ours: string) => ({
+  clean: true as const,
+  text: ours,
+});
 
 describe("mergeMemoryFiles", () => {
   it("returns { ok: true } with union-merged tags", async () => {
@@ -93,6 +114,29 @@ describe("mergeMemoryFiles", () => {
     expect(res.reason).toMatch(/project_id/);
   });
 
+  it("rejects on immutable-field divergence (id)", async () => {
+    const a = base();
+    const o = base();
+    const t = a.replace("id: mem-1", "id: mem-X");
+    const res = await mergeMemoryFiles(a, o, t, { diff3: passthroughDiff3 });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.reason).toMatch(/\bid\b/);
+  });
+
+  it("rejects on immutable-field divergence (created_at)", async () => {
+    const a = base();
+    const o = base();
+    const t = a.replace(
+      "created: '2026-04-01T00:00:00.000Z'",
+      "created: '2025-01-01T00:00:00.000Z'",
+    );
+    const res = await mergeMemoryFiles(a, o, t, { diff3: passthroughDiff3 });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.reason).toMatch(/created_at/);
+  });
+
   it("rejects on parse failure of any side", async () => {
     const res = await mergeMemoryFiles(base(), "not markdown", base(), {
       diff3: passthroughDiff3,
@@ -133,6 +177,16 @@ describe("mergeMemoryFiles", () => {
     expect(m.verified_by).toBe("bob");
   });
 
+  it("clean diff3 path uses the returned text", async () => {
+    // passthroughDiff3 returns ours; verify that is what ends up in the merged file.
+    const a = base({ content: "ancestor-body" });
+    const o = base({ content: "ours-body" });
+    const t = base({ content: "theirs-body" });
+    const res = await mergeMemoryFiles(a, o, t, { diff3: passthroughDiff3 });
+    if (!res.ok) throw new Error(res.reason);
+    expect(parseMemoryFile(res.merged).memory.content.trim()).toBe("ours-body");
+  });
+
   it("falls back to LWW when diff3 reports conflict", async () => {
     const a = base({ content: "base-body" });
     const o = base({
@@ -150,5 +204,417 @@ describe("mergeMemoryFiles", () => {
     expect(parseMemoryFile(res.merged).memory.content.trim()).toBe(
       "theirs-body",
     );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Body subsection: Comments
+  // ---------------------------------------------------------------------------
+
+  describe("comments", () => {
+    /** Build the ## Comments markdown block for one or more comments. */
+    const commentBlock = (
+      comments: Array<{ id: string; author: string; ts: string; text: string }>,
+    ): string =>
+      [
+        "## Comments",
+        "",
+        ...comments.map(
+          (c) => `> [!comment] ${c.author} · ${c.ts} · ${c.id}\n> ${c.text}`,
+        ),
+      ].join("\n");
+
+    it("union of comments by id — different comments on each side are both preserved", async () => {
+      const comA = {
+        id: "com-1",
+        author: "alice",
+        ts: "2026-04-10T08:00:00.000Z",
+        text: "first",
+      };
+      const comB = {
+        id: "com-2",
+        author: "bob",
+        ts: "2026-04-11T09:00:00.000Z",
+        text: "second",
+      };
+
+      const makeWithComments = (comments: (typeof comA)[]) =>
+        base({
+          body:
+            comments.length === 0
+              ? ["body", ""]
+              : ["body", "", commentBlock(comments), ""],
+        });
+
+      const ancestor = makeWithComments([]);
+      const ours = makeWithComments([comA]);
+      const theirs = makeWithComments([comB]);
+
+      const res = await mergeMemoryFiles(ancestor, ours, theirs, {
+        diff3: passthroughDiff3,
+      });
+      if (!res.ok) throw new Error(res.reason);
+
+      const { comments: merged, memory } = parseMemoryFile(res.merged);
+      // Both comments present
+      expect(merged).toHaveLength(2);
+      const ids = merged.map((c) => c.id).sort();
+      expect(ids).toEqual(["com-1", "com-2"]);
+
+      // Chronological order (ascending created_at)
+      expect(merged[0]!.created_at.getTime()).toBeLessThanOrEqual(
+        merged[1]!.created_at.getTime(),
+      );
+
+      // Derived counts recomputed
+      expect(memory.comment_count).toBe(2);
+      expect(memory.last_comment_at?.toISOString()).toBe(
+        "2026-04-11T09:00:00.000Z",
+      );
+    });
+
+    it("last_comment_at and comment_count are recomputed from merged comments", async () => {
+      const comEarly = {
+        id: "com-early",
+        author: "alice",
+        ts: "2026-04-10T00:00:00.000Z",
+        text: "early",
+      };
+      const comLate = {
+        id: "com-late",
+        author: "bob",
+        ts: "2026-04-20T00:00:00.000Z",
+        text: "late",
+      };
+
+      const withComments = (comments: (typeof comEarly)[]) =>
+        base({
+          body:
+            comments.length === 0
+              ? ["body", ""]
+              : ["body", "", commentBlock(comments), ""],
+        });
+
+      const ancestor = withComments([]);
+      const ours = withComments([comEarly]);
+      const theirs = withComments([comLate]);
+
+      const res = await mergeMemoryFiles(ancestor, ours, theirs, {
+        diff3: passthroughDiff3,
+      });
+      if (!res.ok) throw new Error(res.reason);
+
+      const { memory } = parseMemoryFile(res.merged);
+      expect(memory.comment_count).toBe(2);
+      expect(memory.last_comment_at?.toISOString()).toBe(
+        "2026-04-20T00:00:00.000Z",
+      );
+    });
+
+    it("comment collision — theirs wins", async () => {
+      const comOurs = {
+        id: "com-shared",
+        author: "alice",
+        ts: "2026-04-10T00:00:00.000Z",
+        text: "ours version",
+      };
+      const comTheirs = {
+        id: "com-shared",
+        author: "alice",
+        ts: "2026-04-10T00:00:00.000Z",
+        text: "theirs version",
+      };
+
+      const withComment = (c: typeof comOurs) =>
+        base({ body: ["body", "", commentBlock([c]), ""] });
+
+      const ancestor = base();
+      const ours = withComment(comOurs);
+      const theirs = withComment(comTheirs);
+
+      const res = await mergeMemoryFiles(ancestor, ours, theirs, {
+        diff3: passthroughDiff3,
+      });
+      if (!res.ok) throw new Error(res.reason);
+
+      const { comments: merged } = parseMemoryFile(res.merged);
+      expect(merged).toHaveLength(1);
+      expect(merged[0]!.content).toBe("theirs version");
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Body subsection: Relationships
+  // ---------------------------------------------------------------------------
+
+  describe("relationships", () => {
+    /** Inline relationship line matching relationship-parser.ts format. */
+    const relLine = (opts: {
+      type: string;
+      target: string;
+      id: string;
+      confidence: number;
+      by: string;
+      at: string;
+    }) =>
+      `- ${opts.type}:: [[${opts.target}]] — id: ${opts.id}, confidence: ${opts.confidence}, by: ${opts.by}, at: ${opts.at}`;
+
+    it("union of relationships — different entries on each side are both preserved", async () => {
+      const relA = {
+        type: "overrides",
+        target: "mem-2",
+        id: "rel-1",
+        confidence: 0.9,
+        by: "alice",
+        at: "2026-04-10T00:00:00.000Z",
+      };
+      const relB = {
+        type: "refines",
+        target: "mem-3",
+        id: "rel-2",
+        confidence: 0.8,
+        by: "bob",
+        at: "2026-04-11T00:00:00.000Z",
+      };
+
+      const withRels = (rels: (typeof relA)[]) =>
+        base({
+          body:
+            rels.length === 0
+              ? ["body", ""]
+              : ["body", "", "## Relationships", "", ...rels.map(relLine), ""],
+        });
+
+      const ancestor = withRels([]);
+      const ours = withRels([relA]);
+      const theirs = withRels([relB]);
+
+      const res = await mergeMemoryFiles(ancestor, ours, theirs, {
+        diff3: passthroughDiff3,
+      });
+      if (!res.ok) throw new Error(res.reason);
+
+      const { relationships: merged, memory } = parseMemoryFile(res.merged);
+      expect(merged).toHaveLength(2);
+      const ids = merged.map((r) => r.id).sort();
+      expect(ids).toEqual(["rel-1", "rel-2"]);
+      expect(memory.relationship_count).toBe(2);
+    });
+
+    it("relationship collision (same source/target/type) — theirs wins", async () => {
+      const relOurs = {
+        type: "overrides",
+        target: "mem-2",
+        id: "rel-ours",
+        confidence: 0.7,
+        by: "alice",
+        at: "2026-04-10T00:00:00.000Z",
+      };
+      const relTheirs = {
+        type: "overrides",
+        target: "mem-2",
+        id: "rel-theirs",
+        confidence: 0.95,
+        by: "bob",
+        at: "2026-04-11T00:00:00.000Z",
+      };
+
+      const withRel = (r: typeof relOurs) =>
+        base({
+          body: ["body", "", "## Relationships", "", relLine(r), ""],
+        });
+
+      const ancestor = base();
+      const ours = withRel(relOurs);
+      const theirs = withRel(relTheirs);
+
+      const res = await mergeMemoryFiles(ancestor, ours, theirs, {
+        diff3: passthroughDiff3,
+      });
+      if (!res.ok) throw new Error(res.reason);
+
+      const { relationships: merged } = parseMemoryFile(res.merged);
+      // Collision on (source_id=mem-1, target_id=mem-2, type=overrides) → theirs wins
+      expect(merged).toHaveLength(1);
+      expect(merged[0]!.id).toBe("rel-theirs");
+      expect(merged[0]!.confidence).toBeCloseTo(0.95);
+    });
+
+    it("relationship_count recomputed", async () => {
+      const relA = {
+        type: "overrides",
+        target: "mem-2",
+        id: "rel-1",
+        confidence: 1,
+        by: "alice",
+        at: "2026-04-10T00:00:00.000Z",
+      };
+      const relB = {
+        type: "refines",
+        target: "mem-3",
+        id: "rel-2",
+        confidence: 1,
+        by: "bob",
+        at: "2026-04-10T00:00:00.000Z",
+      };
+      const relC = {
+        type: "implements",
+        target: "mem-4",
+        id: "rel-3",
+        confidence: 1,
+        by: "carol",
+        at: "2026-04-10T00:00:00.000Z",
+      };
+
+      const withRels = (rels: (typeof relA)[]) =>
+        base({
+          body:
+            rels.length === 0
+              ? ["body", ""]
+              : ["body", "", "## Relationships", "", ...rels.map(relLine), ""],
+        });
+
+      const ancestor = withRels([relA]);
+      const ours = withRels([relA, relB]);
+      const theirs = withRels([relA, relC]);
+
+      const res = await mergeMemoryFiles(ancestor, ours, theirs, {
+        diff3: passthroughDiff3,
+      });
+      if (!res.ok) throw new Error(res.reason);
+
+      const { memory } = parseMemoryFile(res.merged);
+      expect(memory.relationship_count).toBe(3); // rel-1, rel-2, rel-3
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Body subsection: Flags
+  // ---------------------------------------------------------------------------
+
+  describe("flags", () => {
+    /**
+     * Build a flags YAML array string for embedding in the frontmatter.
+     * Each flag entry uses the shape expected by flag-parser.ts.
+     */
+    const flagsYaml = (
+      flags: Array<{
+        id: string;
+        type: string;
+        severity: string;
+        reason: string;
+        created: string;
+        resolved?: string;
+      }>,
+    ): string => {
+      if (flags.length === 0) return "flags: []";
+      const entries = flags
+        .map((f) =>
+          [
+            "  - id: " + f.id,
+            "    type: " + f.type,
+            "    severity: " + f.severity,
+            "    reason: " + f.reason,
+            "    created: '" + f.created + "'",
+            "    resolved: " + (f.resolved ? `'${f.resolved}'` : "null"),
+            "    resolved_by: null",
+          ].join("\n"),
+        )
+        .join("\n");
+      return "flags:\n" + entries;
+    };
+
+    it("union of flags by id — different flags on each side are both preserved", async () => {
+      const flagA = {
+        id: "flag-1",
+        type: "duplicate",
+        severity: "needs_review",
+        reason: "looks like mem-2",
+        created: "2026-04-10T00:00:00.000Z",
+      };
+      const flagB = {
+        id: "flag-2",
+        type: "verify",
+        severity: "needs_review",
+        reason: "outdated?",
+        created: "2026-04-11T00:00:00.000Z",
+      };
+
+      const ancestor = base({ flags: flagsYaml([]) });
+      const ours = base({ flags: flagsYaml([flagA]) });
+      const theirs = base({ flags: flagsYaml([flagB]) });
+
+      const res = await mergeMemoryFiles(ancestor, ours, theirs, {
+        diff3: passthroughDiff3,
+      });
+      if (!res.ok) throw new Error(res.reason);
+
+      const { flags: merged } = parseMemoryFile(res.merged);
+      expect(merged).toHaveLength(2);
+      const ids = merged.map((f) => f.id).sort();
+      expect(ids).toEqual(["flag-1", "flag-2"]);
+    });
+
+    it("flag collision (same id) — theirs wins", async () => {
+      const flagOurs = {
+        id: "flag-shared",
+        type: "duplicate",
+        severity: "needs_review" as const,
+        reason: "ours reason",
+        created: "2026-04-10T00:00:00.000Z",
+      };
+      const flagTheirs = {
+        id: "flag-shared",
+        type: "verify",
+        severity: "needs_review" as const,
+        reason: "theirs reason",
+        created: "2026-04-10T00:00:00.000Z",
+      };
+
+      const ancestor = base({ flags: flagsYaml([]) });
+      const ours = base({ flags: flagsYaml([flagOurs]) });
+      const theirs = base({ flags: flagsYaml([flagTheirs]) });
+
+      const res = await mergeMemoryFiles(ancestor, ours, theirs, {
+        diff3: passthroughDiff3,
+      });
+      if (!res.ok) throw new Error(res.reason);
+
+      const { flags: merged } = parseMemoryFile(res.merged);
+      expect(merged).toHaveLength(1);
+      expect(merged[0]!.flag_type).toBe("verify");
+      expect(merged[0]!.details.reason).toBe("theirs reason");
+    });
+
+    it("flag_count = unresolved flags only (one resolved, one open → count = 1)", async () => {
+      const flagResolved = {
+        id: "flag-resolved",
+        type: "duplicate",
+        severity: "needs_review" as const,
+        reason: "was a dupe",
+        created: "2026-04-10T00:00:00.000Z",
+        resolved: "2026-04-15T00:00:00.000Z",
+      };
+      const flagOpen = {
+        id: "flag-open",
+        type: "verify",
+        severity: "needs_review" as const,
+        reason: "still open",
+        created: "2026-04-11T00:00:00.000Z",
+      };
+
+      const ancestor = base({ flags: flagsYaml([]) });
+      const ours = base({ flags: flagsYaml([flagResolved]) });
+      const theirs = base({ flags: flagsYaml([flagOpen]) });
+
+      const res = await mergeMemoryFiles(ancestor, ours, theirs, {
+        diff3: passthroughDiff3,
+      });
+      if (!res.ok) throw new Error(res.reason);
+
+      const { memory, flags: merged } = parseMemoryFile(res.merged);
+      expect(merged).toHaveLength(2);
+      // flag_count = unresolved only
+      expect(memory.flag_count).toBe(1);
+    });
   });
 });

--- a/tests/unit/backend/vault/repositories/audit-repository.test.ts
+++ b/tests/unit/backend/vault/repositories/audit-repository.test.ts
@@ -86,11 +86,13 @@ describe("VaultAuditRepository (git-log reader)", () => {
           "2026-04-01T00:00:00.000Z",
           "create\n\nAB-Action: created\nAB-Memory: mem-1\nAB-Actor: alice",
         ].join("\x1f") + "\x1e",
+      diffTree: () => "project/memories/mem-1.md\n",
+      show: (rev) => {
+        if (rev.startsWith("abc123:")) return memoryMd({});
+        throw new Error(`unexpected rev ${rev}`);
+      },
     });
-    const repo = new VaultAuditRepository({
-      root: "/tmp/vault",
-      git,
-    });
+    const repo = new VaultAuditRepository({ root: "/tmp/vault", git });
     const entries = await repo.findByMemoryId("mem-1");
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({
@@ -99,6 +101,7 @@ describe("VaultAuditRepository (git-log reader)", () => {
       actor: "alice",
       reason: null,
       diff: null,
+      project_id: PROJECT_ID,
     });
     expect(entries[0]!.created_at).toBeInstanceOf(Date);
   });

--- a/tests/unit/backend/vault/repositories/audit-repository.test.ts
+++ b/tests/unit/backend/vault/repositories/audit-repository.test.ts
@@ -5,7 +5,7 @@ import { VaultAuditRepository } from "../../../../../src/backend/vault/repositor
 const PROJECT_ID = "proj-1";
 
 function fakeGit(stubs: {
-  log?: (args: unknown) => string;
+  log?: (args: string[]) => string;
   show?: (rev: string) => string;
   diffTree?: (sha: string) => string;
 }): SimpleGit {
@@ -74,7 +74,6 @@ describe("VaultAuditRepository (git-log reader)", () => {
     const repo = new VaultAuditRepository({
       root: "/tmp/vault",
       git,
-      projectId: PROJECT_ID,
     });
     expect(await repo.findByMemoryId("mem-1")).toEqual([]);
   });
@@ -91,7 +90,6 @@ describe("VaultAuditRepository (git-log reader)", () => {
     const repo = new VaultAuditRepository({
       root: "/tmp/vault",
       git,
-      projectId: PROJECT_ID,
     });
     const entries = await repo.findByMemoryId("mem-1");
     expect(entries).toHaveLength(1);
@@ -127,10 +125,10 @@ describe("VaultAuditRepository (git-log reader)", () => {
     const repo = new VaultAuditRepository({
       root: "/tmp/vault",
       git,
-      projectId: PROJECT_ID,
     });
     const entries = await repo.findByMemoryId("mem-1");
     expect(entries).toHaveLength(1);
+    expect(entries[0]!.project_id).toBe(PROJECT_ID);
     expect(entries[0]!.diff).toEqual({
       before: {
         content: "body-text",
@@ -171,10 +169,10 @@ describe("VaultAuditRepository (git-log reader)", () => {
     const repo = new VaultAuditRepository({
       root: "/tmp/vault",
       git,
-      projectId: PROJECT_ID,
     });
     const entries = await repo.findByMemoryId("mem-1");
     expect(entries).toHaveLength(1);
+    expect(entries[0]!.project_id).toBe(PROJECT_ID);
     expect(entries[0]!.diff).toEqual({
       before: {
         content: "body-text",
@@ -209,7 +207,6 @@ describe("VaultAuditRepository (git-log reader)", () => {
     const repo = new VaultAuditRepository({
       root: "/tmp/vault",
       git,
-      projectId: PROJECT_ID,
     });
     const entries = await repo.findByMemoryId("mem-1");
     expect(entries).toHaveLength(1);
@@ -236,7 +233,6 @@ describe("VaultAuditRepository (git-log reader)", () => {
     const repo = new VaultAuditRepository({
       root: "/tmp/vault",
       git,
-      projectId: PROJECT_ID,
     });
     const entries = await repo.findByMemoryId("mem-1");
     expect(entries.map((e) => e.action)).toEqual(["archived", "created"]);
@@ -247,7 +243,6 @@ describe("VaultAuditRepository (git-log reader)", () => {
     const repo = new VaultAuditRepository({
       root: "/tmp/vault",
       git,
-      projectId: PROJECT_ID,
     });
     await repo.create({
       id: "a1",
@@ -278,7 +273,32 @@ describe("VaultAuditRepository (git-log reader)", () => {
     const repo = new VaultAuditRepository({
       root: "/tmp/vault",
       git,
-      projectId: PROJECT_ID,
+    });
+    const entries = await repo.findByMemoryId("mem-1");
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.action).toBe("created");
+  });
+
+  it("drops commits with unmapped action (e.g. AB-Action: verified)", async () => {
+    // Documents the policy: actions not in TRAILER_TO_AUDIT are silently filtered.
+    const git = fakeGit({
+      log: () =>
+        [
+          [
+            "ccc",
+            "2026-04-03T00:00:00.000Z",
+            "x\n\nAB-Action: verified\nAB-Memory: mem-1\nAB-Actor: a",
+          ].join("\x1f"),
+          [
+            "ddd",
+            "2026-04-04T00:00:00.000Z",
+            "x\n\nAB-Action: created\nAB-Memory: mem-1\nAB-Actor: a",
+          ].join("\x1f"),
+        ].join("\x1e") + "\x1e",
+    });
+    const repo = new VaultAuditRepository({
+      root: "/tmp/vault",
+      git,
     });
     const entries = await repo.findByMemoryId("mem-1");
     expect(entries).toHaveLength(1);

--- a/tests/unit/backend/vault/repositories/audit-repository.test.ts
+++ b/tests/unit/backend/vault/repositories/audit-repository.test.ts
@@ -7,6 +7,7 @@ const PROJECT_ID = "proj-1";
 function fakeGit(stubs: {
   log?: (args: unknown) => string;
   show?: (rev: string) => string;
+  diffTree?: (sha: string) => string;
 }): SimpleGit {
   const raw = vi.fn<(args: string[]) => Promise<string>>(async (args) => {
     if (args[0] === "log") {
@@ -16,6 +17,12 @@ function fakeGit(stubs: {
     if (args[0] === "show") {
       if (!stubs.show) throw new Error("unexpected git show call");
       return stubs.show(args[1]!);
+    }
+    if (args[0] === "diff-tree") {
+      if (!stubs.diffTree) throw new Error("unexpected git diff-tree call");
+      // args: ["diff-tree", "--no-commit-id", "-r", "--name-only", sha]
+      const sha = args[args.length - 1]!;
+      return stubs.diffTree(sha);
     }
     throw new Error(`unexpected git args: ${args.join(" ")}`);
   });
@@ -98,7 +105,7 @@ describe("VaultAuditRepository (git-log reader)", () => {
     expect(entries[0]!.created_at).toBeInstanceOf(Date);
   });
 
-  it("reconstructs { before, after } for an update commit", async () => {
+  it("reconstructs { before, after } for an update commit (project-scoped memory)", async () => {
     const git = fakeGit({
       log: () =>
         [
@@ -106,11 +113,13 @@ describe("VaultAuditRepository (git-log reader)", () => {
           "2026-04-20T10:00:00.000Z",
           "update\n\nAB-Action: updated\nAB-Memory: mem-1\nAB-Actor: bob",
         ].join("\x1f") + "\x1e",
+      // diff-tree returns the canonical path; guessCandidatePaths uses this
+      // rather than falling back to the unsafe heuristic.
+      diffTree: () => "project/memories/mem-1.md\n",
       show: (rev) => {
-        // rev = "def456^:workspaces/ws-1/memories/mem-1.md" or "def456:..."
-        if (rev.startsWith("def456^:"))
+        if (rev === "def456^:project/memories/mem-1.md")
           return memoryMd({ title: "hello", tags: ["a"] });
-        if (rev.startsWith("def456:"))
+        if (rev === "def456:project/memories/mem-1.md")
           return memoryMd({ title: "hello-v2", tags: ["a", "b"] });
         throw new Error(`unexpected rev ${rev}`);
       },
@@ -138,6 +147,74 @@ describe("VaultAuditRepository (git-log reader)", () => {
         metadata: null,
       },
     });
+  });
+
+  it("reconstructs diff for an update commit on a workspace-scoped memory", async () => {
+    // Workspace-scoped memories live at workspaces/<ws-id>/memories/<id>.md —
+    // diff-tree must return this path so guessCandidatePaths resolves correctly.
+    const git = fakeGit({
+      log: () =>
+        [
+          "ghi789",
+          "2026-04-21T12:00:00.000Z",
+          "update ws\n\nAB-Action: updated\nAB-Memory: mem-1\nAB-Actor: carol",
+        ].join("\x1f") + "\x1e",
+      diffTree: () => "workspaces/ws-1/memories/mem-1.md\n",
+      show: (rev) => {
+        if (rev === "ghi789^:workspaces/ws-1/memories/mem-1.md")
+          return memoryMd({ title: "before-ws", tags: ["x"] });
+        if (rev === "ghi789:workspaces/ws-1/memories/mem-1.md")
+          return memoryMd({ title: "after-ws", tags: ["x", "y"] });
+        throw new Error(`unexpected rev ${rev}`);
+      },
+    });
+    const repo = new VaultAuditRepository({
+      root: "/tmp/vault",
+      git,
+      projectId: PROJECT_ID,
+    });
+    const entries = await repo.findByMemoryId("mem-1");
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.diff).toEqual({
+      before: {
+        content: "body-text",
+        title: "before-ws",
+        type: "fact",
+        tags: ["x"],
+        metadata: null,
+      },
+      after: {
+        content: "body-text",
+        title: "after-ws",
+        type: "fact",
+        tags: ["x", "y"],
+        metadata: null,
+      },
+    });
+  });
+
+  it("returns diff:null (with warn log) when diff-tree fails", async () => {
+    // When diff-tree throws (e.g. root commit, git error), guessCandidatePaths
+    // should return [] and reconstructUpdateDiff returns null — no silent guess.
+    const git = fakeGit({
+      log: () =>
+        [
+          "zzz999",
+          "2026-04-21T13:00:00.000Z",
+          "update\n\nAB-Action: updated\nAB-Memory: mem-1\nAB-Actor: dave",
+        ].join("\x1f") + "\x1e",
+      // No diffTree stub — the raw() mock will throw "unexpected git diff-tree call",
+      // which guessCandidatePaths catches and converts to an empty candidates list.
+    });
+    const repo = new VaultAuditRepository({
+      root: "/tmp/vault",
+      git,
+      projectId: PROJECT_ID,
+    });
+    const entries = await repo.findByMemoryId("mem-1");
+    expect(entries).toHaveLength(1);
+    // diff is null — no silent fallback path guessing
+    expect(entries[0]!.diff).toBeNull();
   });
 
   it("sorts entries newest-first", async () => {

--- a/tests/unit/backend/vault/repositories/audit-repository.test.ts
+++ b/tests/unit/backend/vault/repositories/audit-repository.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { SimpleGit } from "simple-git";
+import { VaultAuditRepository } from "../../../../../src/backend/vault/repositories/audit-repository.js";
+
+const PROJECT_ID = "proj-1";
+
+function fakeGit(stubs: {
+  log?: (args: unknown) => string;
+  show?: (rev: string) => string;
+}): SimpleGit {
+  const raw = vi.fn<(args: string[]) => Promise<string>>(async (args) => {
+    if (args[0] === "log") {
+      if (!stubs.log) throw new Error("unexpected git log call");
+      return stubs.log(args);
+    }
+    if (args[0] === "show") {
+      if (!stubs.show) throw new Error("unexpected git show call");
+      return stubs.show(args[1]!);
+    }
+    throw new Error(`unexpected git args: ${args.join(" ")}`);
+  });
+  return { raw } as unknown as SimpleGit;
+}
+
+const memoryMd = (
+  over: Partial<{
+    title: string;
+    content: string;
+    updated: string;
+    tags: string[];
+  }>,
+) =>
+  [
+    "---",
+    "id: mem-1",
+    `project_id: ${PROJECT_ID}`,
+    "workspace_id: ws-1",
+    `title: ${over.title ?? "hello"}`,
+    "type: fact",
+    "scope: workspace",
+    `tags: ${JSON.stringify(over.tags ?? ["a", "b"])}`,
+    "author: alice",
+    "source: manual",
+    "session_id: null",
+    "metadata: null",
+    "embedding_model: null",
+    "embedding_dimensions: null",
+    "version: 1",
+    "created: '2026-04-01T00:00:00.000Z'",
+    `updated: '${over.updated ?? "2026-04-20T10:00:00.000Z"}'`,
+    "verified: null",
+    "archived: null",
+    "verified_by: null",
+    "---",
+    "",
+    `# ${over.title ?? "hello"}`,
+    "",
+    over.content ?? "body-text",
+    "",
+  ].join("\n");
+
+describe("VaultAuditRepository (git-log reader)", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns [] when git log yields nothing", async () => {
+    const git = fakeGit({ log: () => "" });
+    const repo = new VaultAuditRepository({
+      root: "/tmp/vault",
+      git,
+      projectId: PROJECT_ID,
+    });
+    expect(await repo.findByMemoryId("mem-1")).toEqual([]);
+  });
+
+  it("parses a single created commit — diff is null", async () => {
+    const git = fakeGit({
+      log: () =>
+        [
+          "abc123",
+          "2026-04-01T00:00:00.000Z",
+          "create\n\nAB-Action: created\nAB-Memory: mem-1\nAB-Actor: alice",
+        ].join("\x1f") + "\x1e",
+    });
+    const repo = new VaultAuditRepository({
+      root: "/tmp/vault",
+      git,
+      projectId: PROJECT_ID,
+    });
+    const entries = await repo.findByMemoryId("mem-1");
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      memory_id: "mem-1",
+      action: "created",
+      actor: "alice",
+      reason: null,
+      diff: null,
+    });
+    expect(entries[0]!.created_at).toBeInstanceOf(Date);
+  });
+
+  it("reconstructs { before, after } for an update commit", async () => {
+    const git = fakeGit({
+      log: () =>
+        [
+          "def456",
+          "2026-04-20T10:00:00.000Z",
+          "update\n\nAB-Action: updated\nAB-Memory: mem-1\nAB-Actor: bob",
+        ].join("\x1f") + "\x1e",
+      show: (rev) => {
+        // rev = "def456^:workspaces/ws-1/memories/mem-1.md" or "def456:..."
+        if (rev.startsWith("def456^:"))
+          return memoryMd({ title: "hello", tags: ["a"] });
+        if (rev.startsWith("def456:"))
+          return memoryMd({ title: "hello-v2", tags: ["a", "b"] });
+        throw new Error(`unexpected rev ${rev}`);
+      },
+    });
+    const repo = new VaultAuditRepository({
+      root: "/tmp/vault",
+      git,
+      projectId: PROJECT_ID,
+    });
+    const entries = await repo.findByMemoryId("mem-1");
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.diff).toEqual({
+      before: {
+        content: "body-text",
+        title: "hello",
+        type: "fact",
+        tags: ["a"],
+        metadata: null,
+      },
+      after: {
+        content: "body-text",
+        title: "hello-v2",
+        type: "fact",
+        tags: ["a", "b"],
+        metadata: null,
+      },
+    });
+  });
+
+  it("sorts entries newest-first", async () => {
+    const git = fakeGit({
+      log: () =>
+        [
+          [
+            "aaa",
+            "2026-04-01T00:00:00.000Z",
+            "x\n\nAB-Action: created\nAB-Memory: mem-1\nAB-Actor: a",
+          ].join("\x1f"),
+          [
+            "bbb",
+            "2026-04-02T00:00:00.000Z",
+            "x\n\nAB-Action: archived\nAB-Memory: mem-1\nAB-Actor: a",
+          ].join("\x1f"),
+        ].join("\x1e") + "\x1e",
+    });
+    const repo = new VaultAuditRepository({
+      root: "/tmp/vault",
+      git,
+      projectId: PROJECT_ID,
+    });
+    const entries = await repo.findByMemoryId("mem-1");
+    expect(entries.map((e) => e.action)).toEqual(["archived", "created"]);
+  });
+
+  it("create() is a no-op (returns without throwing, no git calls)", async () => {
+    const git = fakeGit({});
+    const repo = new VaultAuditRepository({
+      root: "/tmp/vault",
+      git,
+      projectId: PROJECT_ID,
+    });
+    await repo.create({
+      id: "a1",
+      project_id: PROJECT_ID,
+      memory_id: "mem-1",
+      action: "created",
+      actor: "alice",
+      reason: null,
+      diff: null,
+      created_at: new Date(),
+    });
+  });
+
+  it("skips commits whose trailer fails to parse", async () => {
+    const git = fakeGit({
+      log: () =>
+        [
+          ["aaa", "2026-04-01T00:00:00.000Z", "garbage-no-trailer"].join(
+            "\x1f",
+          ),
+          [
+            "bbb",
+            "2026-04-02T00:00:00.000Z",
+            "x\n\nAB-Action: created\nAB-Memory: mem-1\nAB-Actor: a",
+          ].join("\x1f"),
+        ].join("\x1e") + "\x1e",
+    });
+    const repo = new VaultAuditRepository({
+      root: "/tmp/vault",
+      git,
+      projectId: PROJECT_ID,
+    });
+    const entries = await repo.findByMemoryId("mem-1");
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.action).toBe("created");
+  });
+});

--- a/tests/unit/backend/vault/repositories/traversal.test.ts
+++ b/tests/unit/backend/vault/repositories/traversal.test.ts
@@ -32,7 +32,7 @@ describe("traversal rejection for vault secondary repositories", () => {
     // before passing it to git grep.
     it.each(UNSAFE)("findByMemoryId(%j) throws", async (memoryId) => {
       const git = simpleGit({ baseDir: root });
-      const repo = new VaultAuditRepository({ root, git, projectId: "p1" });
+      const repo = new VaultAuditRepository({ root, git });
       await expect(repo.findByMemoryId(memoryId)).rejects.toThrow(
         /invalid memory_id/,
       );

--- a/tests/unit/backend/vault/repositories/traversal.test.ts
+++ b/tests/unit/backend/vault/repositories/traversal.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { simpleGit } from "simple-git";
 import { VaultAuditRepository } from "../../../../../src/backend/vault/repositories/audit-repository.js";
 import { VaultSessionRepository } from "../../../../../src/backend/vault/repositories/session-repository.js";
 import { VaultSessionTrackingRepository } from "../../../../../src/backend/vault/repositories/session-tracking-repository.js";
@@ -25,25 +26,13 @@ describe("traversal rejection for vault secondary repositories", () => {
     await rm(root, { recursive: true, force: true });
   });
 
-  describe("VaultAuditRepository.create rejects unsafe memory_id", () => {
-    it.each(UNSAFE)("memory_id=%j throws", async (memoryId) => {
-      const repo = new VaultAuditRepository({ root });
-      await expect(
-        repo.create({
-          id: "a1",
-          project_id: "p1",
-          memory_id: memoryId,
-          action: "created",
-          actor: "chris",
-          reason: null,
-          diff: null,
-          created_at: new Date("2026-04-21T00:00:00.000Z"),
-        }),
-      ).rejects.toThrow(/invalid memory_id/);
-    });
-
+  describe("VaultAuditRepository.findByMemoryId rejects unsafe memory_id", () => {
+    // create() is a no-op in the git-log-reader implementation, so no
+    // traversal guard is needed there. findByMemoryId validates the id
+    // before passing it to git grep.
     it.each(UNSAFE)("findByMemoryId(%j) throws", async (memoryId) => {
-      const repo = new VaultAuditRepository({ root });
+      const git = simpleGit({ baseDir: root });
+      const repo = new VaultAuditRepository({ root, git, projectId: "p1" });
       await expect(repo.findByMemoryId(memoryId)).rejects.toThrow(
         /invalid memory_id/,
       );

--- a/tests/unit/cli/merge-memory.test.ts
+++ b/tests/unit/cli/merge-memory.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { run } from "../../../src/cli/merge-memory.js";
+
+async function tmp(body: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "merge-"));
+  const p = join(dir, "f.md");
+  await writeFile(p, body, "utf8");
+  return p;
+}
+
+// Dates must be single-quoted so gray-matter parses them as strings.
+// Bare ISO timestamps are parsed as Date objects, which fails isoDate().
+const memoryMd = (title: string) =>
+  [
+    "---",
+    "id: mem-1",
+    "project_id: proj-1",
+    "workspace_id: ws-1",
+    `title: ${title}`,
+    "type: fact",
+    "scope: workspace",
+    'tags: ["a"]',
+    "author: alice",
+    "source: null",
+    "session_id: null",
+    "metadata: null",
+    "embedding_model: null",
+    "embedding_dimensions: null",
+    "version: 1",
+    "created: '2026-04-01T00:00:00.000Z'",
+    "updated: '2026-04-20T10:00:00.000Z'",
+    "verified: null",
+    "archived: null",
+    "verified_by: null",
+    "flags: []",
+    "---",
+    "",
+    `# ${title}`,
+    "",
+    "body",
+    "",
+  ].join("\n");
+
+describe("merge-memory CLI run()", () => {
+  it("returns 0 and writes merged content to %A", async () => {
+    const A = await tmp(memoryMd("ours"));
+    const O = await tmp(memoryMd("base"));
+    const B = await tmp(memoryMd("theirs"));
+    const code = await run([A, O, B]);
+    expect(code).toBe(0);
+    const out = await readFile(A, "utf8");
+    expect(out).toMatch(/title: /);
+  });
+
+  it("returns 1 on parse failure", async () => {
+    const A = await tmp("not yaml");
+    const O = await tmp(memoryMd("x"));
+    const B = await tmp(memoryMd("y"));
+    expect(await run([A, O, B])).toBe(1);
+  });
+
+  it("returns 1 on immutable-field divergence", async () => {
+    const A = await tmp(memoryMd("ours"));
+    const O = await tmp(memoryMd("base"));
+    const theirs = memoryMd("theirs").replace(
+      "project_id: proj-1",
+      "project_id: proj-X",
+    );
+    const B = await tmp(theirs);
+    expect(await run([A, O, B])).toBe(1);
+  });
+
+  it("prints a parse error to stderr on exit 1 (smoke)", async () => {
+    const A = await tmp("not yaml");
+    const O = await tmp(memoryMd("x"));
+    const B = await tmp(memoryMd("y"));
+    const errs: unknown[] = [];
+    const origErr = console.error;
+    console.error = (...args) => {
+      errs.push(args);
+    };
+    try {
+      await run([A, O, B]);
+    } finally {
+      console.error = origErr;
+    }
+    expect(errs.length).toBeGreaterThan(0);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,6 @@ export default defineConfig({
     hookTimeout: 30000,
     testTimeout: 15000,
     fileParallelism: false, // D-64: Integration tests share a single DB; run sequentially
-    exclude: ["**/node_modules/**", "**/.worktrees/**"],
+    exclude: ["**/node_modules/**", "**/.worktrees/**", "**/dist/**"],
   },
 });


### PR DESCRIPTION
## Summary

- `VaultAuditRepository` now reads from `git log --grep='^AB-Memory: <id>$'` + `git show` blob re-parse for `{before, after}` diffs. `create()` becomes a no-op; `_audit/*.jsonl` is gone.
- New `agent-brain-memory` git merge driver (`src/cli/merge-memory.ts`) replaces `*.md merge=union` on memory paths. Per-field rules: set union for tags, monotonic max for `updated_at`/`archived_at`/`verified_*`, LWW by `updated_at` for title/content/etc, per-key LWW for `metadata`, append-by-id for body subsections (comments/flags/relationships).
- Bootstrap writes `[merge "agent-brain-memory"]` to `.git/config` on every `VaultBackend.create` (self-heals install path) + swaps `.gitattributes` to three path-specific rules. Phase 4b vaults migrate transparently via one reconcile commit.
- Also fixes baseline `session-start.test.ts:664` — strip zero/false backend meta fields defensively so the envelope's "absent = healthy" invariant holds regardless of backend.

## Test plan

- [x] Unit — trailer parser (8 tests)
- [x] Unit — `VaultAuditRepository` git-log reader (10 tests, covers project_id derivation, diff3 stubbing, trailer filtering, immutable edge cases)
- [x] Unit — pure `mergeMemoryFiles` (22 tests, every per-field rule + subsection union + collision policy)
- [x] Unit — CLI wrapper (4 tests)
- [x] Unit — merge-driver config writer (2 tests)
- [x] Unit — bootstrap (`.gitattributes` swap, `_audit/` cleanup, Phase 4b migration)
- [x] Contract — audit repository parameterized (vault skips 4 roundtrip-dependent tests via `it.skipIf`; "unknown memory → []" runs against both backends)
- [x] Contract — backend end-to-end scenario asserts vault surfaces 3 audit entries from mutation commits vs pg's single explicit-create
- [x] Integration — two-clone merge driver smoke (concurrent tag edits merge to sorted union, proves custom driver fired)
- [x] Integration — `AuditService.getHistory` over real commits (create + update + archive lifecycle)
- [x] Full suite — `npm test` — 1022 passed, 4 skipped

## Related

- Spec: `docs/superpowers/specs/2026-04-23-vault-backend-phase-4c-audit-merge-design.md`
- Plan: `docs/superpowers/plans/2026-04-23-vault-backend-phase-4c-audit-merge.md`
- Issue: #38 (orphaned `merged` AuditAction — deferred to consolidation feature)
- Roadmap: Phase 4d = parse_errors flags + perf budget verification (deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)