### PR TITLE
feat(session-start): index + persisted-file payload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ ralph.yml
 *.tfvars
 !*.tfvars.example
 .worktrees/
+
+.agent-brain/

--- a/docs/superpowers/plans/2026-04-25-session-start-payload-index.md
+++ b/docs/superpowers/plans/2026-04-25-session-start-payload-index.md
@@ -1,0 +1,1170 @@
+# Session-Start Payload Index Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the verbatim `memory_session_start` response with a 2KB title-only index in `additionalContext` plus a full markdown body the hook writes to `<workspace>/.agent-brain/session.md` and the agent is forced to `Read` before responding.
+
+**Architecture:** Pure renderers (`renderPreview`, `renderFull`) live in `src/utils/session-start-render.ts` and are called by both the MCP tool wrapper (`src/tools/memory-session-start.ts`) and the REST hook endpoint (`src/routes/api-tools.ts`). The service layer (`MemoryService.sessionStart`) is unchanged. Hook scripts (Claude + Copilot) write `response.full` to a workspace-local file, substitute the path into `response.preview`, and emit the substituted preview as `additionalContext`. CLAUDE.md / instructions snippet guidance for `memory_search` shifts from restrictive to liberal.
+
+**Tech Stack:** TypeScript (Node ESM), vitest, drizzle, Zod, Express 5, MCP SDK, bash hook scripts.
+
+**Spec:** `docs/superpowers/specs/2026-04-25-session-start-payload-index-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+
+- `src/utils/session-start-render.ts` — `renderPreview` + `renderFull` pure functions, byte-budget logic.
+- `tests/unit/session-start-render.test.ts` — unit tests for both renderers.
+
+**Modified files:**
+
+- `src/types/envelope.ts` — add `index_truncated_count?: number` to `EnvelopeCoreMeta`.
+- `src/tools/memory-session-start.ts` — wrap service result with renderers, emit wire shape `{preview, full, meta}`.
+- `src/routes/api-tools.ts` — same wrapping for the REST `memory_session_start` endpoint used by the hook scripts.
+- `tests/integration/session-start.test.ts` — keep service-level assertions (still uses `result.data`); no changes here unless an assertion regresses.
+- `tests/unit/mcp-schemas.test.ts` (if it asserts on tool output schema) — update output schema expectation.
+- `hooks/claude/memory-session-start.sh` — write file, ensure `.gitignore`, substitute path.
+- `hooks/copilot/memory-session-start.sh` — same.
+- `hooks/claude/claude-md-snippet.md` — replace `When to Call memory_search` section + add `Working with Loaded Memories` section.
+- `hooks/copilot/instructions-snippet.md` — same content, copilot framing.
+
+**Untouched:**
+
+- `src/services/memory-service.ts` — service-layer return shape preserved.
+- All existing service-level integration tests pass without modification (they assert on `result.data`).
+
+---
+
+## Task 1: Add `index_truncated_count` to envelope meta
+
+**Files:**
+
+- Modify: `src/types/envelope.ts`
+
+- [ ] **Step 1: Add field to `EnvelopeCoreMeta`**
+
+In `src/types/envelope.ts`, add after the existing `project_scope_status` field inside the `EnvelopeCoreMeta` interface:
+
+```ts
+index_truncated_count?: number; // session_start only: count of index rows dropped to fit preview budget
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/types/envelope.ts
+git commit -m "feat(session-start): add index_truncated_count to envelope meta"
+```
+
+---
+
+## Task 2: Write failing unit test for `renderPreview` — basic shape
+
+**Files:**
+
+- Create: `tests/unit/session-start-render.test.ts`
+
+- [ ] **Step 1: Create test file with first failing test**
+
+Create `tests/unit/session-start-render.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  renderPreview,
+  renderFull,
+} from "../../src/utils/session-start-render.js";
+import type { MemorySummaryWithRelevance } from "../../src/types/memory.js";
+
+function mem(
+  overrides: Partial<MemorySummaryWithRelevance> = {},
+): MemorySummaryWithRelevance {
+  return {
+    id: "abc123",
+    title: "Sample memory title",
+    content: "Sample content body",
+    type: "fact",
+    scope: "workspace",
+    tags: null,
+    author: "alice",
+    source: "manual",
+    created_at: new Date("2026-04-25T00:00:00.000Z"),
+    updated_at: new Date("2026-04-25T00:00:00.000Z"),
+    verified_at: null,
+    verified_by: null,
+    comment_count: 0,
+    flag_count: 0,
+    relationship_count: 0,
+    last_comment_at: null,
+    relevance: 0.9,
+    ...overrides,
+  };
+}
+
+describe("renderPreview", () => {
+  it("emits header, index rows, and search-guidance footer with {{PATH}} placeholder", () => {
+    const memories = [
+      mem({
+        id: "id1",
+        title: "First memory",
+        scope: "project",
+        type: "pattern",
+      }),
+      mem({
+        id: "id2",
+        title: "Second memory",
+        scope: "workspace",
+        type: "fact",
+      }),
+    ];
+
+    const result = renderPreview(memories);
+
+    expect(result.text).toContain("{{PATH}}");
+    expect(result.text).toContain("MUST Read");
+    expect(result.text).toContain("- id1 [project] pattern — First memory");
+    expect(result.text).toContain("- id2 [workspace] fact — Second memory");
+    expect(result.text).toContain("Search guidance");
+    expect(result.truncatedCount).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/session-start-render.test.ts`
+Expected: FAIL — `Cannot find module '../../src/utils/session-start-render.js'`.
+
+---
+
+## Task 3: Implement `renderPreview` minimally to pass Task 2
+
+**Files:**
+
+- Create: `src/utils/session-start-render.ts`
+
+- [ ] **Step 1: Create the module with minimal `renderPreview`**
+
+Create `src/utils/session-start-render.ts`:
+
+```ts
+import type { MemorySummaryWithRelevance } from "../types/memory.js";
+import type { FlagResponse } from "../types/flag.js";
+
+export interface RenderPreviewResult {
+  text: string;
+  truncatedCount: number;
+}
+
+const DEFAULT_INDEX_BUDGET_BYTES = 1500;
+
+const HEADER = `IMPORTANT — full memories are NOT in this preview.
+Index below shows %COUNT% memories. Full bodies at:
+{{PATH}}
+
+You MUST Read this file before responding to the user's
+first message. Do not proceed without it.
+
+## Memory index
+`;
+
+const FOOTER = `
+Search guidance: see your memory instructions
+(CLAUDE.md / agent-brain snippet).
+`;
+
+function indexRow(m: MemorySummaryWithRelevance): string {
+  return `- ${m.id} [${m.scope}] ${m.type} — ${m.title}`;
+}
+
+export function renderPreview(
+  memories: MemorySummaryWithRelevance[],
+  _indexBudget: number = DEFAULT_INDEX_BUDGET_BYTES,
+): RenderPreviewResult {
+  const rows = memories.map(indexRow);
+  const indexBlock = rows.join("\n");
+  const text =
+    HEADER.replace("%COUNT%", String(memories.length)) + indexBlock + FOOTER;
+  return { text, truncatedCount: 0 };
+}
+
+export function renderFull(
+  _memories: MemorySummaryWithRelevance[],
+  _flags?: FlagResponse[],
+): string {
+  return "";
+}
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/session-start-render.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/utils/session-start-render.ts tests/unit/session-start-render.test.ts
+git commit -m "feat(session-start): renderPreview shell with header/index/footer"
+```
+
+---
+
+## Task 4: Add failing test for project-scope priority on budget overflow
+
+**Files:**
+
+- Modify: `tests/unit/session-start-render.test.ts`
+
+- [ ] **Step 1: Add test that exercises the budget overflow + project priority**
+
+Append inside `describe("renderPreview", ...)`:
+
+```ts
+it("drops lowest-relevance non-project rows when index exceeds budget; never drops project rows", () => {
+  const longTitle = "x".repeat(60);
+  // 50 memories, mix of scopes; only project memories have ranked relevance "below" workspace
+  const memories: MemorySummaryWithRelevance[] = [];
+  for (let i = 0; i < 5; i++) {
+    memories.push(
+      mem({
+        id: `proj${i}`,
+        title: `${longTitle} project ${i}`,
+        scope: "project",
+        type: "pattern",
+        relevance: 0.1, // intentionally low — must not be dropped
+      }),
+    );
+  }
+  for (let i = 0; i < 45; i++) {
+    memories.push(
+      mem({
+        id: `ws${i}`,
+        title: `${longTitle} workspace ${i}`,
+        scope: "workspace",
+        type: "fact",
+        relevance: 0.9 - i * 0.01, // descending
+      }),
+    );
+  }
+
+  // Budget tight enough to force truncation
+  const result = renderPreview(memories, 1500);
+
+  // All 5 project rows present
+  for (let i = 0; i < 5; i++) {
+    expect(result.text).toContain(`proj${i} [project]`);
+  }
+  // truncatedCount > 0 and equals dropped non-project count
+  expect(result.truncatedCount).toBeGreaterThan(0);
+  // Highest-relevance workspace row is kept
+  expect(result.text).toContain("ws0 [workspace]");
+  // Lowest-relevance workspace row is dropped (ws44 has relevance ~0.46, lower than ws0 0.9)
+  expect(result.text).not.toContain("ws44 [workspace]");
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/session-start-render.test.ts`
+Expected: FAIL — `truncatedCount` is 0; the assertion on `truncatedCount > 0` fails.
+
+---
+
+## Task 5: Implement budget enforcement in `renderPreview`
+
+**Files:**
+
+- Modify: `src/utils/session-start-render.ts`
+
+- [ ] **Step 1: Replace `renderPreview` with budget-aware version**
+
+Replace the existing `renderPreview` function in `src/utils/session-start-render.ts` with:
+
+```ts
+export function renderPreview(
+  memories: MemorySummaryWithRelevance[],
+  indexBudget: number = DEFAULT_INDEX_BUDGET_BYTES,
+): RenderPreviewResult {
+  // Always include all project-scope rows
+  const projectRows = memories.filter((m) => m.scope === "project");
+  // Non-project rows ranked by relevance descending (input may already be sorted; sort defensively)
+  const nonProjectRows = memories
+    .filter((m) => m.scope !== "project")
+    .slice()
+    .sort((a, b) => b.relevance - a.relevance);
+
+  const projectLines = projectRows.map(indexRow);
+  const projectBytes = byteLengthOfLines(projectLines);
+
+  // Budget remaining for non-project rows
+  let remaining = indexBudget - projectBytes;
+  const keptNonProject: string[] = [];
+  let truncatedCount = 0;
+  for (const m of nonProjectRows) {
+    const line = indexRow(m);
+    const cost =
+      keptNonProject.length === 0 && projectLines.length === 0
+        ? line.length
+        : line.length + 1; // +1 for joining newline
+    if (cost <= remaining) {
+      keptNonProject.push(line);
+      remaining -= cost;
+    } else {
+      truncatedCount++;
+    }
+  }
+
+  const indexBlock = [...projectLines, ...keptNonProject].join("\n");
+  const totalCount =
+    projectRows.length + keptNonProject.length + truncatedCount;
+  const text =
+    HEADER.replace("%COUNT%", String(totalCount)) + indexBlock + FOOTER;
+  return { text, truncatedCount };
+}
+
+function byteLengthOfLines(lines: string[]): number {
+  if (lines.length === 0) return 0;
+  // Sum char lengths + (lines.length - 1) join newlines
+  return lines.reduce((acc, l) => acc + l.length, 0) + (lines.length - 1);
+}
+```
+
+(The `indexRow` and `HEADER`/`FOOTER` constants stay as defined in Task 3.)
+
+- [ ] **Step 2: Run tests to verify both pass**
+
+Run: `npx vitest run tests/unit/session-start-render.test.ts`
+Expected: both `renderPreview` tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/utils/session-start-render.ts tests/unit/session-start-render.test.ts
+git commit -m "feat(session-start): enforce index byte budget with project-scope priority"
+```
+
+---
+
+## Task 6: Add failing test for `renderFull` — sections by scope + ordering
+
+**Files:**
+
+- Modify: `tests/unit/session-start-render.test.ts`
+
+- [ ] **Step 1: Add `renderFull` describe block with first test**
+
+Append to `tests/unit/session-start-render.test.ts`:
+
+```ts
+describe("renderFull", () => {
+  it("groups memories into sections by scope with relevance-descending order within group", () => {
+    const memories: MemorySummaryWithRelevance[] = [
+      mem({
+        id: "p1",
+        title: "Proj A",
+        scope: "project",
+        relevance: 0.5,
+        content: "Body P1",
+      }),
+      mem({
+        id: "w2",
+        title: "WS Low",
+        scope: "workspace",
+        relevance: 0.4,
+        content: "Body W2",
+      }),
+      mem({
+        id: "w1",
+        title: "WS High",
+        scope: "workspace",
+        relevance: 0.9,
+        content: "Body W1",
+      }),
+      mem({
+        id: "u1",
+        title: "User One",
+        scope: "user",
+        relevance: 0.7,
+        content: "Body U1",
+      }),
+    ];
+
+    const out = renderFull(memories);
+
+    expect(out).toContain("## project rules");
+    expect(out).toContain("## workspace memories");
+    expect(out).toContain("## user memories");
+
+    // Per-memory section uses title as a heading
+    expect(out).toContain("## Proj A");
+    expect(out).toContain("## WS High");
+    expect(out).toContain("## WS Low");
+    expect(out).toContain("## User One");
+
+    // Frontmatter-style fields present
+    expect(out).toContain("**id:** p1");
+    expect(out).toContain("**scope:** project");
+    expect(out).toContain("**type:** fact");
+
+    // Body content present
+    expect(out).toContain("Body P1");
+    expect(out).toContain("Body W1");
+
+    // Within workspace group, WS High appears before WS Low
+    expect(out.indexOf("## WS High")).toBeLessThan(out.indexOf("## WS Low"));
+  });
+
+  it("emits a flags section when flags are non-empty, omits it otherwise", () => {
+    const m = mem({ id: "m1", title: "T1", scope: "workspace" });
+    const withoutFlags = renderFull([m]);
+    expect(withoutFlags).not.toContain("## flags");
+
+    const withFlags = renderFull(
+      [m],
+      [
+        {
+          flag_id: "f1",
+          flag_type: "verify",
+          memory: { id: "m1", title: "T1", content: "C1", scope: "workspace" },
+          reason: "stale claim",
+        },
+      ],
+    );
+    expect(withFlags).toContain("## flags");
+    expect(withFlags).toContain("f1");
+    expect(withFlags).toContain("verify");
+    expect(withFlags).toContain("stale claim");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify both new tests fail**
+
+Run: `npx vitest run tests/unit/session-start-render.test.ts`
+Expected: FAIL — `renderFull` returns empty string, all `toContain` assertions fail.
+
+---
+
+## Task 7: Implement `renderFull`
+
+**Files:**
+
+- Modify: `src/utils/session-start-render.ts`
+
+- [ ] **Step 1: Replace stub `renderFull` with real implementation**
+
+Replace the placeholder `renderFull` function with:
+
+```ts
+const SECTION_HEADERS = {
+  project: "## project rules",
+  workspace: "## workspace memories",
+  user: "## user memories",
+} as const;
+
+function formatDate(d: Date | null): string {
+  if (!d) return "none";
+  return d.toISOString().slice(0, 10);
+}
+
+function memorySection(m: MemorySummaryWithRelevance): string {
+  const tags = m.tags && m.tags.length > 0 ? m.tags.join(", ") : "none";
+  const verified = formatDate(m.verified_at);
+  return `## ${m.title}
+
+- **id:** ${m.id}
+- **scope:** ${m.scope} · **type:** ${m.type} · **author:** ${m.author}
+- **created:** ${formatDate(m.created_at)} · **updated:** ${formatDate(m.updated_at)} · **verified:** ${verified}
+- **tags:** ${tags}
+
+${m.content}
+`;
+}
+
+function flagsSection(flags: FlagResponse[]): string {
+  const lines = flags.map(
+    (f) =>
+      `- **${f.flag_id}** (${f.flag_type}) on \`${f.memory.id}\` "${f.memory.title}" — ${f.reason}`,
+  );
+  return `## flags
+
+${lines.join("\n")}
+`;
+}
+
+export function renderFull(
+  memories: MemorySummaryWithRelevance[],
+  flags?: FlagResponse[],
+): string {
+  const byScope = {
+    project: [] as MemorySummaryWithRelevance[],
+    workspace: [] as MemorySummaryWithRelevance[],
+    user: [] as MemorySummaryWithRelevance[],
+  };
+  for (const m of memories) {
+    byScope[m.scope].push(m);
+  }
+  for (const k of Object.keys(byScope) as Array<keyof typeof byScope>) {
+    byScope[k].sort((a, b) => b.relevance - a.relevance);
+  }
+
+  const parts: string[] = [];
+  for (const scope of ["project", "workspace", "user"] as const) {
+    if (byScope[scope].length === 0) continue;
+    parts.push(SECTION_HEADERS[scope]);
+    for (const m of byScope[scope]) {
+      parts.push(memorySection(m));
+    }
+  }
+
+  if (flags && flags.length > 0) {
+    parts.push(flagsSection(flags));
+  }
+
+  return parts.join("\n");
+}
+```
+
+- [ ] **Step 2: Run tests to verify all pass**
+
+Run: `npx vitest run tests/unit/session-start-render.test.ts`
+Expected: all `renderPreview` and `renderFull` tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/utils/session-start-render.ts tests/unit/session-start-render.test.ts
+git commit -m "feat(session-start): renderFull with scope-grouped sections + flags"
+```
+
+---
+
+## Task 8: Wire renderers into MCP tool wrapper
+
+**Files:**
+
+- Modify: `src/tools/memory-session-start.ts`
+
+- [ ] **Step 1: Read the existing tool wrapper for the current shape**
+
+Run: `cat src/tools/memory-session-start.ts`
+Expected: shows the current `registerMemorySessionStart` calling `memoryService.sessionStart` and returning `toolResponse(result)` directly.
+
+- [ ] **Step 2: Replace the tool wrapper to apply renderers**
+
+Replace the body of the `async (params) => { ... }` handler in `src/tools/memory-session-start.ts` with:
+
+```ts
+async (params) => {
+  return withErrorHandling(async () => {
+    const envelope = await memoryService.sessionStart(
+      params.workspace_id,
+      params.user_id,
+      params.context,
+      params.limit,
+      params.project_limit,
+    );
+    const previewResult = renderPreview(envelope.data);
+    const full = renderFull(envelope.data, envelope.meta.flags);
+    return toolResponse({
+      preview: previewResult.text,
+      full,
+      meta: {
+        ...envelope.meta,
+        index_truncated_count: previewResult.truncatedCount,
+      },
+    });
+  });
+},
+```
+
+Add the import at the top:
+
+```ts
+import { renderPreview, renderFull } from "../utils/session-start-render.js";
+```
+
+- [ ] **Step 3: Run typecheck + unit tests**
+
+Run: `npm run typecheck && npx vitest run tests/unit/session-start-render.test.ts`
+Expected: PASS, no type errors.
+
+- [ ] **Step 4: Run full unit test suite to confirm no regression**
+
+Run: `npm run test:unit`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/tools/memory-session-start.ts
+git commit -m "feat(session-start): emit {preview, full, meta} from MCP tool wrapper"
+```
+
+---
+
+## Task 9: Wire renderers into REST hook endpoint
+
+**Files:**
+
+- Modify: `src/routes/api-tools.ts` (lines around 40 — `memory_session_start` case)
+
+- [ ] **Step 1: Read the REST handler to confirm shape**
+
+Run: `sed -n '1,100p' src/routes/api-tools.ts`
+Expected: shows a switch/case dispatcher; for `memory_session_start` it calls `memoryService.sessionStart(...)` and returns the envelope via `res.json(...)` or similar.
+
+- [ ] **Step 2: Apply the same wrapping at the REST handler**
+
+In `src/routes/api-tools.ts`, locate the `memory_session_start` branch (around line 40) and replace the response construction with the same shape produced by Task 8:
+
+```ts
+const envelope = await memoryService.sessionStart(
+  body.workspace_id,
+  body.user_id,
+  body.context,
+  body.limit,
+  body.project_limit,
+);
+const previewResult = renderPreview(envelope.data);
+const full = renderFull(envelope.data, envelope.meta.flags);
+return res.json({
+  preview: previewResult.text,
+  full,
+  meta: {
+    ...envelope.meta,
+    index_truncated_count: previewResult.truncatedCount,
+  },
+});
+```
+
+Add the import at the top:
+
+```ts
+import { renderPreview, renderFull } from "../utils/session-start-render.js";
+```
+
+(Adjust variable names — `body`/`req.body` — to match the actual file. Read the surrounding code before editing.)
+
+- [ ] **Step 3: Run typecheck + unit + integration tests**
+
+Run: `npm run typecheck && npm run test:unit`
+Expected: PASS.
+
+Run: `npm test -- tests/integration/session-start.test.ts` (or full integration if Postgres is up)
+Expected: PASS — service-level tests still pass because the service shape is unchanged.
+
+- [ ] **Step 4: Live smoke check against the running dev server**
+
+Restart the dev server if needed, then:
+
+```bash
+curl -sf -X POST "http://localhost:19898/api/tools/memory_session_start" \
+  -H 'Content-Type: application/json' \
+  -d '{"workspace_id":"agent-brain","user_id":"chris","limit":10}' \
+  | jq 'keys, (.meta | keys), (.preview | length), (.full | length)'
+```
+
+Expected: top-level keys = `["full","meta","preview"]`; meta contains `index_truncated_count`; `preview.length` ≤ ~2200; `full.length` > preview length.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/routes/api-tools.ts
+git commit -m "feat(session-start): emit {preview, full, meta} from REST hook endpoint"
+```
+
+---
+
+## Task 10: Update Claude hook to write file + substitute path
+
+**Files:**
+
+- Modify: `hooks/claude/memory-session-start.sh`
+
+- [ ] **Step 1: Read the current hook script for reference**
+
+Run: `cat hooks/claude/memory-session-start.sh`
+Expected: shows the script that POSTs the REST endpoint and wraps the response in `additionalContext`.
+
+- [ ] **Step 2: Replace the hook with the new flow**
+
+Overwrite `hooks/claude/memory-session-start.sh` with:
+
+```bash
+#!/bin/bash
+# Claude Code SessionStart Hook: load agent-brain memories.
+# Writes full memories to <cwd>/.agent-brain/session.md and emits a preview
+# (title-only index + path) as additionalContext. Agent is instructed to Read
+# the file before responding.
+# On any failure, emits the existing fallback additionalContext.
+
+INPUT=$(cat)
+AGENT_BRAIN_URL="${AGENT_BRAIN_URL:-http://localhost:19898}"
+CWD=$(echo "$INPUT" | jq -r '.cwd // ""')
+CLIENT_SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // .sessionId // ""')
+
+USER_ID=$(whoami | tr '[:upper:]' '[:lower:]')
+WORKSPACE_ID=$(basename "$CWD")
+
+FALLBACK_MSG="Agent Brain session_start did not succeed — memories were not loaded this session. Call memory_search explicitly when team knowledge or prior context is relevant."
+
+emit_fallback() {
+  local reason="$1"
+  echo "agent-brain SessionStart: ${reason}" >&2
+  jq -cn --arg ctx "$FALLBACK_MSG" \
+    '{hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'
+  exit 0
+}
+
+ensure_gitignore() {
+  local cwd="$1"
+  local gi="${cwd}/.gitignore"
+  # Only touch .gitignore if cwd looks like a writable directory
+  [ -d "$cwd" ] || return 0
+  if [ ! -f "$gi" ] || ! grep -qxF ".agent-brain/" "$gi" 2>/dev/null; then
+    printf "\n.agent-brain/\n" >> "$gi" 2>/dev/null || true
+  fi
+}
+
+if [ -z "$CWD" ] || [ ! -d "$CWD" ]; then
+  emit_fallback "missing or invalid cwd"
+fi
+
+if ! curl -sf "${AGENT_BRAIN_URL}/health" >/dev/null 2>&1; then
+  emit_fallback "server unreachable (${AGENT_BRAIN_URL}/health)"
+fi
+
+RESPONSE=$(curl -sf -X POST "${AGENT_BRAIN_URL}/api/tools/memory_session_start" \
+  -H 'Content-Type: application/json' \
+  -d "{\"workspace_id\":\"${WORKSPACE_ID}\",\"user_id\":\"${USER_ID}\",\"limit\":10}") \
+  || emit_fallback "memory_session_start POST failed (HTTP 4xx/5xx or network error)"
+
+if [ -z "$RESPONSE" ]; then
+  emit_fallback "memory_session_start returned empty body"
+fi
+
+PREVIEW=$(echo "$RESPONSE" | jq -r '.preview // ""')
+FULL=$(echo "$RESPONSE" | jq -r '.full // ""')
+if [ -z "$PREVIEW" ] || [ -z "$FULL" ]; then
+  emit_fallback "memory_session_start response missing preview/full fields"
+fi
+
+# Stash agent-brain session_id for the stop hook to read
+if [ -n "$CLIENT_SESSION_ID" ]; then
+  AB_SESSION_ID=$(echo "$RESPONSE" | jq -r '.meta.session_id // ""')
+  if [ -n "$AB_SESSION_ID" ]; then
+    echo "$AB_SESSION_ID" > "/tmp/agent-brain-sid-${CLIENT_SESSION_ID}"
+  fi
+fi
+
+DEST_DIR="${CWD}/.agent-brain"
+DEST_FILE="${DEST_DIR}/session.md"
+mkdir -p "$DEST_DIR" 2>/dev/null || emit_fallback "could not create ${DEST_DIR}"
+printf "%s" "$FULL" > "$DEST_FILE" 2>/dev/null || emit_fallback "could not write ${DEST_FILE}"
+ensure_gitignore "$CWD"
+
+# Substitute {{PATH}} placeholder with the absolute file path
+SUBSTITUTED_PREVIEW=$(printf "%s" "$PREVIEW" | sed "s|{{PATH}}|${DEST_FILE}|g")
+CTX_ESCAPED=$(printf "%s" "$SUBSTITUTED_PREVIEW" | jq -Rs '.')
+
+cat <<EOF
+{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": ${CTX_ESCAPED}}}
+EOF
+```
+
+- [ ] **Step 3: Make the script executable and run a smoke test against the dev server**
+
+```bash
+chmod +x hooks/claude/memory-session-start.sh
+echo "{\"cwd\":\"$(pwd)\",\"session_id\":\"plan-task10-smoke\"}" | hooks/claude/memory-session-start.sh
+```
+
+Expected stdout: a JSON object with `hookSpecificOutput.additionalContext` containing the index, the substituted absolute path, and the "MUST Read" instruction.
+
+Then verify the file was written:
+
+```bash
+ls -la .agent-brain/session.md
+head -20 .agent-brain/session.md
+grep -F ".agent-brain/" .gitignore
+```
+
+Expected: file exists with markdown content; `.gitignore` contains `.agent-brain/`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add hooks/claude/memory-session-start.sh .gitignore
+git commit -m "feat(hooks/claude): write session.md, substitute path, emit preview"
+```
+
+(If `.gitignore` already had the entry, drop it from the `git add`.)
+
+---
+
+## Task 11: Update Copilot hook to mirror Task 10
+
+**Files:**
+
+- Modify: `hooks/copilot/memory-session-start.sh`
+
+- [ ] **Step 1: Read the current Copilot hook**
+
+Run: `cat hooks/copilot/memory-session-start.sh`
+Expected: similar structure to the Claude hook but emits both flat and `hookSpecificOutput` envelopes.
+
+- [ ] **Step 2: Replace the Copilot hook with the new flow**
+
+Overwrite `hooks/copilot/memory-session-start.sh` with:
+
+```bash
+#!/bin/bash
+# Copilot CLI SessionStart Hook: load agent-brain memories.
+# Writes full memories to <cwd>/.agent-brain/session.md and emits a preview
+# (title-only index + path) as additionalContext. Agent is instructed to Read
+# the file before responding.
+# Requires Copilot CLI v1.0.24+ (additionalContext + once-per-session firing).
+
+INPUT=$(cat)
+AGENT_BRAIN_URL="${AGENT_BRAIN_URL:-http://localhost:19898}"
+
+CWD=$(echo "$INPUT" | jq -r '.cwd // ""')
+SESSION_KEY="${COPILOT_SESSION_ID:-$(echo "$INPUT" | jq -r '.session_id // ""')}"
+[ -z "$SESSION_KEY" ] && SESSION_KEY=$(date +%Y%m%d%H%M%S)
+
+USER_ID=$(whoami | tr '[:upper:]' '[:lower:]')
+WORKSPACE_ID=$(basename "$CWD")
+
+FALLBACK_MSG="Agent Brain session_start did not succeed — memories were not loaded this session. Call memory_search explicitly when team knowledge or prior context is relevant."
+
+emit_envelope() {
+  local ctx="$1"
+  jq -cn --arg ctx "$ctx" \
+    '{additionalContext: $ctx,
+      hookSpecificOutput: {hookEventName: "SessionStart", additionalContext: $ctx}}'
+}
+
+emit_fallback() {
+  local reason="$1"
+  echo "agent-brain sessionStart: ${reason}" >&2
+  emit_envelope "$FALLBACK_MSG"
+  exit 0
+}
+
+ensure_gitignore() {
+  local cwd="$1"
+  local gi="${cwd}/.gitignore"
+  [ -d "$cwd" ] || return 0
+  if [ ! -f "$gi" ] || ! grep -qxF ".agent-brain/" "$gi" 2>/dev/null; then
+    printf "\n.agent-brain/\n" >> "$gi" 2>/dev/null || true
+  fi
+}
+
+if [ -z "$CWD" ] || [ ! -d "$CWD" ]; then
+  emit_fallback "missing or invalid cwd"
+fi
+
+if ! curl -sf "${AGENT_BRAIN_URL}/health" >/dev/null 2>&1; then
+  emit_fallback "server unreachable (${AGENT_BRAIN_URL}/health)"
+fi
+
+RESPONSE=$(curl -sf -X POST "${AGENT_BRAIN_URL}/api/tools/memory_session_start" \
+  -H 'Content-Type: application/json' \
+  -d "{\"workspace_id\":\"${WORKSPACE_ID}\",\"user_id\":\"${USER_ID}\",\"limit\":10}") \
+  || emit_fallback "memory_session_start POST failed (HTTP 4xx/5xx or network error)"
+
+if [ -z "$RESPONSE" ]; then
+  emit_fallback "memory_session_start returned empty body"
+fi
+
+PREVIEW=$(echo "$RESPONSE" | jq -r '.preview // ""')
+FULL=$(echo "$RESPONSE" | jq -r '.full // ""')
+if [ -z "$PREVIEW" ] || [ -z "$FULL" ]; then
+  emit_fallback "memory_session_start response missing preview/full fields"
+fi
+
+AB_SESSION_ID=$(echo "$RESPONSE" | jq -r '.meta.session_id // ""')
+if [ -n "$AB_SESSION_ID" ]; then
+  echo "$AB_SESSION_ID" > "/tmp/agent-brain-sid-${SESSION_KEY}"
+fi
+
+DEST_DIR="${CWD}/.agent-brain"
+DEST_FILE="${DEST_DIR}/session.md"
+mkdir -p "$DEST_DIR" 2>/dev/null || emit_fallback "could not create ${DEST_DIR}"
+printf "%s" "$FULL" > "$DEST_FILE" 2>/dev/null || emit_fallback "could not write ${DEST_FILE}"
+ensure_gitignore "$CWD"
+
+SUBSTITUTED_PREVIEW=$(printf "%s" "$PREVIEW" | sed "s|{{PATH}}|${DEST_FILE}|g")
+emit_envelope "$SUBSTITUTED_PREVIEW"
+
+exit 0
+```
+
+- [ ] **Step 3: Make executable + smoke test**
+
+```bash
+chmod +x hooks/copilot/memory-session-start.sh
+echo "{\"cwd\":\"$(pwd)\",\"session_id\":\"plan-task11-smoke\"}" | hooks/copilot/memory-session-start.sh | jq 'keys'
+```
+
+Expected: `["additionalContext","hookSpecificOutput"]`. The `additionalContext` value contains the substituted path.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add hooks/copilot/memory-session-start.sh
+git commit -m "feat(hooks/copilot): write session.md, substitute path, emit preview"
+```
+
+---
+
+## Task 12: Update CLAUDE.md snippet — replace search guidance + add Working with Loaded Memories
+
+**Files:**
+
+- Modify: `hooks/claude/claude-md-snippet.md`
+
+- [ ] **Step 1: Replace the `Session Start` and `When to Call memory_search` sections**
+
+In `hooks/claude/claude-md-snippet.md`, locate the existing `### Session Start` section (currently 2 lines) and the following `### When to Call memory_search` section. Replace both with:
+
+```markdown
+### Session Start
+
+SessionStart hook delivers a TITLE-ONLY index of available memories
+plus a forced read of `<workspace>/.agent-brain/session.md` for full
+bodies. Read that file before answering the first user message.
+No manual `memory_session_start` call needed.
+
+### Working with Loaded Memories
+
+`<workspace>/.agent-brain/session.md` contains the full bodies of the
+memories indexed in the SessionStart preview. The preview lists
+`<id> [<scope>] <type> — <title>` per memory; full bodies are in the
+file. Read it once at session start; use it as your in-context
+reference until the next session.
+
+### When to Call `memory_search`
+
+Call `memory_search` whenever:
+
+1. **The user's task touches a topic that overlaps an index title** — the
+   title alone may not be enough; pull the full memory or related ones.
+2. **You are reasoning about an unfamiliar area of the codebase or domain**
+   — even if no index entry obviously matches.
+3. **You are about to take an action affecting shared systems** — deploys,
+   DB migrations, credential rotation, integration tests, etc.
+
+Prefer false positives over misses. Searches are cheap; missing a
+load-bearing memory is expensive.
+
+For a specific entry by id, use `memory_get`.
+
+**Do NOT search for purely local actions** (file edits, dependency
+installs, local builds, linting, formatting) UNLESS the index suggests
+a relevant memory.
+```
+
+- [ ] **Step 2: Verify no other section header was disturbed**
+
+Run: `grep -n "^##\|^###" hooks/claude/claude-md-snippet.md`
+Expected: original heading order preserved except for the two replaced sections; no duplicates.
+
+---
+
+## Task 13: Mirror snippet update to Copilot instructions
+
+**Files:**
+
+- Modify: `hooks/copilot/instructions-snippet.md`
+
+- [ ] **Step 1: Replace the equivalent sections in the Copilot snippet**
+
+In `hooks/copilot/instructions-snippet.md`, locate the existing `## Session Start` section and the `## When to Call memory_search` section. Replace both with:
+
+```markdown
+## Session Start
+
+If `memory-session-start.sh` hook (Copilot CLI v1.0.24+) installed,
+SessionStart delivers a TITLE-ONLY index of available memories plus a
+forced read of `<workspace>/.agent-brain/session.md` for full bodies.
+Read that file before answering the first user message.
+
+If unsure hook active AND no memories appeared by first response, call
+`memory_session_start` yourself.
+
+## Working with Loaded Memories
+
+`<workspace>/.agent-brain/session.md` contains the full bodies of the
+memories indexed in the SessionStart preview. The preview lists
+`<id> [<scope>] <type> — <title>` per memory; full bodies are in the
+file. Read it once at session start; use it as your in-context
+reference until the next session.
+
+## When to Call `memory_search`
+
+Call `memory_search` whenever:
+
+1. **User's task touches topic overlapping index title** — title alone
+   may not be enough; pull full memory or related.
+2. **Reasoning about unfamiliar area of codebase or domain** — even if
+   no index entry obviously matches.
+3. **About to take action affecting shared systems** — deploys, DB
+   migrations, credential rotation, integration tests, etc.
+
+Prefer false positives over misses. Searches cheap; missing a
+load-bearing memory expensive.
+
+For specific entry by id, use `memory_get`.
+
+**Do NOT search for purely local actions** (file edits, dependency
+installs, local builds, linting, formatting) UNLESS index suggests
+relevant memory.
+```
+
+- [ ] **Step 2: Diff the two snippets to verify only intentional differences remain**
+
+Run: `diff hooks/copilot/instructions-snippet.md hooks/claude/claude-md-snippet.md`
+Expected: differences limited to:
+
+- H1 heading (`# Agent Memory` vs `## Memory System`)
+- Copilot-specific hook references and copilot-specific framing in `Session Start`
+- Other intentional differences pre-existing in the files (e.g. `Choosing source` section structure differs)
+
+If unexpected drift on the new sections appears, fix inline.
+
+- [ ] **Step 3: Commit both snippet updates together**
+
+```bash
+git add hooks/claude/claude-md-snippet.md hooks/copilot/instructions-snippet.md
+git commit -m "docs(hooks): liberal memory_search guidance + Working with Loaded Memories"
+```
+
+---
+
+## Task 14: End-to-end manual verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Restart the dev server (so the new tool wrapper is live)**
+
+Run whatever the project uses to restart the dev server — typically `npm run dev` in a fresh terminal, or restart the watcher. Verify health:
+
+```bash
+curl -sf "http://localhost:19898/health" && echo " — server up"
+```
+
+Expected: `{"status":"ok"}` (or similar) followed by ` — server up`.
+
+- [ ] **Step 2: Hit the REST endpoint and inspect the new shape**
+
+```bash
+curl -sf -X POST "http://localhost:19898/api/tools/memory_session_start" \
+  -H 'Content-Type: application/json' \
+  -d '{"workspace_id":"agent-brain","user_id":"chris","limit":10}' \
+  | jq '{
+      keys: keys,
+      preview_bytes: (.preview|length),
+      full_bytes: (.full|length),
+      meta_keys: (.meta|keys),
+      truncated: (.meta.index_truncated_count // null),
+      preview_has_path_placeholder: (.preview|test("\\{\\{PATH\\}\\}")),
+      preview_has_must_read: (.preview|test("MUST Read"))
+    }'
+```
+
+Expected:
+
+- `keys`: includes `"preview"`, `"full"`, `"meta"` (no `"data"`).
+- `preview_bytes` ≤ ~2200.
+- `full_bytes` substantially larger than `preview_bytes`.
+- `meta_keys` includes `index_truncated_count`.
+- `preview_has_path_placeholder` = `true`.
+- `preview_has_must_read` = `true`.
+
+- [ ] **Step 3: Run the Claude hook end-to-end**
+
+```bash
+echo "{\"cwd\":\"$(pwd)\",\"session_id\":\"plan-task14-claude\"}" \
+  | hooks/claude/memory-session-start.sh \
+  | jq '.hookSpecificOutput.additionalContext' -r \
+  | head -30
+```
+
+Expected: substituted preview text, `{{PATH}}` replaced with `<cwd>/.agent-brain/session.md` absolute path, "MUST Read" instruction visible, index lines below.
+
+Then:
+
+```bash
+ls -la .agent-brain/session.md
+wc -c .agent-brain/session.md
+head -30 .agent-brain/session.md
+grep -F ".agent-brain/" .gitignore
+```
+
+Expected: file exists with size > preview, content is grouped markdown sections, `.gitignore` contains the entry.
+
+- [ ] **Step 4: Run the Copilot hook end-to-end**
+
+```bash
+echo "{\"cwd\":\"$(pwd)\",\"session_id\":\"plan-task14-copilot\"}" \
+  | hooks/copilot/memory-session-start.sh \
+  | jq '. | {keys: keys, ctx_head: (.additionalContext[0:300])}'
+```
+
+Expected: top-level keys `additionalContext` and `hookSpecificOutput`; `ctx_head` shows the substituted path and "MUST Read" instruction.
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `npm run typecheck && npm run lint && npm run test:unit`
+Expected: all pass.
+
+(Integration tests with Postgres can be skipped if DB not running locally; the unit suite + the live curl smoke covers the new code.)
+
+- [ ] **Step 6: Inspect a real session in Claude Code (manual)**
+
+Start a fresh Claude Code session in this repo. Confirm:
+
+1. The agent's first action is a `Read` of `.agent-brain/session.md`.
+2. The agent does not assume memory bodies are already in context.
+3. If asked "what memories do you have?", the agent references content from `session.md`.
+
+If the agent skips the Read, capture the failure and iterate on the wording in the preview header (the `HEADER` constant in `src/utils/session-start-render.ts`) and/or the CLAUDE.md snippet. Re-test.
+
+- [ ] **Step 7: Final commit if any tweaks made during verification**
+
+```bash
+git status
+# If anything changed during verification, commit it:
+# git add <changed files>
+# git commit -m "fix(session-start): adjust preview wording after manual verification"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:**
+  - Wire shape `{preview, full, meta}` → Tasks 8, 9.
+  - Preview format with index + path + instruction → Tasks 2, 3, 5.
+  - Index byte budget with project priority → Tasks 4, 5.
+  - Persisted file format (sections by scope, flags) → Tasks 6, 7.
+  - File path `<workspace>/.agent-brain/session.md` + `.gitignore` → Tasks 10, 11.
+  - Hook script flow → Tasks 10, 11.
+  - CLAUDE.md / instructions snippet update → Tasks 12, 13.
+  - Reliability fallbacks (server unreachable, disk write fails) → Tasks 10, 11 fallback paths.
+  - Manual verification (agent reads file) → Task 14 step 6.
+
+- **No placeholders:** every code step contains the actual code; every command step the actual command.
+
+- **Type/symbol consistency:** `renderPreview`, `renderFull`, `RenderPreviewResult`, `MemorySummaryWithRelevance`, `FlagResponse`, `index_truncated_count` all use the same names across tasks.

--- a/docs/superpowers/plans/2026-04-25-vault-backend-phase-5-watcher.md
+++ b/docs/superpowers/plans/2026-04-25-vault-backend-phase-5-watcher.md
@@ -1,0 +1,2493 @@
+# Vault Backend Phase 5 — Chokidar Watcher Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a chokidar-based watcher + pre-listen boot scan that reconciles the lance vector index, `VaultIndex` (path/id map + unindexable list), and open `parse_error` flags against external edits to `<vault>/**/*.md`. Closes the Phase 4d live-edit gap and subsumes the PR #37 deferred `syncPaths` deletion gap.
+
+**Architecture:** Three new modules under `src/backend/vault/watcher/` — `reconciler.ts` (pure logic: parse → diff hash → lance op + index op + flag op), `watcher.ts` (chokidar wrapper + in-flight ignore set with mtime tuple), `boot-scan.ts` (pre-listen vault walk). `VaultBackend.create()` runs boot scan to completion before starting the watcher; `httpServer.listen()` (in `src/server.ts`) only runs after `create()` resolves, so HTTP readiness gating is automatic.
+
+**Tech Stack:** TypeScript, vitest, chokidar (new dep), `@lancedb/lancedb` (existing), `simple-git` (existing). All design decisions D1–D7 are in `docs/superpowers/specs/2026-04-25-vault-backend-phase-5-watcher-design.md`.
+
+---
+
+## File structure
+
+**New files:**
+
+- `src/backend/vault/watcher/types.ts` — `ReconcileSignal`, `ReconcileResult`, `IgnoreSet` interface, `BootScanResult` type
+- `src/backend/vault/watcher/ignore-set.ts` — `IgnoreSetImpl` (with mtime tuple), `NoopIgnoreSet`
+- `src/backend/vault/watcher/reconciler.ts` — `Reconciler` interface + `createReconciler` factory
+- `src/backend/vault/watcher/watcher.ts` — `VaultWatcher` interface + `createVaultWatcher` factory
+- `src/backend/vault/watcher/boot-scan.ts` — `runBootScan` function
+- `tests/unit/backend/vault/watcher/ignore-set.test.ts`
+- `tests/unit/backend/vault/watcher/reconciler.test.ts`
+- `tests/unit/backend/vault/watcher/watcher.test.ts`
+- `tests/unit/backend/vault/watcher/boot-scan.test.ts`
+- `tests/integration/vault-watcher-e2e.test.ts`
+
+**Modified files:**
+
+- `package.json` — add `chokidar` dep
+- `src/backend/types.ts` — add `watcher_error?: true` to `BackendSessionStartMeta`
+- `src/backend/vault/repositories/memory-files.ts` — accept optional `IgnoreSet` ctor param; record mtime + add to set + schedule release in `edit()`
+- `src/backend/vault/repositories/memory-repository.ts` — accept optional `IgnoreSet` ctor param + plumb to `VaultMemoryFiles`
+- `src/backend/vault/index.ts` — `VaultBackend.create()`: instantiate ignoreSet, reconciler, runBootScan, watcher.start; `close()`: watcher.stop before pushQueue.close; ctor stores `vaultWatcher`; `sessionStart()` surfaces `watcher_error` from a watcher-error sticky flag
+- `tests/contract/repositories/_factories.ts` (and any vault-repo factory used by contract tests) — pass `NoopIgnoreSet` so existing tests don't change behavior
+
+---
+
+## Task 1: Add chokidar dependency
+
+**Files:**
+
+- Modify: `package.json`
+
+- [ ] **Step 1: Verify chokidar not already a dep**
+
+Run: `grep '"chokidar"' /Users/chris/dev/agent-brain/package.json`
+Expected: no output (not present)
+
+- [ ] **Step 2: Add chokidar**
+
+Run: `npm install chokidar`
+
+- [ ] **Step 3: Verify install**
+
+Run: `grep '"chokidar"' /Users/chris/dev/agent-brain/package.json`
+Expected: one line under `dependencies` showing chokidar with a version pin (e.g. `"chokidar": "^4.0.x"` or `^3.x` — accept whatever npm resolves).
+
+- [ ] **Step 4: Verify import works**
+
+Run: `node -e "import('chokidar').then(m => console.log(typeof m.watch))"`
+Expected: `function`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "build: add chokidar dependency for vault watcher
+
+Phase 5 needs chokidar.watch with awaitWriteFinish to debounce
+external edits to vault markdown files. Adds the runtime dep; no
+code changes yet."
+```
+
+---
+
+## Task 2: Watcher types
+
+**Files:**
+
+- Create: `src/backend/vault/watcher/types.ts`
+
+- [ ] **Step 1: Create the types file**
+
+```ts
+// src/backend/vault/watcher/types.ts
+
+export type ReconcileSignal = "add" | "change" | "unlink";
+
+export interface ReconcileResult {
+  action:
+    | "indexed"
+    | "reembedded"
+    | "meta-updated"
+    | "archived"
+    | "skipped"
+    | "parse-error";
+  memoryId?: string;
+  reason?: string;
+}
+
+export interface IgnoreSet {
+  // Record an internal write: absPath + the mtime observed *immediately
+  // post-fsync* of our own write. Watcher uses this to skip its own commits.
+  add(absPath: string, mtimeAfterWrite: number): void;
+  // True only if the path is tracked AND the file's current mtime equals
+  // the recorded mtime. mtime mismatch means an external edit collided
+  // with our write window — caller should fall through to reconcile.
+  has(absPath: string, currentMtime: number): boolean;
+  // Schedules deletion of the entry after `graceMs` ms. graceMs must
+  // outlast chokidar's awaitWriteFinish.stabilityThreshold so the change
+  // event has time to fire and be checked.
+  releaseAfter(absPath: string, graceMs: number): void;
+}
+
+export interface BootScanResult {
+  scanned: number;
+  reconciled: number;
+  orphaned: number;
+  parseErrors: number;
+  embedErrors: number;
+}
+```
+
+- [ ] **Step 2: Verify the file typechecks**
+
+Run: `npx tsc --noEmit -p .`
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/backend/vault/watcher/types.ts
+git commit -m "feat(vault): add Phase 5 watcher type definitions
+
+Pulls ReconcileSignal/ReconcileResult/IgnoreSet/BootScanResult into a
+shared types module so reconciler/watcher/boot-scan can compile
+independently and unit tests can mock against the interface."
+```
+
+---
+
+## Task 3: IgnoreSet implementation — failing test
+
+**Files:**
+
+- Create: `tests/unit/backend/vault/watcher/ignore-set.test.ts`
+
+- [ ] **Step 1: Write the failing test file**
+
+```ts
+// tests/unit/backend/vault/watcher/ignore-set.test.ts
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import {
+  IgnoreSetImpl,
+  NoopIgnoreSet,
+} from "../../../../../src/backend/vault/watcher/ignore-set.js";
+
+describe("IgnoreSetImpl", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("returns false for an unknown path", () => {
+    const s = new IgnoreSetImpl();
+    expect(s.has("/abs/foo.md", 1234567890)).toBe(false);
+  });
+
+  it("returns true when path tracked and mtime matches", () => {
+    const s = new IgnoreSetImpl();
+    s.add("/abs/foo.md", 100);
+    expect(s.has("/abs/foo.md", 100)).toBe(true);
+  });
+
+  it("returns false when path tracked but mtime differs (external edit collided)", () => {
+    const s = new IgnoreSetImpl();
+    s.add("/abs/foo.md", 100);
+    expect(s.has("/abs/foo.md", 200)).toBe(false);
+  });
+
+  it("releaseAfter clears the entry after the grace window", () => {
+    const s = new IgnoreSetImpl();
+    s.add("/abs/foo.md", 100);
+    s.releaseAfter("/abs/foo.md", 500);
+    expect(s.has("/abs/foo.md", 100)).toBe(true);
+    vi.advanceTimersByTime(499);
+    expect(s.has("/abs/foo.md", 100)).toBe(true);
+    vi.advanceTimersByTime(1);
+    expect(s.has("/abs/foo.md", 100)).toBe(false);
+  });
+
+  it("releaseAfter is a no-op for an untracked path", () => {
+    const s = new IgnoreSetImpl();
+    expect(() => s.releaseAfter("/abs/missing.md", 500)).not.toThrow();
+    vi.advanceTimersByTime(500);
+    expect(s.has("/abs/missing.md", 1)).toBe(false);
+  });
+
+  it("re-add before grace expiry refreshes mtime + cancels prior release", () => {
+    const s = new IgnoreSetImpl();
+    s.add("/abs/foo.md", 100);
+    s.releaseAfter("/abs/foo.md", 500);
+    vi.advanceTimersByTime(300);
+    s.add("/abs/foo.md", 200); // overwrite mtime
+    s.releaseAfter("/abs/foo.md", 500); // schedule new release
+    vi.advanceTimersByTime(400); // total 700ms — original release would have fired at 500
+    expect(s.has("/abs/foo.md", 200)).toBe(true);
+    vi.advanceTimersByTime(100); // total 800ms — new release fires at 700+500=800
+    expect(s.has("/abs/foo.md", 200)).toBe(false);
+  });
+});
+
+describe("NoopIgnoreSet", () => {
+  it("never tracks anything", () => {
+    const s = new NoopIgnoreSet();
+    s.add("/abs/foo.md", 100);
+    expect(s.has("/abs/foo.md", 100)).toBe(false);
+    s.releaseAfter("/abs/foo.md", 500);
+    expect(s.has("/abs/foo.md", 100)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/backend/vault/watcher/ignore-set.test.ts`
+Expected: FAIL — module `ignore-set.js` not found.
+
+---
+
+## Task 4: IgnoreSet implementation — passing impl
+
+**Files:**
+
+- Create: `src/backend/vault/watcher/ignore-set.ts`
+
+- [ ] **Step 1: Implement IgnoreSetImpl + NoopIgnoreSet**
+
+```ts
+// src/backend/vault/watcher/ignore-set.ts
+import type { IgnoreSet } from "./types.js";
+
+interface Entry {
+  mtime: number;
+  releaseTimer: NodeJS.Timeout | null;
+}
+
+// In-flight write tracker. Mutation sites call add(absPath, mtime) post-fsync,
+// then releaseAfter(absPath, graceMs) once the write has fully settled (commit
+// + lance write + lock release). Watcher consults has(absPath, currentMtime)
+// to decide whether a chokidar event was caused by our own write.
+//
+// has() compares mtime so an external edit landing during the grace window
+// (e.g. user edits the same file between our fsync and grace expiry) is NOT
+// silently skipped — caller falls through to reconcile.
+export class IgnoreSetImpl implements IgnoreSet {
+  private readonly map = new Map<string, Entry>();
+
+  add(absPath: string, mtimeAfterWrite: number): void {
+    const existing = this.map.get(absPath);
+    if (existing?.releaseTimer) clearTimeout(existing.releaseTimer);
+    this.map.set(absPath, { mtime: mtimeAfterWrite, releaseTimer: null });
+  }
+
+  has(absPath: string, currentMtime: number): boolean {
+    const entry = this.map.get(absPath);
+    if (entry === undefined) return false;
+    return entry.mtime === currentMtime;
+  }
+
+  releaseAfter(absPath: string, graceMs: number): void {
+    const entry = this.map.get(absPath);
+    if (entry === undefined) return;
+    if (entry.releaseTimer) clearTimeout(entry.releaseTimer);
+    entry.releaseTimer = setTimeout(() => {
+      this.map.delete(absPath);
+    }, graceMs);
+    // Allow the process to exit even if releases are pending.
+    if (typeof entry.releaseTimer.unref === "function") {
+      entry.releaseTimer.unref();
+    }
+  }
+}
+
+// Default for tests / postgres-backend / any path that doesn't run a watcher.
+export class NoopIgnoreSet implements IgnoreSet {
+  add(): void {}
+  has(): boolean {
+    return false;
+  }
+  releaseAfter(): void {}
+}
+```
+
+- [ ] **Step 2: Run tests to verify pass**
+
+Run: `npx vitest run tests/unit/backend/vault/watcher/ignore-set.test.ts`
+Expected: PASS — 7 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/backend/vault/watcher/ignore-set.ts tests/unit/backend/vault/watcher/ignore-set.test.ts
+git commit -m "feat(vault): add IgnoreSet for self-write filtering
+
+Mutation sites add(absPath, mtimeAfterWrite) post-fsync; watcher
+checks has(absPath, currentMtime). mtime tuple lets an external
+edit colliding with our write window fall through to reconcile
+instead of being silently skipped."
+```
+
+---
+
+## Task 5: Reconciler — happy add path test (no existing row)
+
+**Files:**
+
+- Create: `tests/unit/backend/vault/watcher/reconciler.test.ts`
+
+This is a long file; build it up across the next several tasks. Start with one test for the simplest path.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/backend/vault/watcher/reconciler.test.ts
+import { describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createReconciler } from "../../../../../src/backend/vault/watcher/reconciler.js";
+import { VaultIndex } from "../../../../../src/backend/vault/repositories/vault-index.js";
+
+// Stubs ----------------------------------------------------------------
+
+class StubVectorIndex {
+  rows = new Map<
+    string,
+    { content_hash: string; archived: boolean; vector: number[] }
+  >();
+  upsertCalls: Array<{ id: string; content_hash: string }> = [];
+  upsertMetaOnlyCalls: string[] = [];
+  softArchiveCalls: string[] = [];
+  contentHash: string | undefined;
+
+  async upsert(row: {
+    id: string;
+    vector: number[];
+    content_hash: string;
+  }): Promise<void> {
+    this.upsertCalls.push({ id: row.id, content_hash: row.content_hash });
+    this.rows.set(row.id, {
+      content_hash: row.content_hash,
+      archived: false,
+      vector: row.vector,
+    });
+  }
+  async upsertMetaOnly(meta: { id: string }): Promise<void> {
+    this.upsertMetaOnlyCalls.push(meta.id);
+  }
+  async getContentHash(id: string): Promise<string | undefined> {
+    return this.rows.get(id)?.content_hash ?? this.contentHash;
+  }
+  async softArchive(id: string): Promise<void> {
+    this.softArchiveCalls.push(id);
+    const row = this.rows.get(id);
+    if (row) row.archived = true;
+  }
+  async listAllRowsForOrphanScan(): Promise<
+    Array<{ id: string; path: string }>
+  > {
+    return [];
+  }
+}
+
+class StubFlagService {
+  createCalls: Array<{ memoryId: string; reason: string }> = [];
+  resolveCalls: string[] = [];
+  openFlags = new Map<string, Array<{ id: string; flag_type: string }>>();
+
+  async hasOpenFlag(memoryId: string, flagType: string): Promise<boolean> {
+    return (this.openFlags.get(memoryId) ?? []).some(
+      (f) => f.flag_type === flagType,
+    );
+  }
+  async createFlag(input: {
+    memoryId: string;
+    flagType: string;
+    severity: string;
+    details: { reason: string };
+  }) {
+    this.createCalls.push({
+      memoryId: input.memoryId,
+      reason: input.details.reason,
+    });
+    return { id: `flag-${this.createCalls.length}` };
+  }
+  async getFlagsByMemoryId(memoryId: string) {
+    return this.openFlags.get(memoryId) ?? [];
+  }
+  async resolveFlag(flagId: string) {
+    this.resolveCalls.push(flagId);
+    return { id: flagId };
+  }
+}
+
+const stubEmbed = async (text: string): Promise<number[]> => {
+  // Deterministic: sum of char codes mod 1, 2, 4 — distinct vectors per text.
+  const seed = [...text].reduce((a, c) => a + c.charCodeAt(0), 0);
+  return [seed % 100, (seed * 7) % 100, (seed * 13) % 100, (seed * 17) % 100];
+};
+
+async function setup() {
+  const root = await mkdtemp(join(tmpdir(), "ab-reconciler-"));
+  await mkdir(join(root, "workspaces", "ws"), { recursive: true });
+  const vaultIndex = await VaultIndex.create(root);
+  const vectorIndex = new StubVectorIndex();
+  const flagService = new StubFlagService();
+  const reconciler = createReconciler({
+    vaultIndex,
+    vectorIndex: vectorIndex as any,
+    flagService: flagService as any,
+    embed: stubEmbed,
+    vaultRoot: root,
+  });
+  return { root, vaultIndex, vectorIndex, flagService, reconciler };
+}
+
+const VALID_MD = `---
+id: mem-1
+title: Test memory
+type: pattern
+scope: workspace
+workspace_id: ws
+project_id: proj
+author: alice
+source: agent-auto
+created_at: "2026-04-25T00:00:00.000Z"
+updated_at: "2026-04-25T00:00:00.000Z"
+embedding_model: stub
+embedding_dims: 4
+---
+
+# Test memory
+
+Body content.
+
+## Relationships
+
+## Comments
+`;
+
+describe("reconciler.reconcileFile add (new row)", () => {
+  it("indexes a new file: parse → embed → vectorIndex.upsert → vaultIndex.register", async () => {
+    const { root, vaultIndex, vectorIndex, flagService, reconciler } =
+      await setup();
+    try {
+      const abs = join(root, "workspaces/ws/memories/mem-1.md");
+      await mkdir(join(root, "workspaces/ws/memories"), { recursive: true });
+      await writeFile(abs, VALID_MD);
+
+      const result = await reconciler.reconcileFile(abs, "add");
+
+      expect(result.action).toBe("indexed");
+      expect(result.memoryId).toBe("mem-1");
+      expect(vectorIndex.upsertCalls).toHaveLength(1);
+      expect(vectorIndex.upsertCalls[0].id).toBe("mem-1");
+      expect(vaultIndex.has("mem-1")).toBe(true);
+      expect(vaultIndex.get("mem-1")?.path).toBe(
+        "workspaces/ws/memories/mem-1.md",
+      );
+      expect(flagService.createCalls).toHaveLength(0);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/backend/vault/watcher/reconciler.test.ts`
+Expected: FAIL — `reconciler.js` module not found.
+
+---
+
+## Task 6: Reconciler — minimal impl for add (new row)
+
+**Files:**
+
+- Create: `src/backend/vault/watcher/reconciler.ts`
+
+- [ ] **Step 1: Write minimal impl that passes the new-row add test**
+
+```ts
+// src/backend/vault/watcher/reconciler.ts
+import { readFile } from "node:fs/promises";
+import { relative } from "node:path";
+import { createHash } from "node:crypto";
+import type { VaultIndex } from "../repositories/vault-index.js";
+import type { VaultVectorIndex } from "../vector/lance-index.js";
+import type { FlagService } from "../../../services/flag-service.js";
+import { parseMemoryFile } from "../parser/memory-parser.js";
+import type { Embedder } from "../session-start.js";
+import { logger } from "../../../utils/logger.js";
+import type { MemoryScope } from "../../../types/memory.js";
+import type { ReconcileResult, ReconcileSignal } from "./types.js";
+
+export interface Reconciler {
+  reconcileFile(
+    absPath: string,
+    signal: ReconcileSignal,
+  ): Promise<ReconcileResult>;
+  archiveOrphans(
+    diskPaths: ReadonlySet<string>,
+  ): Promise<{ archived: string[] }>;
+}
+
+export interface ReconcilerDeps {
+  vaultIndex: VaultIndex;
+  vectorIndex: VaultVectorIndex;
+  flagService: FlagService;
+  embed: Embedder;
+  vaultRoot: string;
+}
+
+export function createReconciler(deps: ReconcilerDeps): Reconciler {
+  return new ReconcilerImpl(deps);
+}
+
+class ReconcilerImpl implements Reconciler {
+  constructor(private readonly deps: ReconcilerDeps) {}
+
+  async reconcileFile(
+    absPath: string,
+    signal: ReconcileSignal,
+  ): Promise<ReconcileResult> {
+    if (signal === "unlink") {
+      // Implemented in a later task — placeholder for now.
+      return { action: "skipped", reason: "unlink-not-yet-implemented" };
+    }
+
+    const raw = await readFile(absPath, "utf8");
+    const parsed = parseMemoryFile(raw);
+    const id = parsed.frontmatter.id;
+    const body = parsed.body;
+    const hash = sha256Hex(body);
+    const relPath = relative(this.deps.vaultRoot, absPath);
+
+    const existingHash = await this.deps.vectorIndex.getContentHash(id);
+    if (existingHash === undefined) {
+      // No row in lance — embed + insert.
+      const vector = await this.deps.embed(body);
+      await this.deps.vectorIndex.upsert({
+        id,
+        vector,
+        content_hash: hash,
+        title: parsed.frontmatter.title,
+        scope: parsed.frontmatter.scope as MemoryScope,
+        workspace_id: parsed.frontmatter.workspace_id ?? null,
+        project_id: parsed.frontmatter.project_id ?? null,
+        author: parsed.frontmatter.author,
+        archived: false,
+      } as never);
+      this.deps.vaultIndex.register(id, {
+        path: relPath,
+        scope: parsed.frontmatter.scope as MemoryScope,
+        workspaceId: parsed.frontmatter.workspace_id ?? null,
+        userId: parsed.frontmatter.user_id ?? null,
+      });
+      return { action: "indexed", memoryId: id };
+    }
+
+    // Hash compare branch — implemented in next task.
+    return { action: "skipped", reason: "change-not-yet-implemented" };
+  }
+
+  async archiveOrphans(
+    _diskPaths: ReadonlySet<string>,
+  ): Promise<{ archived: string[] }> {
+    // Implemented in a later task.
+    return { archived: [] };
+  }
+}
+
+function sha256Hex(s: string): string {
+  return createHash("sha256").update(s, "utf8").digest("hex");
+}
+```
+
+- [ ] **Step 2: Run test to verify pass**
+
+Run: `npx vitest run tests/unit/backend/vault/watcher/reconciler.test.ts`
+Expected: PASS — 1 test passes. (Other tests added in later tasks.)
+
+- [ ] **Step 3: Verify the existing test suite is still green**
+
+Run: `npm run test:unit`
+Expected: PASS — all unit tests still pass; no regressions.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/backend/vault/watcher/reconciler.ts tests/unit/backend/vault/watcher/reconciler.test.ts
+git commit -m "feat(vault): reconciler skeleton + add (new row) path
+
+Implements the simplest reconcile path: parse → embed → vector
+upsert → vaultIndex.register. change/unlink/parse-error/orphan
+branches return placeholders; covered in following commits."
+```
+
+---
+
+## Task 7: Reconciler — change with hash-skip + frontmatter-only update
+
+**Files:**
+
+- Modify: `tests/unit/backend/vault/watcher/reconciler.test.ts` (append)
+- Modify: `src/backend/vault/watcher/reconciler.ts`
+
+- [ ] **Step 1: Append failing tests for `change` event**
+
+Add to the test file:
+
+```ts
+describe("reconciler.reconcileFile change (existing row)", () => {
+  it("hash matches + frontmatter unchanged → skipped", async () => {
+    const { root, vectorIndex, reconciler } = await setup();
+    try {
+      const abs = join(root, "workspaces/ws/memories/mem-1.md");
+      await mkdir(join(root, "workspaces/ws/memories"), { recursive: true });
+      await writeFile(abs, VALID_MD);
+
+      // Seed lance with the exact hash this body produces so the change
+      // event sees no body change.
+      const sha256Hex = (s: string) =>
+        require("node:crypto")
+          .createHash("sha256")
+          .update(s, "utf8")
+          .digest("hex");
+      const body =
+        "\n# Test memory\n\nBody content.\n\n## Relationships\n\n## Comments\n";
+      vectorIndex.rows.set("mem-1", {
+        content_hash: sha256Hex(body),
+        archived: false,
+        vector: [0, 0, 0, 0],
+      });
+
+      const result = await reconciler.reconcileFile(abs, "change");
+
+      expect(result.action).toBe("skipped");
+      expect(vectorIndex.upsertCalls).toHaveLength(0);
+      expect(vectorIndex.upsertMetaOnlyCalls).toHaveLength(0);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("hash matches but frontmatter changed → upsertMetaOnly", async () => {
+    const { root, vectorIndex, reconciler } = await setup();
+    try {
+      const abs = join(root, "workspaces/ws/memories/mem-1.md");
+      await mkdir(join(root, "workspaces/ws/memories"), { recursive: true });
+      // Modified title; same body.
+      const md = VALID_MD.replace(
+        "title: Test memory",
+        "title: Renamed memory",
+      );
+      await writeFile(abs, md);
+
+      const sha256Hex = (s: string) =>
+        require("node:crypto")
+          .createHash("sha256")
+          .update(s, "utf8")
+          .digest("hex");
+      const body =
+        "\n# Test memory\n\nBody content.\n\n## Relationships\n\n## Comments\n";
+      vectorIndex.rows.set("mem-1", {
+        content_hash: sha256Hex(body),
+        archived: false,
+        vector: [0, 0, 0, 0],
+      });
+
+      const result = await reconciler.reconcileFile(abs, "change");
+
+      expect(result.action).toBe("meta-updated");
+      expect(vectorIndex.upsertCalls).toHaveLength(0);
+      expect(vectorIndex.upsertMetaOnlyCalls).toEqual(["mem-1"]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("hash differs → re-embed + upsert", async () => {
+    const { root, vectorIndex, reconciler } = await setup();
+    try {
+      const abs = join(root, "workspaces/ws/memories/mem-1.md");
+      await mkdir(join(root, "workspaces/ws/memories"), { recursive: true });
+      await writeFile(abs, VALID_MD);
+
+      vectorIndex.rows.set("mem-1", {
+        content_hash: "stale-hash-different-from-body",
+        archived: false,
+        vector: [0, 0, 0, 0],
+      });
+
+      const result = await reconciler.reconcileFile(abs, "change");
+
+      expect(result.action).toBe("reembedded");
+      expect(vectorIndex.upsertCalls).toHaveLength(1);
+      expect(vectorIndex.upsertCalls[0].id).toBe("mem-1");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail (existing skipped/reason mismatch)**
+
+Run: `npx vitest run tests/unit/backend/vault/watcher/reconciler.test.ts`
+Expected: 1 PASS (new-row add) + 3 FAIL (the new change cases — return value mismatches the placeholder).
+
+- [ ] **Step 3: Implement the change branch**
+
+Replace the `// Hash compare branch — implemented in next task.` block in `reconciler.ts` with:
+
+```ts
+// Existing row: compare body hash.
+if (existingHash === hash) {
+  // Body unchanged. Detect frontmatter change cheaply by comparing the
+  // VaultIndex registered entry against parsed values; if anything
+  // actionable changed, push a meta-only update.
+  const indexEntry = this.deps.vaultIndex.get(id);
+  const fmChanged =
+    indexEntry === undefined ||
+    indexEntry.path !== relPath ||
+    indexEntry.scope !== parsed.frontmatter.scope ||
+    indexEntry.workspaceId !== (parsed.frontmatter.workspace_id ?? null) ||
+    indexEntry.userId !== (parsed.frontmatter.user_id ?? null);
+  if (fmChanged) {
+    await this.deps.vectorIndex.upsertMetaOnly({
+      id,
+      title: parsed.frontmatter.title,
+      scope: parsed.frontmatter.scope as MemoryScope,
+      workspace_id: parsed.frontmatter.workspace_id ?? null,
+      project_id: parsed.frontmatter.project_id ?? null,
+      author: parsed.frontmatter.author,
+      archived: false,
+    } as never);
+    this.deps.vaultIndex.register(id, {
+      path: relPath,
+      scope: parsed.frontmatter.scope as MemoryScope,
+      workspaceId: parsed.frontmatter.workspace_id ?? null,
+      userId: parsed.frontmatter.user_id ?? null,
+    });
+    return { action: "meta-updated", memoryId: id };
+  }
+  return { action: "skipped", memoryId: id, reason: "hash-and-meta-unchanged" };
+}
+
+// Hash differs — re-embed.
+const vector = await this.deps.embed(body);
+await this.deps.vectorIndex.upsert({
+  id,
+  vector,
+  content_hash: hash,
+  title: parsed.frontmatter.title,
+  scope: parsed.frontmatter.scope as MemoryScope,
+  workspace_id: parsed.frontmatter.workspace_id ?? null,
+  project_id: parsed.frontmatter.project_id ?? null,
+  author: parsed.frontmatter.author,
+  archived: false,
+} as never);
+this.deps.vaultIndex.register(id, {
+  path: relPath,
+  scope: parsed.frontmatter.scope as MemoryScope,
+  workspaceId: parsed.frontmatter.workspace_id ?? null,
+  userId: parsed.frontmatter.user_id ?? null,
+});
+return { action: "reembedded", memoryId: id };
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npx vitest run tests/unit/backend/vault/watcher/reconciler.test.ts`
+Expected: 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/vault/watcher/reconciler.ts tests/unit/backend/vault/watcher/reconciler.test.ts
+git commit -m "feat(vault): reconciler change branch with hash-skip
+
+Compare body sha256 against lance content_hash. Match → skip embed
+(optionally upsertMetaOnly if frontmatter changed). Differ →
+re-embed + full upsert. Saves Ollama calls when only frontmatter
+flips (e.g. verified_at bumps)."
+```
+
+---
+
+## Task 8: Reconciler — unlink path with reverse lookup
+
+**Files:**
+
+- Modify: `tests/unit/backend/vault/watcher/reconciler.test.ts` (append)
+- Modify: `src/backend/vault/watcher/reconciler.ts`
+
+- [ ] **Step 1: Append unlink tests**
+
+```ts
+describe("reconciler.reconcileFile unlink", () => {
+  it("known path → softArchive lance + unregister vault index + resolve open parse_error flags", async () => {
+    const { root, vaultIndex, vectorIndex, flagService, reconciler } =
+      await setup();
+    try {
+      const abs = join(root, "workspaces/ws/memories/mem-1.md");
+      vaultIndex.register("mem-1", {
+        path: "workspaces/ws/memories/mem-1.md",
+        scope: "workspace",
+        workspaceId: "ws",
+        userId: null,
+      });
+      vectorIndex.rows.set("mem-1", {
+        content_hash: "h",
+        archived: false,
+        vector: [1, 1, 1, 1],
+      });
+      flagService.openFlags.set("mem-1", [
+        { id: "f1", flag_type: "parse_error" },
+        { id: "f2", flag_type: "duplicate" },
+      ]);
+
+      const result = await reconciler.reconcileFile(abs, "unlink");
+
+      expect(result.action).toBe("archived");
+      expect(result.memoryId).toBe("mem-1");
+      expect(vectorIndex.softArchiveCalls).toEqual(["mem-1"]);
+      expect(vaultIndex.has("mem-1")).toBe(false);
+      expect(flagService.resolveCalls).toEqual(["f1"]); // only parse_error flag resolved
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("unknown path (orphan unlink) → no-op", async () => {
+    const { root, vectorIndex, flagService, reconciler } = await setup();
+    try {
+      const abs = join(root, "workspaces/ws/memories/missing.md");
+      const result = await reconciler.reconcileFile(abs, "unlink");
+      expect(result.action).toBe("skipped");
+      expect(vectorIndex.softArchiveCalls).toHaveLength(0);
+      expect(flagService.resolveCalls).toHaveLength(0);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/unit/backend/vault/watcher/reconciler.test.ts`
+Expected: previous 4 PASS + 2 FAIL on unlink behavior (placeholder returns `skipped/unlink-not-yet-implemented`).
+
+- [ ] **Step 3: Implement unlink branch**
+
+Replace the early-return placeholder in `reconcileFile`:
+
+```ts
+if (signal === "unlink") {
+  const relPath = relative(this.deps.vaultRoot, absPath);
+  const memoryId = this.findIdByPath(relPath);
+  if (memoryId === null) {
+    // Path was never registered (or already cleaned up). Make sure no
+    // unindexable entry lingers for it.
+    this.deps.vaultIndex.clearUnindexable(relPath);
+    return { action: "skipped", reason: "unknown-path" };
+  }
+  try {
+    await this.deps.vectorIndex.softArchive(memoryId);
+  } catch (err) {
+    logger.error(`reconciler: softArchive failed for ${memoryId}:`, err);
+  }
+  this.deps.vaultIndex.unregister(memoryId);
+  await this.resolveOpenParseErrorFlags(memoryId);
+  return { action: "archived", memoryId };
+}
+```
+
+Then add the helper methods inside the class:
+
+```ts
+  private findIdByPath(relPath: string): string | null {
+    for (const [id, entry] of this.deps.vaultIndex.entries()) {
+      if (entry.path === relPath) return id;
+    }
+    return null;
+  }
+
+  private async resolveOpenParseErrorFlags(memoryId: string): Promise<void> {
+    const flags = await this.deps.flagService.getFlagsByMemoryId(memoryId);
+    for (const f of flags) {
+      if ((f as { flag_type?: string }).flag_type !== "parse_error") continue;
+      if ((f as { resolved_at?: unknown }).resolved_at != null) continue;
+      try {
+        await this.deps.flagService.resolveFlag(
+          f.id,
+          "agent-brain",
+          "fixed" as never,
+        );
+      } catch (err) {
+        logger.warn(
+          `reconciler: failed to resolve parse_error flag ${f.id} for ${memoryId}:`,
+          err,
+        );
+      }
+    }
+  }
+```
+
+(Note: the test stub's `resolveFlag` only takes one arg; production `FlagService.resolveFlag(flagId, userId, resolution)` takes three. Stub deliberately ignores extra args.)
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `npx vitest run tests/unit/backend/vault/watcher/reconciler.test.ts`
+Expected: 6 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/vault/watcher/reconciler.ts tests/unit/backend/vault/watcher/reconciler.test.ts
+git commit -m "feat(vault): reconciler unlink path with reverse lookup
+
+Reverse-lookup absPath → memoryId via vaultIndex.entries(); soft-
+archive lance row, unregister index entry, auto-resolve any open
+parse_error flag. Subsumes the PR #37 deferred syncPaths deletion
+gap: chokidar 'unlink' fires on git-pull checkouts too."
+```
+
+---
+
+## Task 9: Reconciler — parse-error branches
+
+**Files:**
+
+- Modify: `tests/unit/backend/vault/watcher/reconciler.test.ts` (append)
+- Modify: `src/backend/vault/watcher/reconciler.ts`
+
+- [ ] **Step 1: Append parse-error tests**
+
+```ts
+const BROKEN_FRONTMATTER_MD = `---
+this is not yaml: at all: ":
+title:
+---
+
+body
+`;
+
+const VALID_FM_BROKEN_BODY_MD = `---
+id: mem-1
+title: Test memory
+type: pattern
+scope: workspace
+workspace_id: ws
+project_id: proj
+author: alice
+source: agent-auto
+created_at: "2026-04-25T00:00:00.000Z"
+updated_at: "2026-04-25T00:00:00.000Z"
+embedding_model: stub
+embedding_dims: 4
+---
+
+(no body heading — parser refuses)
+`;
+
+describe("reconciler.reconcileFile parse failures", () => {
+  it("frontmatter broken + path NOT in index → vaultIndex.setUnindexable", async () => {
+    const { root, vaultIndex, flagService, reconciler } = await setup();
+    try {
+      const abs = join(root, "workspaces/ws/memories/broken.md");
+      await mkdir(join(root, "workspaces/ws/memories"), { recursive: true });
+      await writeFile(abs, BROKEN_FRONTMATTER_MD);
+
+      const result = await reconciler.reconcileFile(abs, "add");
+
+      expect(result.action).toBe("parse-error");
+      expect(flagService.createCalls).toHaveLength(0);
+      expect(
+        vaultIndex.unindexable.find(
+          (u) => u.path === "workspaces/ws/memories/broken.md",
+        ),
+      ).toBeDefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("body broken + id resolvable + no existing flag → flagService.createFlag", async () => {
+    const { root, vaultIndex, flagService, reconciler } = await setup();
+    try {
+      const abs = join(root, "workspaces/ws/memories/mem-1.md");
+      await mkdir(join(root, "workspaces/ws/memories"), { recursive: true });
+      await writeFile(abs, VALID_FM_BROKEN_BODY_MD);
+
+      // Pre-register the path so the id-by-path lookup works even when the
+      // current parse fails. (Phase 5 only registers on a successful parse;
+      // a prior good parse is the realistic scenario here.)
+      vaultIndex.register("mem-1", {
+        path: "workspaces/ws/memories/mem-1.md",
+        scope: "workspace",
+        workspaceId: "ws",
+        userId: null,
+      });
+
+      const result = await reconciler.reconcileFile(abs, "change");
+
+      expect(result.action).toBe("parse-error");
+      expect(result.memoryId).toBe("mem-1");
+      expect(flagService.createCalls).toHaveLength(1);
+      expect(flagService.createCalls[0].memoryId).toBe("mem-1");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("parse failure + id resolvable + flag already open → no duplicate flag", async () => {
+    const { root, vaultIndex, flagService, reconciler } = await setup();
+    try {
+      const abs = join(root, "workspaces/ws/memories/mem-1.md");
+      await mkdir(join(root, "workspaces/ws/memories"), { recursive: true });
+      await writeFile(abs, VALID_FM_BROKEN_BODY_MD);
+      vaultIndex.register("mem-1", {
+        path: "workspaces/ws/memories/mem-1.md",
+        scope: "workspace",
+        workspaceId: "ws",
+        userId: null,
+      });
+      flagService.openFlags.set("mem-1", [
+        { id: "existing", flag_type: "parse_error" },
+      ]);
+
+      const result = await reconciler.reconcileFile(abs, "change");
+
+      expect(result.action).toBe("parse-error");
+      expect(flagService.createCalls).toHaveLength(0);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("parse passes after prior unindexable entry → clearUnindexable", async () => {
+    const { root, vaultIndex, reconciler } = await setup();
+    try {
+      const abs = join(root, "workspaces/ws/memories/mem-1.md");
+      await mkdir(join(root, "workspaces/ws/memories"), { recursive: true });
+      await writeFile(abs, VALID_MD);
+      // Seed a stale unindexable entry that should be cleared.
+      // VaultIndex exposes setUnindexable as a private method, so simulate
+      // through .syncPaths or a direct call. Use the public setUnindexable
+      // method if exposed (Phase 4d); otherwise this test asserts via the
+      // unindexable getter being empty post-reconcile.
+      (
+        vaultIndex as unknown as {
+          setUnindexable: (path: string, reason: string) => void;
+        }
+      ).setUnindexable("workspaces/ws/memories/mem-1.md", "previously broken");
+
+      const result = await reconciler.reconcileFile(abs, "add");
+
+      expect(result.action).toBe("indexed");
+      expect(
+        vaultIndex.unindexable.find(
+          (u) => u.path === "workspaces/ws/memories/mem-1.md",
+        ),
+      ).toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/unit/backend/vault/watcher/reconciler.test.ts`
+Expected: previous 6 PASS + 4 FAIL on parse-error behavior.
+
+- [ ] **Step 3: Verify VaultIndex exposes `setUnindexable` / `clearUnindexable` publicly**
+
+Run: `grep -n "setUnindexable\|clearUnindexable" /Users/chris/dev/agent-brain/src/backend/vault/repositories/vault-index.ts`
+Expected output includes both method definitions. If currently `private`, change to `public` (no behavior change; producer needs them). If they're already public, skip.
+
+- [ ] **Step 4: Implement parse-error branch**
+
+Wrap the parse step in `reconcileFile` with a try/catch and add the success-path side-effect for clearing prior unindexable entries. Replace the body of `reconcileFile` after the `if (signal === "unlink")` block:
+
+```ts
+const raw = await readFile(absPath, "utf8");
+const relPath = relative(this.deps.vaultRoot, absPath);
+let parsed: ReturnType<typeof parseMemoryFile>;
+try {
+  parsed = parseMemoryFile(raw);
+} catch (err) {
+  const reason = err instanceof Error ? err.message : String(err);
+  const memoryId = this.findIdByPath(relPath);
+  if (memoryId === null) {
+    // No id resolvable → record as unindexable so it surfaces in
+    // BackendSessionStartMeta.parse_errors next sessionStart.
+    this.deps.vaultIndex.setUnindexable(relPath, reason);
+    return { action: "parse-error", reason };
+  }
+  // id resolvable → produce a parse_error flag (idempotent).
+  const already = await this.deps.flagService.hasOpenFlag(
+    memoryId,
+    "parse_error",
+  );
+  if (!already) {
+    try {
+      await this.deps.flagService.createFlag({
+        memoryId,
+        flagType: "parse_error",
+        severity: "needs_review",
+        details: { reason: `Parse error in ${relPath}: ${reason}` },
+      });
+    } catch (writeErr) {
+      logger.warn(
+        `reconciler: createFlag(parse_error) failed for ${memoryId}:`,
+        writeErr,
+      );
+    }
+  }
+  return { action: "parse-error", memoryId, reason };
+}
+
+// Successful parse — clear any stale unindexable entry that was
+// tracking this path while it was broken.
+this.deps.vaultIndex.clearUnindexable(relPath);
+
+const id = parsed.frontmatter.id;
+// ... existing body (existingHash check, hash compare, etc.)
+```
+
+After the existing-row hash branch logic, **also auto-resolve any open `parse_error` flag** for the now-good file. Add a call right before each successful return (`indexed`, `meta-updated`, `reembedded`, `skipped` for hash-and-meta-unchanged):
+
+```ts
+await this.resolveOpenParseErrorFlags(id);
+```
+
+…or factor by computing the result first, calling `resolveOpenParseErrorFlags`, then returning. Cleanest:
+
+```ts
+const result = await this.applySuccessfulParse(parsed, hash, relPath);
+await this.resolveOpenParseErrorFlags(parsed.frontmatter.id);
+return result;
+```
+
+…and extract the hash-compare/upsert block into `applySuccessfulParse`. Either factoring is fine; pick the one that keeps the diff smallest.
+
+- [ ] **Step 5: Run tests to verify pass**
+
+Run: `npx vitest run tests/unit/backend/vault/watcher/reconciler.test.ts`
+Expected: 10 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/backend/vault/watcher/reconciler.ts tests/unit/backend/vault/watcher/reconciler.test.ts src/backend/vault/repositories/vault-index.ts
+git commit -m "feat(vault): reconciler parse-error branches
+
+Parse failure with id resolvable → flagService.createFlag (skipped
+when already open). Parse failure without id → vaultIndex.set-
+Unindexable. Successful parse on previously-broken file auto-
+resolves the open parse_error flag and clears the unindexable
+entry. Closes the Phase 4d live-edit gap."
+```
+
+---
+
+## Task 10: Reconciler — archiveOrphans
+
+**Files:**
+
+- Modify: `tests/unit/backend/vault/watcher/reconciler.test.ts` (append)
+- Modify: `src/backend/vault/watcher/reconciler.ts`
+
+- [ ] **Step 1: Append archiveOrphans test**
+
+```ts
+describe("reconciler.archiveOrphans", () => {
+  it("soft-archives lance rows whose path is not in diskPaths", async () => {
+    const { root, vaultIndex, vectorIndex, reconciler } = await setup();
+    try {
+      // Three rows in lance, two paths on disk.
+      vaultIndex.register("a", {
+        path: "workspaces/ws/memories/a.md",
+        scope: "workspace",
+        workspaceId: "ws",
+        userId: null,
+      });
+      vaultIndex.register("b", {
+        path: "workspaces/ws/memories/b.md",
+        scope: "workspace",
+        workspaceId: "ws",
+        userId: null,
+      });
+      vaultIndex.register("c", {
+        path: "workspaces/ws/memories/c.md",
+        scope: "workspace",
+        workspaceId: "ws",
+        userId: null,
+      });
+      vectorIndex.rows.set("a", {
+        content_hash: "h",
+        archived: false,
+        vector: [],
+      });
+      vectorIndex.rows.set("b", {
+        content_hash: "h",
+        archived: false,
+        vector: [],
+      });
+      vectorIndex.rows.set("c", {
+        content_hash: "h",
+        archived: false,
+        vector: [],
+      });
+
+      // Override listAllRowsForOrphanScan stub.
+      (
+        vectorIndex as unknown as {
+          listAllRowsForOrphanScan: () => Promise<
+            Array<{ id: string; path: string }>
+          >;
+        }
+      ).listAllRowsForOrphanScan = async () => [
+        { id: "a", path: "workspaces/ws/memories/a.md" },
+        { id: "b", path: "workspaces/ws/memories/b.md" },
+        { id: "c", path: "workspaces/ws/memories/c.md" },
+      ];
+
+      const diskPaths = new Set([
+        join(root, "workspaces/ws/memories/a.md"),
+        join(root, "workspaces/ws/memories/b.md"),
+      ]);
+      const { archived } = await reconciler.archiveOrphans(diskPaths);
+
+      expect(archived).toEqual(["c"]);
+      expect(vectorIndex.softArchiveCalls).toEqual(["c"]);
+      expect(vaultIndex.has("c")).toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/backend/vault/watcher/reconciler.test.ts -t archiveOrphans`
+Expected: FAIL — placeholder returns empty array.
+
+- [ ] **Step 3: Verify `VaultVectorIndex.listAllRowsForOrphanScan` exists; add if missing**
+
+Run: `grep -n "listAllRowsForOrphanScan\|listAllRows\|allRows" /Users/chris/dev/agent-brain/src/backend/vault/vector/lance-index.ts`
+
+If no method returning `Array<{id, path}>` for non-archived rows exists, add one. Implementation sketch:
+
+```ts
+  // Returns id + path for every non-archived row. Used by the boot
+  // reconciler to detect lance rows whose markdown file no longer exists
+  // on disk (orphan archival).
+  async listAllRowsForOrphanScan(): Promise<Array<{ id: string; path: string }>> {
+    const rows = await this.tbl
+      .query()
+      .where("archived = false")
+      .select(["id", "path"])
+      .toArray();
+    return rows.map((r) => ({ id: String(r.id), path: String(r.path) }));
+  }
+```
+
+(Adapt method/property names to whatever `VaultVectorIndex` actually uses — check the file first.)
+
+- [ ] **Step 4: Implement archiveOrphans in reconciler**
+
+```ts
+  async archiveOrphans(diskPaths: ReadonlySet<string>): Promise<{ archived: string[] }> {
+    const rows = await this.deps.vectorIndex.listAllRowsForOrphanScan();
+    const archived: string[] = [];
+    for (const { id, path: relPath } of rows) {
+      const abs = `${this.deps.vaultRoot}/${relPath}`;
+      // Compare the absolute path so callers can pass either fs.realpath-
+      // resolved entries or join-ed entries — both work as long as the
+      // caller is consistent.
+      if (diskPaths.has(abs)) continue;
+      try {
+        await this.deps.vectorIndex.softArchive(id);
+        this.deps.vaultIndex.unregister(id);
+        archived.push(id);
+      } catch (err) {
+        logger.error(
+          `reconciler: archiveOrphans failed for ${id} (path=${relPath}):`,
+          err,
+        );
+      }
+    }
+    return { archived };
+  }
+```
+
+- [ ] **Step 5: Run test to verify pass**
+
+Run: `npx vitest run tests/unit/backend/vault/watcher/reconciler.test.ts`
+Expected: 11 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/backend/vault/watcher/reconciler.ts src/backend/vault/vector/lance-index.ts tests/unit/backend/vault/watcher/reconciler.test.ts
+git commit -m "feat(vault): reconciler archiveOrphans for boot reconcile
+
+Boot scan calls archiveOrphans(diskPaths) after walking every
+markdown file. Rows in lance whose path is no longer on disk get
+soft-archived and unregistered. Closes lance↔markdown drift left
+over from any earlier crash."
+```
+
+---
+
+## Task 11: Boot scan — happy-path test
+
+**Files:**
+
+- Create: `tests/unit/backend/vault/watcher/boot-scan.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// tests/unit/backend/vault/watcher/boot-scan.test.ts
+import { describe, expect, it } from "vitest";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runBootScan } from "../../../../../src/backend/vault/watcher/boot-scan.js";
+import type { Reconciler } from "../../../../../src/backend/vault/watcher/reconciler.js";
+
+class StubReconciler implements Reconciler {
+  reconcileCalls: Array<{ absPath: string; signal: string }> = [];
+  archiveOrphansCalls: Array<ReadonlySet<string>> = [];
+  scriptedResults = new Map<string, { action: string; reason?: string }>();
+
+  async reconcileFile(absPath: string, signal: "add" | "change" | "unlink") {
+    this.reconcileCalls.push({ absPath, signal });
+    const r = this.scriptedResults.get(absPath) ?? { action: "indexed" };
+    return r as never;
+  }
+  async archiveOrphans(diskPaths: ReadonlySet<string>) {
+    this.archiveOrphansCalls.push(diskPaths);
+    return { archived: [] };
+  }
+}
+
+describe("runBootScan", () => {
+  it("empty vault → all counts zero", async () => {
+    const root = await mkdtemp(join(tmpdir(), "ab-bootscan-"));
+    try {
+      const reconciler = new StubReconciler();
+      const result = await runBootScan({ vaultRoot: root, reconciler });
+      expect(result).toEqual({
+        scanned: 0,
+        reconciled: 0,
+        orphaned: 0,
+        parseErrors: 0,
+        embedErrors: 0,
+      });
+      expect(reconciler.reconcileCalls).toHaveLength(0);
+      expect(reconciler.archiveOrphansCalls).toHaveLength(1);
+      expect(reconciler.archiveOrphansCalls[0].size).toBe(0);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("walks every .md file under root and counts results", async () => {
+    const root = await mkdtemp(join(tmpdir(), "ab-bootscan-"));
+    try {
+      await mkdir(join(root, "workspaces/ws/memories"), { recursive: true });
+      const a = join(root, "workspaces/ws/memories/a.md");
+      const b = join(root, "workspaces/ws/memories/b.md");
+      const c = join(root, "workspaces/ws/memories/c.md");
+      await writeFile(a, "x");
+      await writeFile(b, "x");
+      await writeFile(c, "x");
+
+      const reconciler = new StubReconciler();
+      reconciler.scriptedResults.set(a, { action: "indexed" });
+      reconciler.scriptedResults.set(b, {
+        action: "skipped",
+        reason: "hash-and-meta-unchanged",
+      });
+      reconciler.scriptedResults.set(c, {
+        action: "parse-error",
+        reason: "boom",
+      });
+
+      const result = await runBootScan({ vaultRoot: root, reconciler });
+
+      expect(result.scanned).toBe(3);
+      expect(result.reconciled).toBe(2); // indexed + skipped count as reconciled
+      expect(result.parseErrors).toBe(1);
+      expect(result.embedErrors).toBe(0);
+      expect(reconciler.archiveOrphansCalls).toHaveLength(1);
+      expect(reconciler.archiveOrphansCalls[0].size).toBe(3);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("counts thrown errors against embedErrors and continues", async () => {
+    const root = await mkdtemp(join(tmpdir(), "ab-bootscan-"));
+    try {
+      await mkdir(join(root, "workspaces/ws/memories"), { recursive: true });
+      const a = join(root, "workspaces/ws/memories/a.md");
+      const b = join(root, "workspaces/ws/memories/b.md");
+      await writeFile(a, "x");
+      await writeFile(b, "x");
+
+      const reconciler = new StubReconciler();
+      // Make the first file throw.
+      reconciler.reconcileFile = async (
+        absPath: string,
+        signal: "add" | "change" | "unlink",
+      ) => {
+        reconciler.reconcileCalls.push({ absPath, signal });
+        if (absPath === a) throw new Error("ollama down");
+        return { action: "indexed" } as never;
+      };
+
+      const result = await runBootScan({ vaultRoot: root, reconciler });
+
+      expect(result.scanned).toBe(2);
+      expect(result.reconciled).toBe(1);
+      expect(result.embedErrors).toBe(1);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/backend/vault/watcher/boot-scan.test.ts`
+Expected: FAIL — module not found.
+
+---
+
+## Task 12: Boot scan — implementation
+
+**Files:**
+
+- Create: `src/backend/vault/watcher/boot-scan.ts`
+
+- [ ] **Step 1: Implement runBootScan**
+
+```ts
+// src/backend/vault/watcher/boot-scan.ts
+import { listMarkdownFiles } from "../io/vault-fs.js";
+import { logger } from "../../../utils/logger.js";
+import type { Reconciler } from "./reconciler.js";
+import type { BootScanResult } from "./types.js";
+
+export interface RunBootScanOpts {
+  vaultRoot: string;
+  reconciler: Reconciler;
+}
+
+// Walks every markdown file under <vaultRoot>, calls
+// reconciler.reconcileFile(path, "add") per file, then archives lance rows
+// whose path is no longer on disk. Blocks until consistent so HTTP listen
+// only happens once vault state is in agreement.
+export async function runBootScan(
+  opts: RunBootScanOpts,
+): Promise<BootScanResult> {
+  const { vaultRoot, reconciler } = opts;
+  const paths = await listMarkdownFiles(vaultRoot);
+
+  let reconciled = 0;
+  let parseErrors = 0;
+  let embedErrors = 0;
+  const diskPaths = new Set<string>();
+
+  for (const abs of paths) {
+    diskPaths.add(abs);
+    try {
+      const result = await reconciler.reconcileFile(abs, "add");
+      switch (result.action) {
+        case "indexed":
+        case "reembedded":
+        case "meta-updated":
+        case "skipped":
+          reconciled++;
+          break;
+        case "parse-error":
+          parseErrors++;
+          break;
+        case "archived":
+          // unlink-style result on a still-on-disk file shouldn't happen via
+          // an "add" signal, but log + count as reconciled to be safe.
+          reconciled++;
+          break;
+      }
+    } catch (err) {
+      embedErrors++;
+      logger.error(`runBootScan: reconcile failed for ${abs}:`, err);
+    }
+  }
+
+  const orphan = await reconciler.archiveOrphans(diskPaths);
+
+  return {
+    scanned: paths.length,
+    reconciled,
+    orphaned: orphan.archived.length,
+    parseErrors,
+    embedErrors,
+  };
+}
+```
+
+- [ ] **Step 2: Run tests to verify pass**
+
+Run: `npx vitest run tests/unit/backend/vault/watcher/boot-scan.test.ts`
+Expected: 3 tests PASS.
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `npm run test:unit`
+Expected: PASS — all unit tests still green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/backend/vault/watcher/boot-scan.ts tests/unit/backend/vault/watcher/boot-scan.test.ts
+git commit -m "feat(vault): runBootScan for pre-listen reconcile
+
+Walks every markdown file under <vaultRoot>, calls reconcileFile
+per path with signal=add, then archiveOrphans(diskPaths). Blocks
+until consistent so HTTP listen sees an in-agreement vault."
+```
+
+---
+
+## Task 13: Watcher wrapper — failing test
+
+**Files:**
+
+- Create: `tests/unit/backend/vault/watcher/watcher.test.ts`
+
+- [ ] **Step 1: Write failing test using a chokidar EventEmitter mock**
+
+```ts
+// tests/unit/backend/vault/watcher/watcher.test.ts
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "node:events";
+import { stat } from "node:fs/promises";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createVaultWatcher,
+  type VaultWatcher,
+} from "../../../../../src/backend/vault/watcher/watcher.js";
+import { IgnoreSetImpl } from "../../../../../src/backend/vault/watcher/ignore-set.js";
+import type { Reconciler } from "../../../../../src/backend/vault/watcher/reconciler.js";
+
+// Mock chokidar by hijacking the import.
+class MockFSWatcher extends EventEmitter {
+  closeCalled = false;
+  async close() {
+    this.closeCalled = true;
+  }
+}
+
+vi.mock("chokidar", () => {
+  const watcher = new MockFSWatcher();
+  return {
+    default: { watch: vi.fn(() => watcher) },
+    watch: vi.fn(() => watcher),
+    __watcher: watcher,
+  };
+});
+
+class StubReconciler implements Reconciler {
+  calls: Array<{ absPath: string; signal: string }> = [];
+  blockNext: Promise<void> | null = null;
+  async reconcileFile(absPath: string, signal: "add" | "change" | "unlink") {
+    this.calls.push({ absPath, signal });
+    if (this.blockNext) await this.blockNext;
+    return { action: "indexed" } as never;
+  }
+  async archiveOrphans() {
+    return { archived: [] };
+  }
+}
+
+async function getMockWatcher(): Promise<MockFSWatcher> {
+  const mod = await import("chokidar");
+  return (mod as unknown as { __watcher: MockFSWatcher }).__watcher;
+}
+
+describe("createVaultWatcher", () => {
+  let root: string;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "ab-watcher-"));
+    await mkdir(join(root, "workspaces/ws/memories"), { recursive: true });
+  });
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("start() resolves on chokidar 'ready'", async () => {
+    const w = createVaultWatcher({
+      vaultRoot: root,
+      reconciler: new StubReconciler(),
+    });
+    const mock = await getMockWatcher();
+    const startPromise = w.start();
+    setImmediate(() => mock.emit("ready"));
+    await expect(startPromise).resolves.toBeUndefined();
+  });
+
+  it("change event → reconciler called when ignoreSet does not match", async () => {
+    const reconciler = new StubReconciler();
+    const w = createVaultWatcher({ vaultRoot: root, reconciler });
+    const mock = await getMockWatcher();
+    await Promise.all([w.start(), Promise.resolve(mock.emit("ready"))]);
+
+    const abs = join(root, "workspaces/ws/memories/a.md");
+    await writeFile(abs, "x");
+    mock.emit("change", abs);
+    await new Promise((r) => setImmediate(r));
+
+    expect(reconciler.calls).toEqual([{ absPath: abs, signal: "change" }]);
+  });
+
+  it("change event → reconciler skipped when ignoreSet has matching mtime", async () => {
+    const reconciler = new StubReconciler();
+    const w = createVaultWatcher({ vaultRoot: root, reconciler });
+    const mock = await getMockWatcher();
+    await Promise.all([w.start(), Promise.resolve(mock.emit("ready"))]);
+
+    const abs = join(root, "workspaces/ws/memories/a.md");
+    await writeFile(abs, "x");
+    const s = await stat(abs);
+    w.ignoreSet.add(abs, Number(s.mtime));
+
+    mock.emit("change", abs);
+    await new Promise((r) => setImmediate(r));
+
+    expect(reconciler.calls).toHaveLength(0);
+  });
+
+  it("change event → reconciler called when ignoreSet has different mtime (R2)", async () => {
+    const reconciler = new StubReconciler();
+    const w = createVaultWatcher({ vaultRoot: root, reconciler });
+    const mock = await getMockWatcher();
+    await Promise.all([w.start(), Promise.resolve(mock.emit("ready"))]);
+
+    const abs = join(root, "workspaces/ws/memories/a.md");
+    await writeFile(abs, "x");
+    // Record an mtime that won't match the file's actual mtime.
+    w.ignoreSet.add(abs, 1);
+
+    mock.emit("change", abs);
+    await new Promise((r) => setImmediate(r));
+
+    expect(reconciler.calls).toEqual([{ absPath: abs, signal: "change" }]);
+  });
+
+  it("'error' event is logged and does not throw", async () => {
+    const reconciler = new StubReconciler();
+    const w = createVaultWatcher({ vaultRoot: root, reconciler });
+    const mock = await getMockWatcher();
+    await Promise.all([w.start(), Promise.resolve(mock.emit("ready"))]);
+    expect(() => mock.emit("error", new Error("boom"))).not.toThrow();
+  });
+
+  it("stop() awaits in-flight reconciles", async () => {
+    const reconciler = new StubReconciler();
+    let resolveBlocked: () => void = () => {};
+    reconciler.blockNext = new Promise<void>((r) => (resolveBlocked = r));
+    const w = createVaultWatcher({ vaultRoot: root, reconciler });
+    const mock = await getMockWatcher();
+    await Promise.all([w.start(), Promise.resolve(mock.emit("ready"))]);
+
+    const abs = join(root, "workspaces/ws/memories/a.md");
+    await writeFile(abs, "x");
+    mock.emit("change", abs);
+
+    let stopped = false;
+    const stopPromise = w.stop().then(() => {
+      stopped = true;
+    });
+    await new Promise((r) => setImmediate(r));
+    expect(stopped).toBe(false); // still waiting on the in-flight reconcile
+
+    resolveBlocked();
+    await stopPromise;
+    expect(stopped).toBe(true);
+    expect(mock.closeCalled).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/backend/vault/watcher/watcher.test.ts`
+Expected: FAIL — `watcher.js` not found.
+
+---
+
+## Task 14: Watcher wrapper — implementation
+
+**Files:**
+
+- Create: `src/backend/vault/watcher/watcher.ts`
+
+- [ ] **Step 1: Implement createVaultWatcher**
+
+```ts
+// src/backend/vault/watcher/watcher.ts
+import chokidar from "chokidar";
+import { stat } from "node:fs/promises";
+import { logger } from "../../../utils/logger.js";
+import { IgnoreSetImpl } from "./ignore-set.js";
+import type { IgnoreSet, ReconcileSignal } from "./types.js";
+import type { Reconciler } from "./reconciler.js";
+
+export interface VaultWatcher {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  readonly ignoreSet: IgnoreSet;
+  // Sticky flag: set when chokidar emits 'error'. Surfaced in
+  // BackendSessionStartMeta.watcher_error on next sessionStart.
+  hadError(): boolean;
+}
+
+export interface CreateVaultWatcherOpts {
+  vaultRoot: string;
+  reconciler: Reconciler;
+  awaitWriteFinish?: { stabilityThreshold: number; pollInterval: number };
+  graceMs?: number;
+  // Allows tests / non-vault backends to inject a custom IgnoreSet
+  // (e.g. NoopIgnoreSet). Defaults to a fresh IgnoreSetImpl.
+  ignoreSet?: IgnoreSet;
+}
+
+export function createVaultWatcher(opts: CreateVaultWatcherOpts): VaultWatcher {
+  const ignoreSet = opts.ignoreSet ?? new IgnoreSetImpl();
+  const awaitWriteFinish = opts.awaitWriteFinish ?? {
+    stabilityThreshold: 300,
+    pollInterval: 100,
+  };
+
+  let watcher: chokidar.FSWatcher | null = null;
+  let inFlight = 0;
+  let drainResolvers: Array<() => void> = [];
+  let hadError = false;
+
+  const dispatch = async (
+    absPath: string,
+    signal: ReconcileSignal,
+  ): Promise<void> => {
+    inFlight++;
+    try {
+      // Try to read mtime; if the file is gone (unlink already raced) we
+      // still need to reconcile with whatever signal we got, but we use 0
+      // as the comparison key — IgnoreSet.has() will return false (mtime
+      // mismatch) so the reconcile proceeds.
+      let currentMtime = 0;
+      if (signal !== "unlink") {
+        try {
+          const s = await stat(absPath);
+          currentMtime = Number(s.mtime);
+        } catch {
+          // best-effort
+        }
+      }
+      if (ignoreSet.has(absPath, currentMtime)) return;
+      try {
+        await opts.reconciler.reconcileFile(absPath, signal);
+      } catch (err) {
+        logger.error(`watcher: reconcileFile threw for ${absPath}:`, err);
+      }
+    } finally {
+      inFlight--;
+      if (inFlight === 0 && drainResolvers.length > 0) {
+        const r = drainResolvers;
+        drainResolvers = [];
+        for (const fn of r) fn();
+      }
+    }
+  };
+
+  return {
+    ignoreSet,
+    hadError: () => hadError,
+    async start() {
+      watcher = chokidar.watch(`${opts.vaultRoot}/**/*.md`, {
+        ignoreInitial: true,
+        awaitWriteFinish,
+      });
+      watcher.on("add", (p: string) => void dispatch(p, "add"));
+      watcher.on("change", (p: string) => void dispatch(p, "change"));
+      watcher.on("unlink", (p: string) => void dispatch(p, "unlink"));
+      watcher.on("error", (err: unknown) => {
+        hadError = true;
+        logger.error("watcher: chokidar emitted error:", err);
+      });
+      await new Promise<void>((resolve) => {
+        watcher!.on("ready", () => resolve());
+      });
+    },
+    async stop() {
+      if (watcher) {
+        await watcher.close();
+        watcher = null;
+      }
+      if (inFlight === 0) return;
+      await new Promise<void>((resolve) => {
+        drainResolvers.push(resolve);
+      });
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Run tests to verify pass**
+
+Run: `npx vitest run tests/unit/backend/vault/watcher/watcher.test.ts`
+Expected: 6 tests PASS.
+
+- [ ] **Step 3: Run full suite**
+
+Run: `npm run test:unit`
+Expected: PASS — all unit tests green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/backend/vault/watcher/watcher.ts tests/unit/backend/vault/watcher/watcher.test.ts
+git commit -m "feat(vault): chokidar watcher wrapper with mtime-tuple ignore
+
+Subscribes to add/change/unlink with awaitWriteFinish 300/100 +
+ignoreInitial:true. Each event consults IgnoreSet with current
+mtime so internal writes skip but external edits colliding with
+our window fall through. stop() awaits in-flight reconciles."
+```
+
+---
+
+## Task 15: Plumb IgnoreSet through `VaultMemoryFiles.edit`
+
+**Files:**
+
+- Modify: `src/backend/vault/repositories/memory-files.ts`
+
+Read the file first; the change must (a) accept an optional `IgnoreSet` ctor param defaulting to `NoopIgnoreSet`, (b) post-fsync inside `edit()` capture mtime + `add(absPath, mtime)`, (c) call `releaseAfter(absPath, 500)` after the write fully settles (commit + lance done — i.e. before `edit()` returns).
+
+- [ ] **Step 1: Read current file**
+
+Run: `cat src/backend/vault/repositories/memory-files.ts`
+Note the constructor signature and the body of `edit()`.
+
+- [ ] **Step 2: Add an `ignoreSet` ctor param + import**
+
+At the top of the file:
+
+```ts
+import { stat } from "node:fs/promises";
+import { NoopIgnoreSet } from "../watcher/ignore-set.js";
+import type { IgnoreSet } from "../watcher/types.js";
+```
+
+Add to the constructor / options object the existing class uses:
+
+```ts
+  constructor(opts: {
+    /* ...existing fields... */
+    ignoreSet?: IgnoreSet;
+    graceMs?: number;
+  }) {
+    /* ...existing assignments... */
+    this.ignoreSet = opts.ignoreSet ?? new NoopIgnoreSet();
+    this.graceMs = opts.graceMs ?? 500;
+  }
+```
+
+- [ ] **Step 3: Wrap the markdown write in `edit()` with ignoreSet add/release**
+
+Find the spot in `edit()` where the file has just been written + fsynced. Immediately after the write step, before the lock release / commit step, add:
+
+```ts
+// Tell the watcher this mtime came from our own write so it doesn't
+// re-reconcile what we just emitted. mtime is the kernel-assigned
+// timestamp; we capture it post-write so a chokidar event observing
+// the same mtime is provably ours.
+const s = await stat(absPath);
+this.ignoreSet.add(absPath, Number(s.mtime));
+```
+
+Then, just before `edit()` returns to the caller (after the commit + lance write are done), schedule the release:
+
+```ts
+this.ignoreSet.releaseAfter(absPath, this.graceMs);
+```
+
+- [ ] **Step 4: Verify the existing tests still pass**
+
+Run: `npm run test:unit -- memory-files`
+Expected: PASS — current tests use the noop default, behavior unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/backend/vault/repositories/memory-files.ts
+git commit -m "feat(vault): wire IgnoreSet through VaultMemoryFiles.edit
+
+Accept optional ignoreSet ctor param (defaults to NoopIgnoreSet so
+existing tests + postgres path are untouched). On every edit:
+record mtime post-write, schedule release after graceMs. Watcher
+sees its own writes and skips."
+```
+
+---
+
+## Task 16: Plumb IgnoreSet through `VaultMemoryRepository`
+
+**Files:**
+
+- Modify: `src/backend/vault/repositories/memory-repository.ts`
+- Modify: any factory/builder that constructs `VaultMemoryRepository`
+
+`VaultMemoryRepository.create(opts)` already exists. Add `ignoreSet?: IgnoreSet` to the opts and pass it through to the `VaultMemoryFiles` constructor; also use it on its own write paths (the markdown-writing helpers it calls directly for `create`/`update`/`archive`/`verify`).
+
+- [ ] **Step 1: Read current `VaultMemoryRepository.create` signature**
+
+Run: `grep -n "static create\|create(opts\|VaultMemoryFiles\|new Vault" src/backend/vault/repositories/memory-repository.ts | head`
+
+Note where `VaultMemoryFiles` is instantiated (or where any direct fs writes happen).
+
+- [ ] **Step 2: Thread ignoreSet through**
+
+Add `ignoreSet?: IgnoreSet` to the create-opts type. Pass it forward to `VaultMemoryFiles`. For any direct write paths in this class (not going through `VaultMemoryFiles`), add the same `add(absPath, mtime)` + `releaseAfter(absPath, graceMs)` pattern from Task 15.
+
+- [ ] **Step 3: Run repo tests**
+
+Run: `npm run test:unit -- memory-repository`
+Expected: PASS — defaults unchanged.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/backend/vault/repositories/memory-repository.ts
+git commit -m "feat(vault): wire IgnoreSet through VaultMemoryRepository writes
+
+Forwards ignoreSet to VaultMemoryFiles + records mtime/release on
+any direct write paths (archive, etc.). Default is NoopIgnoreSet
+so postgres + existing contract tests are untouched."
+```
+
+---
+
+## Task 17: BackendSessionStartMeta — `watcher_error` field
+
+**Files:**
+
+- Modify: `src/backend/types.ts`
+
+- [ ] **Step 1: Add the field**
+
+```ts
+  // Chokidar watcher emitted an 'error' event during this process's
+  // lifetime. Sticky from first occurrence to process restart. Surfaces
+  // here so clients can show a degraded-mode banner — watcher does NOT
+  // auto-restart (silent-failure risk).
+  watcher_error?: true;
+```
+
+Insert in `BackendSessionStartMeta` next to the other `?: true` flags (e.g. after `pull_conflict`).
+
+- [ ] **Step 2: Verify typecheck**
+
+Run: `npx tsc --noEmit -p .`
+Expected: no errors. (Single-source-of-truth: envelope picks up the field via the existing `EnvelopeMeta = EnvelopeCoreMeta & BackendSessionStartMeta` intersection.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/backend/types.ts
+git commit -m "feat(vault): BackendSessionStartMeta.watcher_error field
+
+Sticky flag set when chokidar emits 'error'. Surfaces watcher
+degradation to clients without auto-restart (silent-failure
+risk). Envelope intersection picks it up automatically."
+```
+
+---
+
+## Task 18: Wire boot scan + watcher into `VaultBackend.create()`
+
+**Files:**
+
+- Modify: `src/backend/vault/index.ts`
+
+This is the largest single edit. The plan is:
+
+1. Construct `IgnoreSetImpl` early in `create()`.
+2. Pass it into `VaultMemoryRepository.create({ ..., ignoreSet })`.
+3. Build a `Reconciler` from `vaultIndex` + `vectorIndex` + a `FlagService` instance + `embed`.
+4. Run `runBootScan({ vaultRoot, reconciler })`. Surface `parseErrors`/`embedErrors` counts via `bootMeta` (zero values stripped per existing convention).
+5. Construct + start a `VaultWatcher` with the same `ignoreSet`.
+6. Store the watcher on the new `VaultBackend` instance.
+7. `close()`: `watcher.stop()` BEFORE `pushQueue.close()`.
+8. `sessionStart()`: surface `watcher_error: true` from `watcher.hadError()`.
+
+`FlagService` needs an `AuditService` and a `projectId`. Read `src/backend/postgres/index.ts` to mirror how postgres builds these — same constructor pattern applies. (`AuditService` is small; `projectId` comes from config.)
+
+- [ ] **Step 1: Read both backends to align on FlagService construction**
+
+Run: `grep -n "new FlagService\|new AuditService\|projectId" src/backend/postgres/index.ts src/backend/vault/index.ts`
+
+- [ ] **Step 2: Build reconciler dependencies**
+
+Add inside `VaultBackend.create()`, after `memoryRepo` is created but before `return new VaultBackend(...)`:
+
+```ts
+    const ignoreSet = new IgnoreSetImpl();
+    // Re-create memoryRepo with the ignoreSet — alternatively, plumb
+    // ignoreSet into VaultMemoryRepository.create() directly above.
+    // Pick whichever keeps the diff smallest after Task 16.
+
+    const auditService = /* construct as the postgres backend does */;
+    const flagService = new FlagService(
+      flagRepoForVault,
+      auditService,
+      projectId,
+    );
+
+    const reconciler = createReconciler({
+      vaultIndex: vaultIdx,
+      vectorIndex,
+      flagService,
+      embed,
+      vaultRoot: cfg.root,
+    });
+
+    const bootResult = await runBootScan({ vaultRoot: cfg.root, reconciler });
+    if (bootResult.parseErrors > 0) {
+      // Existing parse_errors meta is an array of {path, reason}; populate
+      // it from vaultIdx.unindexable so the surface stays single-source.
+      bootMeta.parse_errors = vaultIdx.unindexable.map((u) => ({
+        path: u.path,
+        reason: u.reason,
+      }));
+    }
+
+    const watcher = createVaultWatcher({
+      vaultRoot: cfg.root,
+      reconciler,
+      ignoreSet,
+    });
+    await watcher.start();
+```
+
+(Pseudocode. The exact placement / variable names depend on the post-Task 16 state of the file. Read carefully and integrate.)
+
+- [ ] **Step 3: Store watcher on the instance**
+
+Add `private readonly watcher: VaultWatcher` to the constructor + pass through:
+
+```ts
+return new VaultBackend(
+  memoryRepo,
+  vectorIndex,
+  vaultIdx,
+  cfg.root,
+  gitOps,
+  trackUsersInGit,
+  git,
+  pushQueue,
+  embed,
+  bootMeta,
+  watcher,
+);
+```
+
+- [ ] **Step 4: Update `close()` and `sessionStart()`**
+
+```ts
+  async close(): Promise<void> {
+    await this.watcher.stop();
+    await this.pushQueue.close();
+    await this.vectorIndex.close();
+  }
+```
+
+```ts
+  async sessionStart(): Promise<BackendSessionStartMeta> {
+    const meta = await runSessionStart({ /* ...existing... */ });
+    if (this.bootMeta.remote_mismatch) meta.remote_mismatch = this.bootMeta.remote_mismatch;
+    if (this.bootMeta.reconcile_failed) meta.reconcile_failed = true;
+    if (this.bootMeta.parse_errors && this.bootMeta.parse_errors.length > 0) {
+      meta.parse_errors = this.bootMeta.parse_errors;
+    }
+    if (this.watcher.hadError()) meta.watcher_error = true;
+    return meta;
+  }
+```
+
+- [ ] **Step 5: Run the full test suite**
+
+Run: `npm run test:unit`
+Expected: PASS.
+
+Run: `npm test` (if integration tests are wired — check `package.json scripts`)
+Expected: PASS or only failures in tests known unrelated to this PR.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/backend/vault/index.ts
+git commit -m "feat(vault): wire boot scan + watcher into VaultBackend.create
+
+Boot scan blocks until the vault is internally consistent (lance ↔
+vaultIndex). Watcher then starts with chokidar + ignoreInitial:
+true. close() awaits watcher.stop() before pushQueue. session-
+Start surfaces watcher_error sticky flag."
+```
+
+---
+
+## Task 19: E2E smoke test — external add/edit/rm
+
+**Files:**
+
+- Create: `tests/integration/vault-watcher-e2e.test.ts`
+
+Five cases per spec D7 / Section "Testing T4". Real chokidar, real `VaultBackend`, tmpdir vault. PR-only with `--testTimeout=10000`. Use polling helpers (`until`) rather than fixed sleeps where possible.
+
+- [ ] **Step 1: Write the E2E test file**
+
+```ts
+// tests/integration/vault-watcher-e2e.test.ts
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { VaultBackend } from "../../src/backend/vault/index.js";
+
+async function until<T>(
+  fn: () => Promise<T | undefined> | T | undefined,
+  timeoutMs = 8000,
+  intervalMs = 100,
+): Promise<T> {
+  const t0 = Date.now();
+  while (Date.now() - t0 < timeoutMs) {
+    const v = await fn();
+    if (v !== undefined && v !== null && v !== false) return v as T;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  throw new Error(`until(): timed out after ${timeoutMs}ms`);
+}
+
+describe("vault watcher E2E", { timeout: 10_000 }, () => {
+  let root: string;
+  let backend: VaultBackend;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "ab-watcher-e2e-"));
+    backend = await VaultBackend.create({
+      root,
+      embeddingDimensions: 4,
+      embed: async (text: string) => {
+        const seed = [...text].reduce((a, c) => a + c.charCodeAt(0), 0);
+        return [
+          seed % 100,
+          (seed * 7) % 100,
+          (seed * 13) % 100,
+          (seed * 17) % 100,
+        ];
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await backend.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  function makeMd(id: string, body = "External body.") {
+    return `---
+id: ${id}
+title: ${id}
+type: pattern
+scope: workspace
+workspace_id: ws
+project_id: proj
+author: alice
+source: agent-auto
+created_at: "2026-04-25T00:00:00.000Z"
+updated_at: "2026-04-25T00:00:00.000Z"
+embedding_model: stub
+embedding_dims: 4
+---
+
+# ${id}
+
+${body}
+
+## Relationships
+
+## Comments
+`;
+  }
+
+  it("external add → memory becomes searchable", async () => {
+    const dir = join(root, "workspaces/ws/memories");
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "ext-add.md"), makeMd("ext-add"));
+
+    const found = await until(async () => {
+      const m = await backend.memoryRepo.findById("ext-add");
+      return m ? true : undefined;
+    });
+    expect(found).toBe(true);
+  });
+
+  it("external edit of body → memory re-embedded", async () => {
+    const dir = join(root, "workspaces/ws/memories");
+    await mkdir(dir, { recursive: true });
+    const path = join(dir, "ext-edit.md");
+    await writeFile(path, makeMd("ext-edit", "First version of the body."));
+
+    await until(async () =>
+      (await backend.memoryRepo.findById("ext-edit")) ? true : undefined,
+    );
+
+    // External edit: change the body so a re-embed must fire.
+    await writeFile(
+      path,
+      makeMd("ext-edit", "Completely different second version."),
+    );
+
+    // The lance row's content_hash should now reflect the new body. Use
+    // search to verify: the new body's distinctive token should rank
+    // higher than the old one.
+    const ok = await until(async () => {
+      const results = await backend.memoryRepo.search(
+        { query: "completely different second version", limit: 5 },
+        { dims: 4 },
+      );
+      return results.find((r) => r.id === "ext-edit") ? true : undefined;
+    });
+    expect(ok).toBe(true);
+  });
+
+  it("external rm → memory excluded from search", async () => {
+    const dir = join(root, "workspaces/ws/memories");
+    await mkdir(dir, { recursive: true });
+    const path = join(dir, "ext-rm.md");
+    await writeFile(path, makeMd("ext-rm"));
+
+    await until(async () =>
+      (await backend.memoryRepo.findById("ext-rm")) ? true : undefined,
+    );
+
+    await rm(path);
+
+    const gone = await until(async () => {
+      const m = await backend.memoryRepo.findById("ext-rm");
+      return m === null || m === undefined ? true : undefined;
+    });
+    expect(gone).toBe(true);
+  });
+
+  it("internal create does NOT trigger a duplicate reindex", async () => {
+    // Internal write goes through memory_create / VaultMemoryRepository.
+    // The IgnoreSet entry recorded post-fsync should make the chokidar
+    // change event a no-op. We assert this by stubbing the embedder to
+    // count calls — exactly one call, not two.
+    let embedCalls = 0;
+    const countingBackend = await VaultBackend.create({
+      root: await mkdtemp(join(tmpdir(), "ab-watcher-internal-")),
+      embeddingDimensions: 4,
+      embed: async (text: string) => {
+        embedCalls++;
+        const seed = [...text].reduce((a, c) => a + c.charCodeAt(0), 0);
+        return [
+          seed % 100,
+          (seed * 7) % 100,
+          (seed * 13) % 100,
+          (seed * 17) % 100,
+        ];
+      },
+    });
+    try {
+      await countingBackend.memoryRepo.create({
+        id: "int-create",
+        title: "Internal create",
+        content: "Internal body content for IgnoreSet test.",
+        type: "pattern",
+        scope: "workspace",
+        workspaceId: "ws",
+        userId: null,
+        projectId: "proj",
+        author: "alice",
+        source: "agent-auto",
+        tags: [],
+      } as never);
+
+      const t0 = Date.now();
+      // Wait long enough for chokidar awaitWriteFinish (300ms) + grace.
+      while (Date.now() - t0 < 1000) {
+        await new Promise((r) => setTimeout(r, 100));
+      }
+      expect(embedCalls).toBe(1);
+    } finally {
+      await countingBackend.close();
+    }
+  });
+
+  it("boot scan repairs state after a kill mid-edit", async () => {
+    const dir = join(root, "workspaces/ws/memories");
+    await mkdir(dir, { recursive: true });
+    const path = join(dir, "boot-test.md");
+    await writeFile(path, makeMd("boot-test"));
+
+    await until(async () =>
+      (await backend.memoryRepo.findById("boot-test")) ? true : undefined,
+    );
+
+    // Simulate "kill" by closing the backend without giving the watcher a
+    // chance to handle a subsequent external edit. Then write the edit,
+    // then re-open the backend — boot scan should reconcile.
+    await backend.close();
+
+    await writeFile(path, makeMd("boot-test", "Body changed while down."));
+
+    backend = await VaultBackend.create({
+      root,
+      embeddingDimensions: 4,
+      embed: async (text: string) => {
+        const seed = [...text].reduce((a, c) => a + c.charCodeAt(0), 0);
+        return [
+          seed % 100,
+          (seed * 7) % 100,
+          (seed * 13) % 100,
+          (seed * 17) % 100,
+        ];
+      },
+    });
+
+    const ok = await until(async () => {
+      const results = await backend.memoryRepo.search(
+        { query: "body changed while down", limit: 5 },
+        { dims: 4 },
+      );
+      return results.find((r) => r.id === "boot-test") ? true : undefined;
+    });
+    expect(ok).toBe(true);
+  });
+});
+```
+
+(Note on `memoryRepo.search` signature: the call shape above assumes `search(input, opts?)`. If the actual `MemoryRepository.search` signature differs, adapt the test to match — the goal is "memory is findable via vector search after the external edit".)
+
+- [ ] **Step 2: Run the E2E suite**
+
+Run: `npx vitest run tests/integration/vault-watcher-e2e.test.ts`
+Expected: 5 tests PASS within 10s timeout each.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/vault-watcher-e2e.test.ts
+git commit -m "test(vault): Phase 5 E2E smoke for chokidar watcher
+
+Real chokidar + real VaultBackend + tmpdir. Five cases:
+external add becomes searchable, external edit re-embeds,
+external rm archives, internal write doesn't double-reindex,
+boot-scan converges after kill mid-edit. PR-only via the
+testTimeout: 10_000 option."
+```
+
+---
+
+## Task 20: Update predecessor non-vault factories
+
+**Files:**
+
+- Modify: `tests/contract/repositories/_factories.ts` (and any other vault-repo construction site if Task 16 changed signatures)
+
+Goal: any place that constructs `VaultMemoryRepository` or `VaultMemoryFiles` must pass either no `ignoreSet` (defaulting to noop) or `new NoopIgnoreSet()`. Verify nothing breaks.
+
+- [ ] **Step 1: Search for construction sites**
+
+Run: `grep -rn "VaultMemoryRepository.create\|new VaultMemoryFiles" src tests`
+
+- [ ] **Step 2: Update each call site if needed**
+
+Default-arg path means most won't need changes. Only update if the test passes a strict opts object that fails type-check after Task 16.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `npm run test:unit`
+Expected: PASS.
+
+- [ ] **Step 4: Commit (if any test files changed)**
+
+```bash
+git add tests/
+git commit -m "test(vault): pass NoopIgnoreSet through repo factories"
+```
+
+(Skip if nothing changed.)
+
+---
+
+## Task 21: Verification & roadmap update
+
+**Files:**
+
+- Modify: `docs/superpowers/specs/2026-04-21-vault-backend-design.md` — flip Phase 5 row to "Done"
+
+- [ ] **Step 1: Run the full suite + typecheck + lint**
+
+Run: `npm run test:unit && npx tsc --noEmit && npx eslint . --max-warnings=0`
+Expected: all green.
+
+- [ ] **Step 2: Run integration suite if available**
+
+Run: `SKIP_DOCKER_START=1 npm test` (if running in a worktree with the parent docker stack already up — see memory `KV9Pu5pA3AFae-Wg-mpbK`).
+Expected: all integration tests pass; if any failure, diagnose before merging.
+
+- [ ] **Step 3: Update the roadmap row**
+
+Edit `docs/superpowers/specs/2026-04-21-vault-backend-design.md`. Find the row:
+
+```
+| 5     | Chokidar watcher. External edit E2E.                                                                                                   |
+```
+
+Replace with:
+
+```
+| 5     | Chokidar watcher + boot reconcile + parse_error live producer + lance↔markdown drift repair. **Done — #TBD.** |
+```
+
+(Replace `#TBD` with the real PR number once the PR is opened.)
+
+- [ ] **Step 4: Commit roadmap update**
+
+```bash
+git add docs/superpowers/specs/2026-04-21-vault-backend-design.md
+git commit -m "docs(vault): mark roadmap Phase 5 done
+
+Watcher + boot reconcile + parse_error live producer shipped.
+PR number filled in once the PR is opened."
+```
+
+---
+
+## Self-review notes
+
+**Spec coverage check:** Goals 1-4 → Tasks 5-12 (reconciler) + 11-12 (boot scan) + 13-14 (watcher); D2 ignoreSet → Tasks 3-4 + 15-16; D4 event handling → Tasks 5-10; D5 boot reconcile gating → Task 18; D7 testing tiers T1/T2/T3/T4 → Tasks 5-12 / 13-14 / 11-12 / 19. `watcher_error` meta (E4) → Task 17 + Task 18 step 4. PR #37 deferred gap closure (Goal 3) → Task 8 (unlink event handles git-pull deletes). All spec sections accounted for.
+
+**Type consistency check:** `Reconciler` interface defined in Task 6 (`reconcileFile`, `archiveOrphans`); used identically in Tasks 11-14. `IgnoreSet` defined Task 2; same shape used Tasks 3-4, 13-14, 15-16. `BootScanResult` defined Task 2; produced Task 12; consumed Task 18.
+
+**Placeholder scan:** No `TBD` / `TODO` / "fill in details" — Task 19's "stubbed" cases are explicit (named, shape shown). Task 21 has `#TBD` for the PR number, which is unavoidable until the PR is opened.
+
+**Risks / known limits:**
+
+- Task 18 has the most integration friction. If post-Task 16 file diff is large, split into 18a (boot scan only) + 18b (watcher start + close + sessionStart).
+- Reconciler test stubs in Task 5 cast to `as never` for vector-index ops. If the real `VaultVectorIndex` API differs (e.g. `softArchive` doesn't exist as a separate method, only `update {archived:true}`), adapt the stub — adjust the production reconciler to match.
+- E2E test in Task 19 needs polling intervals that are short enough to keep test runtime tight (~1-2s per case). Real chokidar `awaitWriteFinish: 300` plus mtime stat means the absolute floor is ~400ms per state transition. Five cases × ~1s each + setup/teardown should fit in <10s comfortably.
+
+---
+
+**Plan complete and saved to `docs/superpowers/plans/2026-04-25-vault-backend-phase-5-watcher.md`.**

--- a/docs/superpowers/specs/2026-04-25-session-start-payload-index-design.md
+++ b/docs/superpowers/specs/2026-04-25-session-start-payload-index-design.md
@@ -21,8 +21,8 @@ This spec replaces the verbatim-in-preview model with a two-layer design: a comp
 
 **In scope:**
 
-- New response shape for `memory_session_start`: `{ preview: string, full: string, meta }`.
-- Server-side rendering of both the preview index and the full markdown body.
+- New wire shape for `memory_session_start` tool: `{ preview: string, full: string, meta }`.
+- Pure renderers (`renderPreview`, `renderFull`) at the tool boundary; service layer unchanged.
 - Hook-script changes (Claude Code + Copilot CLI): write `full` to a workspace-local file, substitute the path into `preview`, emit `preview` as `additionalContext`.
 - CLAUDE.md / instructions snippet update to reframe `memory_search` as a liberal, task-driven primary lookup.
 - Index-byte budget enforcement with project-scope priority.
@@ -48,7 +48,7 @@ interface SessionStartResponse {
 }
 ```
 
-The legacy `data: MemorySummaryWithRelevance[]` field is removed. This is a breaking change to the `memory_session_start` API. No remote consumers exist; both shipped hooks update in the same PR.
+The legacy `data: MemorySummaryWithRelevance[]` field is removed from the wire response. This is a breaking change to the `memory_session_start` tool/REST API. No remote consumers exist; both shipped hooks update in the same PR. The service layer (`MemoryService.sessionStart`) keeps its existing return type for internal callers and tests.
 
 ### Preview format
 
@@ -163,20 +163,44 @@ Per memory `n86khHlXf88S8Fq4i1NwT`, both `claude-md-snippet.md` and `instruction
 
 ### Server changes
 
-**`src/services/memory-service.ts` — `sessionStart`:**
+Rendering happens at the **tool boundary** (the wire layer), not inside the service. The service's internal `Envelope<MemorySummaryWithRelevance[]>` shape is preserved so existing service-level integration tests and other internal callers stay intact. The wire shape `{ preview, full, meta }` is produced by the tool wrapper.
 
-After existing assembly of `result.data` (ranked + project-scoped, deduped, sorted), call two new pure renderers:
+**New module: `src/utils/session-start-render.ts`** — houses two pure renderers and the byte-budget logic. Pure functions, fully unit-testable without a backend.
 
-- `renderPreview(memories, indexBudget=1500): { text: string; truncatedCount: number }`
-- `renderFull(memories, flags): string`
+```ts
+export interface RenderPreviewResult {
+  text: string; // markdown, ≤ 2KB target
+  truncatedCount: number; // index rows dropped to fit budget
+}
 
-Return `{ preview, full, meta }` instead of `{ data, meta }`. Set `meta.index_truncated_count` from the preview renderer.
+export function renderPreview(
+  memories: MemorySummaryWithRelevance[],
+  indexBudget?: number, // bytes; default 1500
+): RenderPreviewResult;
 
-**New module: `src/utils/session-start-render.ts`** — houses both renderers and the byte-budget logic. Pure functions, fully unit-testable without a backend.
+export function renderFull(
+  memories: MemorySummaryWithRelevance[],
+  flags?: FlagResponse[],
+): string;
+```
+
+**`src/services/memory-service.ts`** — unchanged. `sessionStart()` continues to return `Envelope<MemorySummaryWithRelevance[]>` populated as today (ranked + project-scoped, deduped, sorted), with flags + team_activity in meta.
+
+**`src/tools/memory-session-start.ts`** — after calling `memoryService.sessionStart(...)`, calls `renderPreview` + `renderFull` and constructs the wire-shape response:
+
+```ts
+const envelope = await memoryService.sessionStart(...);
+const previewResult = renderPreview(envelope.data);
+const full = renderFull(envelope.data, envelope.meta.flags);
+const meta = { ...envelope.meta, index_truncated_count: previewResult.truncatedCount };
+return toolResponse({ preview: previewResult.text, full, meta });
+```
+
+**`src/routes/api-tools.ts`** — the REST hook endpoint for `memory_session_start` mirrors the same wrapping (the hook scripts hit the REST endpoint, not MCP). Both paths must produce identical wire shape.
 
 **`src/types/envelope.ts`** — add `index_truncated_count?: number` to `EnvelopeCoreMeta`.
 
-**`src/tools/memory-session-start.ts`** — output schema documentation updated; no logic change beyond field-name plumbing.
+**No new top-level type for `SessionStartResponse`** — the wire shape lives only in the tool wrapper. If consumers need a TypeScript type, export it from `src/utils/session-start-render.ts`.
 
 ### Reliability and fallbacks
 

--- a/docs/superpowers/specs/2026-04-25-session-start-payload-index-design.md
+++ b/docs/superpowers/specs/2026-04-25-session-start-payload-index-design.md
@@ -1,0 +1,231 @@
+# Session-Start Payload: Index + Persisted-File Design
+
+**Status:** design (pre-implementation)
+**Date:** 2026-04-25
+**Author:** chris
+
+## Purpose
+
+The current `memory_session_start` response (~40KB for 21 memories in this workspace) overflows Claude Code's ~2KB `additionalContext` preview budget. Memories beyond the first ~2KB are persisted to a tool-results file but are not auto-read, so they silently fall out of the model's context (memory `UhPeYgeER8c0Zaqqiny9Q`). As project-scope rules grow (currently 11 memories, ~7.5KB verbatim), no field-pruning or body-truncation strategy can keep verbatim load within the preview cap.
+
+This spec replaces the verbatim-in-preview model with a two-layer design: a compact title-only index in the preview, plus a full-content file written by the hook that the agent is forced to `Read` as its first action. Per-task memory retrieval shifts toward `memory_search` calls driven by the index and updated CLAUDE.md guidance.
+
+## Drivers
+
+1. **Eliminate silent memory loss at session start.** Today, memories past the 2KB preview boundary are invisible to the agent unless it knows to look for them. Replace "best-effort fit" with "guaranteed delivery via forced file read".
+2. **Scale with workspace size.** Workspaces accumulate project-scope rules and ranked workspace/user memories. The transport must not degrade as N grows.
+3. **Make memory retrieval task-driven, not session-driven.** Reinforce `memory_search` as the primary lookup mechanism for in-task knowledge. Session start surfaces topics, not content.
+4. **Keep cross-harness symmetry.** Claude Code and Copilot CLI share the same protocol — no harness-specific persistence path or shape branching.
+
+## Scope
+
+**In scope:**
+
+- New response shape for `memory_session_start`: `{ preview: string, full: string, meta }`.
+- Server-side rendering of both the preview index and the full markdown body.
+- Hook-script changes (Claude Code + Copilot CLI): write `full` to a workspace-local file, substitute the path into `preview`, emit `preview` as `additionalContext`.
+- CLAUDE.md / instructions snippet update to reframe `memory_search` as a liberal, task-driven primary lookup.
+- Index-byte budget enforcement with project-scope priority.
+
+**Out of scope:**
+
+- Schema changes to memories (no `pinned` field, no body summaries).
+- Consolidation-driven body shortening.
+- New JIT mechanisms beyond the existing PreToolUse autofill (e.g., a UserPromptSubmit semantic-search hook). Considered, deferred.
+- Backwards-compatibility shims. Deployment is local; breaking change is acceptable.
+
+## Design
+
+### Response shape
+
+`memory_session_start` returns an envelope with three top-level fields:
+
+```ts
+interface SessionStartResponse {
+  preview: string; // markdown, ≤ ~2KB; goes into additionalContext
+  full: string; // markdown, no cap; written to disk by hook
+  meta: EnvelopeMeta; // existing meta + new fields below
+}
+```
+
+The legacy `data: MemorySummaryWithRelevance[]` field is removed. This is a breaking change to the `memory_session_start` API. No remote consumers exist; both shipped hooks update in the same PR.
+
+### Preview format
+
+Markdown, server-rendered. Layout:
+
+```
+IMPORTANT — full memories are NOT in this preview.
+Index below shows N memories. Full bodies at:
+{{PATH}}
+
+You MUST Read this file before responding to the user's
+first message. Do not proceed without it.
+
+## Memory index
+
+- <id> [<scope>] <type> — <title>
+- <id> [<scope>] <type> — <title>
+...
+
+Search guidance: see your memory instructions
+(CLAUDE.md / agent-brain snippet).
+```
+
+Each index row carries `id`, `scope`, `type`, `title` (decision **I3**). Estimated row size ≈ 80 bytes. Under the 1.5KB index cap (see Index byte budget below), ~18 rows fit; the remaining ~500 bytes of the 2KB preview hold the surrounding instructions.
+
+`{{PATH}}` is a literal placeholder string in the server response. The hook substitutes the actual file path before emitting `additionalContext`. The placeholder lives in the server output (not the hook) so server-side tests can assert preview rendering without mocking the filesystem.
+
+### Index byte budget
+
+Server caps the index portion at 1.5KB, leaving ~500 bytes for the surrounding instructions. When index rows exceed the cap:
+
+1. Always include all `scope=project` rows (global rules cannot be silently truncated — same invariant as today's `project_truncated` flag).
+2. Drop lowest-relevance non-project rows until under budget.
+3. Set `meta.index_truncated_count` to the number of dropped rows.
+
+The persisted file is unaffected — it always contains every memory the server returned.
+
+### Persisted file
+
+Markdown, no length cap. One section per memory. Format per memory:
+
+```
+## <title>
+
+- **id:** <id>
+- **scope:** <scope> · **type:** <type> · **author:** <author>
+- **created:** <date> · **updated:** <date> · **verified:** <date|none>
+- **tags:** <comma-separated>
+
+<content>
+```
+
+Sections grouped by scope (`## project rules`, `## workspace memories`, `## user memories`) for scan-friendliness. Order within group: relevance descending.
+
+If `meta.flags` is non-empty, an additional `## flags` section enumerates each flag with the related memory id and reason — agent treats this as actionable.
+
+Markdown chosen over JSON: agent reads file once into context; markdown is more token-dense (no key repetition, no escaping) and easier for the agent to scan and quote back. JSON is unnecessary because no script consumes the file.
+
+### File path
+
+`<workspace>/.agent-brain/session.md`
+
+- Workspace-local, single file overwritten per session.
+- Visible in the user's repo for debugging.
+- Requires `.agent-brain/` to be in `.gitignore`. Hook (or installer) ensures the entry exists; if not, hook appends it.
+
+Rationale: workspace-local beats `/tmp` for visibility and survives across machines if the user is debugging across reboots. Single-file overwrite avoids cleanup logic. The user explicitly chose this option.
+
+### Hook script flow
+
+Both `hooks/claude/memory-session-start.sh` and `hooks/copilot/memory-session-start.sh`:
+
+1. POST `/api/tools/memory_session_start`.
+2. On failure (server unreachable, HTTP error, empty body): emit existing fallback `additionalContext`. Do not write file.
+3. On success:
+   a. Ensure `<cwd>/.agent-brain/` directory exists; ensure `.agent-brain/` is in `<cwd>/.gitignore` (append if missing).
+   b. Write `response.full` to `<cwd>/.agent-brain/session.md` (overwrite).
+   c. Substitute `{{PATH}}` in `response.preview` with the absolute file path.
+   d. Emit substituted preview as `additionalContext` (Claude wraps in `hookSpecificOutput`; Copilot emits both flat + wrapped envelopes — current pattern preserved).
+
+### CLAUDE.md / instructions-snippet update
+
+The existing "When to Call `memory_search`" section is restrictive ("only before shared-system actions; not for local actions"). The new design requires a more liberal policy. Replace with:
+
+```
+### Working with Loaded Memories
+
+Session start delivers a TITLE-ONLY index of available memories
+plus a forced read of `<workspace>/.agent-brain/session.md` for
+full bodies. The agent should already have read this file by the
+time it answers the first message.
+
+### When to Call `memory_search`
+
+Call `memory_search` whenever:
+- The user's task touches a topic that overlaps an index title.
+- You are reasoning about an unfamiliar area of the codebase or
+  domain — even if no index entry obviously matches.
+- You are about to take an action that affects shared systems
+  (deploys, migrations, credentials, etc.).
+
+Prefer false positives over misses. Searches are cheap; missing a
+load-bearing memory is expensive.
+
+For a specific entry by id, use `memory_get`.
+
+Do NOT search for purely local actions (file edits, installs,
+linting, formatting) unless the index suggests a relevant memory.
+```
+
+Per memory `n86khHlXf88S8Fq4i1NwT`, both `claude-md-snippet.md` and `instructions-snippet.md` update in the same PR. Run `diff` of the two snippets after edit; only intentional differences (framing, copilot-specific hook refs) should remain.
+
+### Server changes
+
+**`src/services/memory-service.ts` — `sessionStart`:**
+
+After existing assembly of `result.data` (ranked + project-scoped, deduped, sorted), call two new pure renderers:
+
+- `renderPreview(memories, indexBudget=1500): { text: string; truncatedCount: number }`
+- `renderFull(memories, flags): string`
+
+Return `{ preview, full, meta }` instead of `{ data, meta }`. Set `meta.index_truncated_count` from the preview renderer.
+
+**New module: `src/utils/session-start-render.ts`** — houses both renderers and the byte-budget logic. Pure functions, fully unit-testable without a backend.
+
+**`src/types/envelope.ts`** — add `index_truncated_count?: number` to `EnvelopeCoreMeta`.
+
+**`src/tools/memory-session-start.ts`** — output schema documentation updated; no logic change beyond field-name plumbing.
+
+### Reliability and fallbacks
+
+- **Agent skips the Read.** Mitigated by (1) explicit "MUST Read before responding" instruction in preview, and (2) CLAUDE.md guidance loaded earlier in context. If the agent still skips, the index alone gives it enough surface to call `memory_search`/`memory_get` reactively. Worst case degrades to today's behavior, not worse.
+- **Server unreachable.** Hook emits existing fallback `additionalContext` ("session_start did not succeed — call memory_search explicitly"). No file written.
+- **Disk write fails.** Hook detects, emits fallback. Logs reason to stderr.
+- **`.gitignore` write race.** Hook checks-then-appends; not atomic, but `.gitignore` writes are idempotent (adding `.agent-brain/` twice is benign — git deduplicates).
+
+## Testing
+
+Unit:
+
+- `renderPreview`: row count under/at/over budget; project-scope-priority drop order; truncated-count accounting; `{{PATH}}` placeholder present exactly once.
+- `renderFull`: section grouping; flag section present iff flags non-empty; ordering within group.
+- New `meta.index_truncated_count` populated correctly.
+
+Integration (REST hook API):
+
+- POST `/api/tools/memory_session_start` returns shape `{preview, full, meta}` with no legacy `data` field.
+- Preview byte length within budget for synthetic 100-memory workspace.
+
+Hook (manual / scripted):
+
+- `echo '{"cwd":"/tmp/test-ws"}' | hooks/claude/memory-session-start.sh` writes `/tmp/test-ws/.agent-brain/session.md`, appends `.agent-brain/` to `/tmp/test-ws/.gitignore` if absent, and emits `additionalContext` containing the absolute path.
+- Same flow for `hooks/copilot/memory-session-start.sh`.
+- Output size sanity: `wc -c` of the emitted `additionalContext` line stays under ~2.2KB across realistic workspace sizes.
+
+Snippet sync:
+
+- `diff hooks/copilot/instructions-snippet.md hooks/claude/claude-md-snippet.md` after edit shows only known-intentional differences.
+
+## Migration
+
+Single PR:
+
+1. Add `renderPreview`, `renderFull`, types, service-method change, tool-schema doc update.
+2. Update both hook scripts.
+3. Update both snippets.
+4. Update tests.
+5. Manually verify in a fresh Claude Code session: agent reads `<workspace>/.agent-brain/session.md` before first response.
+
+No deprecation window. Local-only deployment.
+
+## Open Questions
+
+None at design time. All major decisions resolved in brainstorming session 2026-04-25.
+
+## Non-Goals (deferred)
+
+- **JIT semantic search via UserPromptSubmit hook.** Worth considering after the index design proves itself; would inject task-relevant memories per prompt, reducing reliance on the index. Defer until usage shows the index isn't enough.
+- **Memory body summaries / consolidation-driven shortening.** No mechanism exists today; speculative ROI.
+- **`pinned` schema field.** Today's `scope=project` already serves "must always load" semantics. Revisit if a finer distinction emerges.

--- a/docs/superpowers/specs/2026-04-25-vault-backend-phase-5-watcher-design.md
+++ b/docs/superpowers/specs/2026-04-25-vault-backend-phase-5-watcher-design.md
@@ -8,10 +8,10 @@
 
 ## Goals
 
-1. **Watcher.** Detect external edits to `<vault>/**/*.md` (Obsidian saves, vim writes, `git pull` checkouts) and reconcile lance vector index + in-memory path index + parse-error sidecars.
+1. **Watcher.** Detect external edits to `<vault>/**/*.md` (Obsidian saves, vim writes, `git pull` checkouts) and reconcile lance vector index + `VaultIndex` (path/id map + unindexable list) + open `parse_error` flags.
 2. **Boot reconcile.** Run a vault-wide pre-listen scan that brings lance and in-memory state into agreement with disk before HTTP accepts requests. Repairs lance↔markdown drift left over from any earlier crash.
 3. **Subsume PR #37 deferred gap.** `VaultMemoryRepository.syncPaths` previously added pulled paths to the in-memory index but did not remove deletions. Watcher's `unlink` event subsumes this — no separate `syncPaths` patch needed.
-4. **Close Phase 4d live-edit gap.** Phase 4d `parse_error` sidecar producer ran startup-only (memory `9Hjd5H76LXM-sk189lszP`). Watcher gives a live signal source so external edits that break frontmatter surface as flags without restart.
+4. **Close Phase 4d live-edit gap.** Phase 4d `parse_error` flag producer (`VaultParseErrorChecker` in `src/backend/vault/parse-error-checker.ts`) only ran during consolidation, not on live edits. Watcher gives a live signal source so external edits that break frontmatter surface as flags / `unindexable` entries without restart.
 
 Non-goals: see "Non-Goals" section.
 
@@ -43,15 +43,17 @@ chokidar's built-in stable-write detection. Coalesces Obsidian autosave bursts a
 
 ### D4. Per-event handling
 
-| chokidar event                        | Action                                                                                                                                                                                                                                  |
-| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `add`                                 | Parse → embed → `vectorIndex.upsert` → `memoryRepo.indexAdd` → archive any stale `parse_error` sidecar for path                                                                                                                         |
-| `change`                              | Parse → compare body hash to lance `content_hash`. Hash matches: only `vectorIndex.upsertMetaOnly` if frontmatter changed (else skipped). Hash differs: full re-embed + `vectorIndex.upsert`. Always: archive stale parse_error sidecar |
-| `unlink`                              | `memoryRepo.findByPath(absPath)` → soft-archive lance row (`archived = true` flip per Phase 3 semantic, memory `GKep85Rl4NGJbnTScVXNz`) → `memoryRepo.indexRemove` → archive any sidecars for path                                      |
-| `unlinkDir`                           | Iterate cached entries under prefix → soft-archive each                                                                                                                                                                                 |
-| `addDir` / `ready`                    | No-op (initial scan handled by `runBootScan`)                                                                                                                                                                                           |
-| Parse failure on any event            | `flagRepo.upsertParseErrorSidecar(absPath, err)` (Phase 4d helper, idempotent via O_EXCL)                                                                                                                                               |
-| Parse pass on previously-flagged path | Auto-archive sidecar (Phase 4d auto-resolution semantic)                                                                                                                                                                                |
+| chokidar event                                  | Action                                                                                                                                                                                                                                                        |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `add`                                           | Parse → if id resolves: embed → `vectorIndex.upsert` → `vaultIndex.register(id, entry)` + clear any `unindexable` for path; else: `vaultIndex.setUnindexable(path, reason)`                                                                                   |
+| `change`                                        | Parse → compare body hash to lance `content_hash`. Hash matches: only `vectorIndex.upsertMetaOnly` if frontmatter changed (else `skipped`). Hash differs: full re-embed + `vectorIndex.upsert`. Always: resolve any open `parse_error` flag for the memory id |
+| `unlink`                                        | `vaultIndex` reverse-lookup absPath → memoryId. If found: `vectorIndex` soft-archive (`archived = true` flip per memory `GKep85Rl4NGJbnTScVXNz`) → `vaultIndex.unregister(id)` → resolve any open `parse_error` flag for that id                              |
+| `unlinkDir`                                     | Iterate `vaultIndex.entries()` under prefix → apply unlink action per entry                                                                                                                                                                                   |
+| `addDir` / `ready`                              | No-op (initial scan handled by `runBootScan`)                                                                                                                                                                                                                 |
+| Parse failure on any event, file already in idx | `flagService.createFlag(memoryId, "parse_error", reason)` if no open one exists (Phase 4d producer logic)                                                                                                                                                     |
+| Parse failure, file NOT in idx                  | `vaultIndex.setUnindexable(path, reason)` — surfaces in `BackendSessionStartMeta.parse_errors` next sessionStart                                                                                                                                              |
+| Parse pass on previously-flagged file           | Auto-resolve any open `parse_error` flag for the memory id (Phase 4d auto-resolution semantic)                                                                                                                                                                |
+| Parse pass on previously-unindexable path       | `vaultIndex.clearUnindexable(path)` — file recovered                                                                                                                                                                                                          |
 
 ### D5. Boot reconcile = explicit pre-listen scan (Q5 / B)
 
@@ -82,7 +84,7 @@ Reasoning: separation of concerns — chokidar wiring (watcher) vs business logi
 - **T3 boot-scan unit tests** (real fs tmpdir, stub reconciler) — cover counts, parse failures during scan, lance orphan detection.
 - **T4 E2E smoke** (real chokidar + real backend + tmpdir) — five cases only; PR-only with `--testTimeout=10000`.
 
-Tier 5 (existing contract tests) unchanged; watcher is additive. Optionally extend `users-gitignore-invariant.test.ts` to assert watcher does not emit user-scope content via flag sidecars.
+Tier 5 (existing contract tests) unchanged; watcher is additive. Optionally extend `users-gitignore-invariant.test.ts` to assert watcher does not surface user-scope content in `parse_error` flag reasons or unindexable entries.
 
 ## Architecture
 
@@ -134,10 +136,10 @@ export interface Reconciler {
 }
 
 export function createReconciler(deps: {
-  parser: MemoryParser;
-  memoryRepo: VaultMemoryRepository;
-  vectorIndex: VaultVectorIndex;
-  flagRepo: VaultFlagRepository;
+  vaultIndex: VaultIndex; // path/id map + unindexable list
+  vectorIndex: VaultVectorIndex; // lance upsert/softArchive/upsertMetaOnly + content_hash compare
+  flagService: FlagService; // createFlag / resolveFlag / hasOpenFlag for parse_error
+  embed: Embedder; // (text) => Promise<number[]>; same provider VaultBackend uses
   vaultRoot: string;
 }): Reconciler;
 ```
@@ -172,46 +174,56 @@ export async function runBootScan(opts: {
 }>;
 ```
 
-### Wiring in `VaultBackend.start()`
+### Wiring in `VaultBackend.create()`
+
+`VaultBackend.create()` is already the async lifecycle entry point in `src/backend/vault/index.ts`. Boot scan + watcher start fold into it; `httpServer.listen()` (in `src/server.ts`) only runs after `create()` resolves, so the gate is satisfied naturally.
 
 ```
-1. ensureVaultGit()                           # existing
-2. alignWithRemote()                          # existing (Phase 4b)
-3. runBootScan()                              # new — blocks until consistent
-4. watcher.start()                            # new — resolves on chokidar 'ready'
-5. httpServer.listen()                        # existing — only after 1-4 complete
+VaultBackend.create():
+  1. ensureVaultGit()                          # existing
+  2. ensureRemote() → reconcileDirty() → alignWithRemote()  # existing (Phase 4b)
+  3. VaultVectorIndex.create()                 # existing
+  4. VaultIndex.create()                       # existing
+  5. VaultMemoryRepository.create()            # existing
+  6. runBootScan(reconciler, vaultIndex, vectorIndex)  # new — blocks until consistent
+  7. createVaultWatcher(...).start()           # new — resolves on chokidar 'ready'
+  8. return new VaultBackend(...)              # caller (server.ts) then listen()s
 ```
+
+`VaultBackend` gains a `vaultWatcher: VaultWatcher` private field. `close()` adds `await this.vaultWatcher.stop()` BEFORE `pushQueue.close()` (watcher might enqueue commits via reconciler-triggered writes; drain pushQueue last).
 
 ### Mutation-site changes
 
 - `VaultMemoryFiles.edit` (`src/backend/vault/repositories/memory-files.ts`) — accept optional `ignoreSet: IgnoreSet` ctor param. Post-fsync inside `edit()`: read mtime of written file, call `ignoreSet.add(absPath, mtime)`, schedule `ignoreSet.releaseAfter(absPath, 500)` after the commit completes.
-- `VaultMemoryRepository` — same plumbing for archive (unlink path). Add `findByPath(absPath): MemoryRecord | undefined` if not already present. Add `indexAdd(record)` and `indexRemove(absPath)` methods so reconciler can sync the in-memory map without going through `create`/`archive` (which re-trigger commit + lance write — double work).
+- `VaultMemoryRepository` write paths (`create`, `update`, `archive`, `verify`) — same `ignoreSet` plumbing for the markdown write step. Optional ctor param defaulting to `NoopIgnoreSet`. No new public methods needed — reconciler uses `VaultIndex` directly (`register` / `unregister` / `entries` / `setUnindexable` / `clearUnindexable` already exist).
+- Reverse path → id lookup for `unlink` events: iterate `vaultIndex.entries()` matching `entry.path === relPath`. O(N) but small N at vault scale; avoids new index. If profiling shows hotspot, add a reverse map later.
 - `GitOpsImpl.stageAndCommit` callers — no direct change; commits update markdown mtime which is captured at `edit()` post-fsync.
 - `src/backend/types.ts` — extend `BackendSessionStartMeta` with `watcher_error?: true` (literal-`true` presence-only convention per memory `bONZKfXKa_cv4a2s0I2NV`).
-- `package.json` — confirm `chokidar` dependency (likely already transitively available; verify at plan time).
+- `package.json` — add `chokidar` dependency (not currently listed; need explicit add).
 
 ## Data flow
 
 ### Boot path
 
 ```
-VaultBackend.start()
+VaultBackend.create()
   ├─ ensureVaultGit()
-  ├─ alignWithRemote()
+  ├─ ensureRemote() → reconcileDirty() → alignWithRemote()
+  ├─ VaultVectorIndex.create() / VaultIndex.create() / VaultMemoryRepository.create()
   ├─ runBootScan()
   │    ├─ listMarkdownFiles(vaultRoot) → diskPaths
   │    ├─ for each path:
   │    │     reconciler.reconcileFile(path, "add")
   │    │       ├─ parser.parse(content)
   │    │       │     ├─ ok    → diff lance content_hash
-  │    │       │     │           ├─ no row     → embed + lance.upsert + memoryRepo.indexAdd + flag.archiveStaleSidecar
-  │    │       │     │           ├─ hash same  → if frontmatter changed → lance.upsertMetaOnly; else skipped
-  │    │       │     │           └─ hash diff  → embed + lance.upsert + flag.archiveStaleSidecar
-  │    │       │     └─ fail  → flag.upsertParseErrorSidecar(path, err)
+  │    │       │     │           ├─ no row     → embed + lance.upsert + vaultIndex.register + flagService.resolve(open parse_error flags)
+  │    │       │     │           ├─ hash same  → if frontmatter changed → lance.upsertMetaOnly; else skipped. flagService.resolve(open parse_error flags)
+  │    │       │     │           └─ hash diff  → embed + lance.upsert + flagService.resolve(open parse_error flags)
+  │    │       │     └─ fail  → if id-in-vaultIndex: flagService.createFlag(id, "parse_error", reason); else: vaultIndex.setUnindexable(path, reason)
   │    └─ reconciler.archiveOrphans(diskPaths)
-  │          └─ lance.scan archived=false → for each row: if row.path ∉ diskPaths → lance.update {archived:true} + memoryRepo.indexRemove
-  ├─ watcher.start()
-  └─ httpServer.listen()
+  │          └─ lance.scan archived=false → for each row: if row.path ∉ diskPaths → lance.update {archived:true} + vaultIndex.unregister(id)
+  ├─ watcher.start()                  # chokidar watch + ready
+  └─ return new VaultBackend(...)     # caller does httpServer.listen()
 ```
 
 ### Live path (post-`ready`)
@@ -224,9 +236,9 @@ External edit (Obsidian save / git pull checkout / vim write)
        if ignoreSet.has(absPath, currentMtime): return    # internal write, skip
        reconciler.reconcileFile(absPath, signal)
          add/change → same logic as boot path
-         unlink    → memoryId = memoryRepo.findByPath(absPath)
-                     if found: lance.update {archived:true} + memoryRepo.indexRemove + flag.archiveSidecarsForPath
-                     if not:  no-op (orphan event for unknown path)
+         unlink    → memoryId = vaultIndex reverse-lookup of absPath (iterate entries)
+                     if found: lance.update {archived:true} + vaultIndex.unregister(id) + flagService.resolve(open parse_error flags)
+                     if not:  vaultIndex.clearUnindexable(path) (in case it was unindexable) → no-op otherwise
 ```
 
 ### Internal write path (existing tools, augmented)
@@ -261,11 +273,11 @@ memory_create / memory_update / memory_archive
 
 ## Error handling
 
-- **E1. Parse failure during reconcile.** Reconciler catches `MemoryParseError` only. `flagRepo.upsertParseErrorSidecar` (idempotent via O_EXCL); returns `{action: "parse-error"}`. Other thrown errors (EACCES, EIO) → `logger.error` + rethrow; watcher catches at dispatch level + logs; does NOT crash watcher. Boot scan catches per-file + accumulates count → reported in return. If `parseErrors > 0`, `BackendSessionStartMeta.parse_errors` carries forward (existing Phase 4b plumbing).
+- **E1. Parse failure during reconcile.** Reconciler catches parse errors only (raw `Error` from `parseMemoryFile`). Two branches: (a) memoryId resolvable from prior parse → `flagService.createFlag(id, "parse_error", reason)` if no open one exists; idempotency via Phase 4d duplicate-flag guard. (b) memoryId NOT resolvable (frontmatter completely broken) → `vaultIndex.setUnindexable(path, reason)`; surfaces via `BackendSessionStartMeta.parse_errors` on next `sessionStart`. Returns `{action: "parse-error"}`. Other thrown errors (EACCES, EIO) → `logger.error` + rethrow; watcher catches at dispatch + logs; does NOT crash watcher. Boot scan accumulates count → reported in return.
 - **E2. Lance write failure during reconcile.** Markdown is source of truth (memory `GKep85Rl4NGJbnTScVXNz`). Lance failure → `logger.error` + result `{action: "skipped", reason: "lance-failure"}`. In-memory index NOT updated. Next chokidar event on same path retries; if file unchanged, no event → drift persists until next process boot via `runBootScan`. Live drift recovery deferred (Phase 8 perf+reliability).
 - **E3. Embed call failure (Ollama down).** Same as E2: log + skip. Boot scan does NOT block startup on embed failure — log + skip + continue. Boot return reports `embedErrors: N`. HTTP comes up; affected memories searchable but with stale embeddings. Acceptable degradation.
 - **E4. chokidar internal error.** chokidar's `error` event → `logger.error`. Do NOT auto-restart watcher (silent failure risk). Surface via `BackendSessionStartMeta.watcher_error?: true`.
-- **E5. Sidecar write failure during parse_error path.** `flagRepo` write fails (disk full / permission). Log + continue reconcile. parse_error visibility lost for that file until next reconcile attempt. No cascade.
+- **E5. Flag write failure during parse_error path.** `flagService.createFlag` throws (disk full / pg failure on shared envelope). Log + continue reconcile. parse_error visibility lost for that file until next reconcile attempt. No cascade.
 - **E6. ignoreSet false negative.** Watcher reconciles a file we just wrote. Cost: one wasted parse + hash compare → hash matches lance → `skipped`. Idempotent, low cost.
 - **E7. ignoreSet false positive.** External edit lands during ignoreSet window with mtime != recorded. R2 mtime tuple catches → fall through to reconcile.
 
@@ -281,8 +293,9 @@ memory_create / memory_update / memory_archive
 - `change`: hash diff → `reembedded`
 - `unlink`: existing → `archived` + index remove
 - `unlink`: unknown path → no-op
-- parse fail → sidecar upsert + result `parse-error`
-- parse pass on previously-flagged path → sidecar archived
+- parse fail with id resolvable → `flagService.createFlag` called (mock asserts) + result `parse-error`
+- parse fail with id NOT resolvable → `vaultIndex.setUnindexable` called + result `parse-error`
+- parse pass on previously-flagged file → `flagService.resolveFlag` called for each open `parse_error` flag
 - `archiveOrphans`: lance has 3 rows, disk has 2 paths → 1 archived
 - lance failure during upsert → `skipped/lance-failure`, no index mutation
 
@@ -318,7 +331,7 @@ memory_create / memory_update / memory_archive
 
 ### T5 — Existing contract tests
 
-Unchanged. Optionally extend `tests/contract/repositories/users-gitignore-invariant.test.ts` to assert watcher does not emit user-scope content via flag sidecars.
+Unchanged. Optionally extend `tests/contract/repositories/users-gitignore-invariant.test.ts` to assert watcher does not surface user-scope content in flag reasons or unindexable entries.
 
 ## Non-Goals
 

--- a/docs/superpowers/specs/2026-04-25-vault-backend-phase-5-watcher-design.md
+++ b/docs/superpowers/specs/2026-04-25-vault-backend-phase-5-watcher-design.md
@@ -1,0 +1,344 @@
+# Vault Backend Phase 5 — Chokidar Watcher + External Edit E2E
+
+**Status:** Design approved 2026-04-25. Ready for implementation plan.
+
+**Roadmap source:** `docs/superpowers/specs/2026-04-21-vault-backend-design.md` line 458 — "Chokidar watcher. External edit E2E."
+
+**Predecessor phases:** 4a (#34, git write path), 4b (#37, push queue + pull), 4c (#39, audit + merge driver), 4d (#41, parse-error flags + perf benchmarks). Main is clean baseline as of commit `dab283d` (PR #42, null-stripping replacer).
+
+## Goals
+
+1. **Watcher.** Detect external edits to `<vault>/**/*.md` (Obsidian saves, vim writes, `git pull` checkouts) and reconcile lance vector index + in-memory path index + parse-error sidecars.
+2. **Boot reconcile.** Run a vault-wide pre-listen scan that brings lance and in-memory state into agreement with disk before HTTP accepts requests. Repairs lance↔markdown drift left over from any earlier crash.
+3. **Subsume PR #37 deferred gap.** `VaultMemoryRepository.syncPaths` previously added pulled paths to the in-memory index but did not remove deletions. Watcher's `unlink` event subsumes this — no separate `syncPaths` patch needed.
+4. **Close Phase 4d live-edit gap.** Phase 4d `parse_error` sidecar producer ran startup-only (memory `9Hjd5H76LXM-sk189lszP`). Watcher gives a live signal source so external edits that break frontmatter surface as flags without restart.
+
+Non-goals: see "Non-Goals" section.
+
+## Decisions
+
+### D1. Scope = full closure (Q1 / D)
+
+Phase 5 ships watcher + boot reindex + parse_error live coupling in one cycle. Reasoning: watcher is the single natural producer of "file changed" reactions; splitting these into separate phases re-touches the same code path multiple times. Phase 3 `content_hash` skip and Phase 4d `parse_error` resurface fall out for free once watcher exists.
+
+### D2. Self-write filtering = in-flight ignore set with mtime tuple (Q2 / A + R2 refinement)
+
+A `Set<absPath, mtimeAfterWrite>` is maintained by mutation sites. Watcher callback checks `ignoreSet.has(absPath)`:
+
+- Path absent → reconcile (external edit).
+- Path present, file's current mtime equals recorded mtime → skip (our own write).
+- Path present, current mtime differs → fall through to reconcile (external edit collided with our write window).
+
+Entries are released after a grace window post-fsync (`stabilityThreshold + 200ms` = 500ms default).
+
+Rejected alternatives: hash coalesce (parses every internal write — wasteful), naive mtime stamp (collisions on FS with 1ms granularity), unwatch/rewatch (chokidar internal cost; missed external events during window).
+
+### D3. Debounce = chokidar `awaitWriteFinish` (Q3 / A)
+
+```
+{ stabilityThreshold: 300, pollInterval: 100 }
+```
+
+chokidar's built-in stable-write detection. Coalesces Obsidian autosave bursts and editor-flush bursts into one `change` event per logical edit. Latency floor of 300ms post-edit until reindex; acceptable for human-edit path. Internal writes skipped via D2 — `awaitWriteFinish` only matters for external edits.
+
+### D4. Per-event handling
+
+| chokidar event                        | Action                                                                                                                                                                                                                                  |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `add`                                 | Parse → embed → `vectorIndex.upsert` → `memoryRepo.indexAdd` → archive any stale `parse_error` sidecar for path                                                                                                                         |
+| `change`                              | Parse → compare body hash to lance `content_hash`. Hash matches: only `vectorIndex.upsertMetaOnly` if frontmatter changed (else skipped). Hash differs: full re-embed + `vectorIndex.upsert`. Always: archive stale parse_error sidecar |
+| `unlink`                              | `memoryRepo.findByPath(absPath)` → soft-archive lance row (`archived = true` flip per Phase 3 semantic, memory `GKep85Rl4NGJbnTScVXNz`) → `memoryRepo.indexRemove` → archive any sidecars for path                                      |
+| `unlinkDir`                           | Iterate cached entries under prefix → soft-archive each                                                                                                                                                                                 |
+| `addDir` / `ready`                    | No-op (initial scan handled by `runBootScan`)                                                                                                                                                                                           |
+| Parse failure on any event            | `flagRepo.upsertParseErrorSidecar(absPath, err)` (Phase 4d helper, idempotent via O_EXCL)                                                                                                                                               |
+| Parse pass on previously-flagged path | Auto-archive sidecar (Phase 4d auto-resolution semantic)                                                                                                                                                                                |
+
+### D5. Boot reconcile = explicit pre-listen scan (Q5 / B)
+
+`runBootScan` iterates `listMarkdownFiles(vaultRoot)`, calls `reconcileFile(path, "add")` per file, then queries lance for paths-not-on-disk and archives them. `httpServer.listen()` does not run until the scan completes.
+
+chokidar starts after the scan with `ignoreInitial: true` — only live events trigger callbacks.
+
+Reasoning: explicit phase boundary makes HTTP readiness clear. Otherwise the first request after restart could read stale lance results. Orphan detection (lance row whose path no longer exists on disk) is trivial in an explicit scan; would require a separate post-`ready` sweep with `ignoreInitial: false`. The Phase 4d `parse_error` startup-scan is just a special case of the boot reconcile and folds in naturally.
+
+### D6. Module boundary = three modules (approach 3)
+
+```
+src/backend/vault/watcher/
+├── reconciler.ts     # pure-ish: reconcileFile(absPath, signal) + archiveOrphans
+├── watcher.ts        # chokidar wrapper + ignore set
+├── boot-scan.ts      # walks vault, calls reconciler, archives orphans
+└── types.ts          # WatcherSignal, ReconcileResult, IgnoreSet
+```
+
+Reconciler depends on parser, memoryRepo, vectorIndex, flagRepo. Does NOT depend on chokidar. Watcher depends on chokidar + reconciler. Boot scan depends on reconciler + `listMarkdownFiles`.
+
+Reasoning: separation of concerns — chokidar wiring (watcher) vs business logic (reconciler). Reconciler is reusable for boot-scan and live-event paths. Unit tests don't touch chokidar; matches Phase 4d pattern of separating producer logic from invocation site.
+
+### D7. Test strategy = tiered, four tiers (Q6 / D)
+
+- **T1 reconciler unit tests** (synchronous, mock deps) — cover all per-event branches in D4 + parse failures + lance failures + orphan archive.
+- **T2 watcher unit tests** (mock chokidar via EventEmitter stub) — cover ignoreSet semantics, mtime-tuple R2 case, error-event handling, shutdown-awaits-in-flight.
+- **T3 boot-scan unit tests** (real fs tmpdir, stub reconciler) — cover counts, parse failures during scan, lance orphan detection.
+- **T4 E2E smoke** (real chokidar + real backend + tmpdir) — five cases only; PR-only with `--testTimeout=10000`.
+
+Tier 5 (existing contract tests) unchanged; watcher is additive. Optionally extend `users-gitignore-invariant.test.ts` to assert watcher does not emit user-scope content via flag sidecars.
+
+## Architecture
+
+### Module layout
+
+```
+src/backend/vault/watcher/
+├── reconciler.ts
+├── watcher.ts
+├── boot-scan.ts
+└── types.ts
+```
+
+### Component interfaces
+
+```ts
+// types.ts
+export type ReconcileSignal = "add" | "change" | "unlink";
+
+export interface ReconcileResult {
+  action:
+    | "indexed"
+    | "reembedded"
+    | "meta-updated"
+    | "archived"
+    | "skipped"
+    | "parse-error";
+  memoryId?: string;
+  reason?: string;
+}
+
+export interface IgnoreSet {
+  add(absPath: string, mtimeAfterWrite: number): void;
+  has(absPath: string, currentMtime: number): boolean; // returns true only if path tracked AND mtime matches
+  releaseAfter(absPath: string, graceMs: number): void;
+}
+```
+
+```ts
+// reconciler.ts
+export interface Reconciler {
+  reconcileFile(
+    absPath: string,
+    signal: ReconcileSignal,
+  ): Promise<ReconcileResult>;
+  archiveOrphans(
+    diskPaths: ReadonlySet<string>,
+  ): Promise<{ archived: string[] }>;
+}
+
+export function createReconciler(deps: {
+  parser: MemoryParser;
+  memoryRepo: VaultMemoryRepository;
+  vectorIndex: VaultVectorIndex;
+  flagRepo: VaultFlagRepository;
+  vaultRoot: string;
+}): Reconciler;
+```
+
+```ts
+// watcher.ts
+export interface VaultWatcher {
+  start(): Promise<void>; // resolves on chokidar 'ready'
+  stop(): Promise<void>; // chokidar.close(); awaits in-flight reconciles
+  ignoreSet: IgnoreSet;
+}
+
+export function createVaultWatcher(opts: {
+  vaultRoot: string;
+  reconciler: Reconciler;
+  awaitWriteFinish?: { stabilityThreshold: number; pollInterval: number }; // default 300/100
+  graceMs?: number; // default 500ms
+}): VaultWatcher;
+```
+
+```ts
+// boot-scan.ts
+export async function runBootScan(opts: {
+  vaultRoot: string;
+  reconciler: Reconciler;
+}): Promise<{
+  scanned: number;
+  reconciled: number;
+  orphaned: number;
+  parseErrors: number;
+  embedErrors: number;
+}>;
+```
+
+### Wiring in `VaultBackend.start()`
+
+```
+1. ensureVaultGit()                           # existing
+2. alignWithRemote()                          # existing (Phase 4b)
+3. runBootScan()                              # new — blocks until consistent
+4. watcher.start()                            # new — resolves on chokidar 'ready'
+5. httpServer.listen()                        # existing — only after 1-4 complete
+```
+
+### Mutation-site changes
+
+- `VaultMemoryFiles.edit` (`src/backend/vault/repositories/memory-files.ts`) — accept optional `ignoreSet: IgnoreSet` ctor param. Post-fsync inside `edit()`: read mtime of written file, call `ignoreSet.add(absPath, mtime)`, schedule `ignoreSet.releaseAfter(absPath, 500)` after the commit completes.
+- `VaultMemoryRepository` — same plumbing for archive (unlink path). Add `findByPath(absPath): MemoryRecord | undefined` if not already present. Add `indexAdd(record)` and `indexRemove(absPath)` methods so reconciler can sync the in-memory map without going through `create`/`archive` (which re-trigger commit + lance write — double work).
+- `GitOpsImpl.stageAndCommit` callers — no direct change; commits update markdown mtime which is captured at `edit()` post-fsync.
+- `src/backend/types.ts` — extend `BackendSessionStartMeta` with `watcher_error?: true` (literal-`true` presence-only convention per memory `bONZKfXKa_cv4a2s0I2NV`).
+- `package.json` — confirm `chokidar` dependency (likely already transitively available; verify at plan time).
+
+## Data flow
+
+### Boot path
+
+```
+VaultBackend.start()
+  ├─ ensureVaultGit()
+  ├─ alignWithRemote()
+  ├─ runBootScan()
+  │    ├─ listMarkdownFiles(vaultRoot) → diskPaths
+  │    ├─ for each path:
+  │    │     reconciler.reconcileFile(path, "add")
+  │    │       ├─ parser.parse(content)
+  │    │       │     ├─ ok    → diff lance content_hash
+  │    │       │     │           ├─ no row     → embed + lance.upsert + memoryRepo.indexAdd + flag.archiveStaleSidecar
+  │    │       │     │           ├─ hash same  → if frontmatter changed → lance.upsertMetaOnly; else skipped
+  │    │       │     │           └─ hash diff  → embed + lance.upsert + flag.archiveStaleSidecar
+  │    │       │     └─ fail  → flag.upsertParseErrorSidecar(path, err)
+  │    └─ reconciler.archiveOrphans(diskPaths)
+  │          └─ lance.scan archived=false → for each row: if row.path ∉ diskPaths → lance.update {archived:true} + memoryRepo.indexRemove
+  ├─ watcher.start()
+  └─ httpServer.listen()
+```
+
+### Live path (post-`ready`)
+
+```
+External edit (Obsidian save / git pull checkout / vim write)
+  → chokidar event (after awaitWriteFinish stabilizes)
+  → watcher dispatches:
+       fs.stat absPath → currentMtime
+       if ignoreSet.has(absPath, currentMtime): return    # internal write, skip
+       reconciler.reconcileFile(absPath, signal)
+         add/change → same logic as boot path
+         unlink    → memoryId = memoryRepo.findByPath(absPath)
+                     if found: lance.update {archived:true} + memoryRepo.indexRemove + flag.archiveSidecarsForPath
+                     if not:  no-op (orphan event for unknown path)
+```
+
+### Internal write path (existing tools, augmented)
+
+```
+memory_create / memory_update / memory_archive
+  → MemoryService → VaultMemoryRepository / VaultMemoryFiles.edit
+  → withFileLock + write markdown
+  → fs.stat → mtime
+  → ignoreSet.add(absPath, mtime)
+  → commit + lance write
+  → ignoreSet.releaseAfter(absPath, 500ms)
+  → response returns
+  → chokidar fires change event ~50-300ms later (awaitWriteFinish stable)
+  → watcher checks ignoreSet → mtime matches → skip
+```
+
+### Critical invariants
+
+- Boot scan completes before any external client can hit the server.
+- `graceMs` ≥ `awaitWriteFinish.stabilityThreshold`; 500ms vs 300ms = 200ms safety margin.
+- Reconcile is idempotent: hash-skip means duplicate events are cheap (parse + hash compare, no embed, no lance write).
+
+## Race & coordination
+
+- **R1. Internal write vs watcher.** Solved by ignoreSet (D2) + grace window outlasting `stabilityThreshold`.
+- **R2. Concurrent external edit during internal write.** External overwrites internal between fsync and grace expiry. Mitigation: ignoreSet uses `(absPath, mtimeAfterWrite)` tuple; `has()` compares current mtime; mismatch → fall through to reconcile.
+- **R3. Boot scan vs incoming external edit.** Boot scan runs pre-listen; chokidar not yet started. External edits during boot-scan window are picked up once chokidar starts (subsequent `change` event with later mtime). Acceptable.
+- **R4. Watcher vs `git pull` mid-pull.** Pull does N file ops → N chokidar events → each goes through `awaitWriteFinish` → idempotent reconcile. Push-queue mutex (Phase 4b) prevents pull-during-write.
+- **R5. Reconciler concurrency.** Multiple `reconcileFile` invocations interleave; each acquires `VaultMemoryFiles` lock per path → per-file serial, cross-file parallel. Lance ops independent across rows. Safe.
+- **R6. Watcher vs shutdown.** `VaultBackend.stop()`: `watcher.stop()` (chokidar.close, awaits in-flight callbacks) → `pushQueue.drain()` → done.
+
+## Error handling
+
+- **E1. Parse failure during reconcile.** Reconciler catches `MemoryParseError` only. `flagRepo.upsertParseErrorSidecar` (idempotent via O_EXCL); returns `{action: "parse-error"}`. Other thrown errors (EACCES, EIO) → `logger.error` + rethrow; watcher catches at dispatch level + logs; does NOT crash watcher. Boot scan catches per-file + accumulates count → reported in return. If `parseErrors > 0`, `BackendSessionStartMeta.parse_errors` carries forward (existing Phase 4b plumbing).
+- **E2. Lance write failure during reconcile.** Markdown is source of truth (memory `GKep85Rl4NGJbnTScVXNz`). Lance failure → `logger.error` + result `{action: "skipped", reason: "lance-failure"}`. In-memory index NOT updated. Next chokidar event on same path retries; if file unchanged, no event → drift persists until next process boot via `runBootScan`. Live drift recovery deferred (Phase 8 perf+reliability).
+- **E3. Embed call failure (Ollama down).** Same as E2: log + skip. Boot scan does NOT block startup on embed failure — log + skip + continue. Boot return reports `embedErrors: N`. HTTP comes up; affected memories searchable but with stale embeddings. Acceptable degradation.
+- **E4. chokidar internal error.** chokidar's `error` event → `logger.error`. Do NOT auto-restart watcher (silent failure risk). Surface via `BackendSessionStartMeta.watcher_error?: true`.
+- **E5. Sidecar write failure during parse_error path.** `flagRepo` write fails (disk full / permission). Log + continue reconcile. parse_error visibility lost for that file until next reconcile attempt. No cascade.
+- **E6. ignoreSet false negative.** Watcher reconciles a file we just wrote. Cost: one wasted parse + hash compare → hash matches lance → `skipped`. Idempotent, low cost.
+- **E7. ignoreSet false positive.** External edit lands during ignoreSet window with mtime != recorded. R2 mtime tuple catches → fall through to reconcile.
+
+## Testing
+
+### T1 — Reconciler unit tests
+
+`tests/unit/backend/vault/watcher/reconciler.test.ts`. Mock deps (parser real; memoryRepo, vectorIndex, flagRepo as in-memory stubs).
+
+- `add`: new file → embed + index + flag-archive
+- `change`: hash same + frontmatter same → `skipped`
+- `change`: hash same + frontmatter diff → `meta-updated`
+- `change`: hash diff → `reembedded`
+- `unlink`: existing → `archived` + index remove
+- `unlink`: unknown path → no-op
+- parse fail → sidecar upsert + result `parse-error`
+- parse pass on previously-flagged path → sidecar archived
+- `archiveOrphans`: lance has 3 rows, disk has 2 paths → 1 archived
+- lance failure during upsert → `skipped/lance-failure`, no index mutation
+
+### T2 — Watcher unit tests
+
+`tests/unit/backend/vault/watcher/watcher.test.ts`. Mock chokidar via `EventEmitter` stub. Real reconciler with stubbed deps.
+
+- emit `add` → reconciler called with signal `"add"`
+- ignoreSet.has(path) with matching mtime → reconciler NOT called
+- ignoreSet.has(path) but current mtime != recorded → reconciler IS called (R2)
+- `releaseAfter` clears entry after grace
+- chokidar `error` event → logger + does not throw; sets `watcher_error` meta flag
+- `stop()` awaits in-flight reconcile
+
+### T3 — Boot-scan unit tests
+
+`tests/unit/backend/vault/watcher/boot-scan.test.ts`. Real fs (tmpdir), stub reconciler.
+
+- empty vault → counts all zero
+- 5 files all parse → 5 reconcile calls
+- 3 files parse + 1 fails + 1 already-indexed → counts correct
+- 2 lance orphans → `archiveOrphans` called
+
+### T4 — E2E smoke
+
+`tests/integration/vault-watcher-e2e.test.ts`. Real chokidar + tmpdir + real `VaultBackend` (lance + git). PR-only, `--testTimeout=10000`. Five cases only:
+
+1. External `writeFile` of new memory → `memory_search` returns it within 1s
+2. External edit of existing memory body → re-embedded; search relevance changes
+3. External `rm` → `memory_search` excludes
+4. Internal `memory_create` does NOT cause double-reindex (assert lance row written count == 1)
+5. Boot scan + watcher composition: kill backend mid-edit, restart, assert state converges
+
+### T5 — Existing contract tests
+
+Unchanged. Optionally extend `tests/contract/repositories/users-gitignore-invariant.test.ts` to assert watcher does not emit user-scope content via flag sidecars.
+
+## Non-Goals
+
+- Watcher-driven incremental git commit of external edits. External edits stay uncommitted in working tree; user runs git themselves. Potential Phase 6 work.
+- HNSW / IvfPq tuning (Phase 8).
+- Reverse migration vault→pg (Phase 6).
+- Rename detection. chokidar `add`+`unlink` pair handled as archive+new, not move. Filename = title since commit `2fb21f1`, so renames carry semantic meaning; deferred until demand surfaces.
+- Multi-vault per server. One watcher per `VaultBackend` instance.
+
+## Plan-time deferrals
+
+These are implementation-level choices, intentionally left for `writing-plans`:
+
+- Exact chokidar option set beyond `awaitWriteFinish` + `ignoreInitial` (`atomic`, `followSymlinks`, etc.).
+- Logger field shape for watcher events.
+- Whether `runBootScan` parallelizes file processing (likely sequential at small scale; revisit at >1000 memories).
+- Reconciler API for soft-archive: direct `lance.update` call vs delegating to `vectorIndex.softArchive(memoryId)` helper. Lean toward helper.
+- Concrete `graceMs` + `awaitWriteFinish` constants — exposed via `VaultBackendConfig` for test override.
+- Whether tier 4 E2E uses `vitest.config.ts` test name pattern or separate vitest project.
+
+## Open questions
+
+None blocking implementation. All architectural choices locked above.

--- a/hooks/claude/claude-md-snippet.md
+++ b/hooks/claude/claude-md-snippet.md
@@ -4,7 +4,11 @@ User use [agent-brain](https://github.com/feigi/agent-brain) (MCP server) as sol
 
 ### Session Start
 
-Relevant memories load auto at session start via SessionStart hook. No manual `memory_session_start` call needed. Use `memory_search` for extra lookups during session.
+SessionStart hook delivers a TITLE-ONLY index of available memories plus a forced read of `<workspace>/.agent-brain/session.md` for full bodies. Read that file before answering the first user message. No manual `memory_session_start` call needed.
+
+### Working with Loaded Memories
+
+`<workspace>/.agent-brain/session.md` contains the full bodies of the memories indexed in the SessionStart preview. The preview lists `<id> [<scope>] <type> — <title>` per memory; full bodies are in the file. Read it once at session start; use it as your in-context reference until the next session.
 
 ### Identity Parameters
 
@@ -13,13 +17,17 @@ Relevant memories load auto at session start via SessionStart hook. No manual `m
 
 ### When to Call `memory_search`
 
-**Call `memory_search` before actions affecting shared systems.** Includes:
+Call `memory_search` whenever:
 
-1. **User asks about notes, context, team knowledge** — e.g. "any notes?", "what should I know?"
-2. **Before actions affecting shared infra** — deploys, DB migrations, credential rotation, etc.
-3. **Before shared/integration tests** (e.g. E2E, load tests) — NOT local unit tests or builds
+1. **The user's task touches a topic that overlaps an index title** — the title alone may not be enough; pull the full memory or related ones.
+2. **You are reasoning about an unfamiliar area of the codebase or domain** — even if no index entry obviously matches.
+3. **You are about to take an action affecting shared systems** — deploys, DB migrations, credential rotation, integration tests, etc.
 
-**Do NOT search for purely local actions** like editing files, installing deps, local builds, linting, formatting.
+Prefer false positives over misses. Searches are cheap; missing a load-bearing memory is expensive.
+
+For a specific entry by id, use `memory_get`.
+
+**Do NOT search for purely local actions** (file edits, dependency installs, local builds, linting, formatting) UNLESS the index suggests a relevant memory.
 
 ### Saving Memories
 

--- a/hooks/claude/memory-session-start.sh
+++ b/hooks/claude/memory-session-start.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-# Claude Code SessionStart Hook: Load agent-brain memories
-# Calls the REST API on the persistent HTTP server.
-# On failure, emits a fallback additionalContext so the agent knows to call
-# memory_search explicitly instead of assuming no memories exist.
+# Claude Code SessionStart Hook: load agent-brain memories.
+# Writes full memories to <cwd>/.agent-brain/session.md and emits a preview
+# (title-only index + path) as additionalContext. Agent is instructed to Read
+# the file before responding.
+# On any failure, emits the existing fallback additionalContext.
 
 INPUT=$(cat)
 AGENT_BRAIN_URL="${AGENT_BRAIN_URL:-http://localhost:19898}"
@@ -22,12 +23,23 @@ emit_fallback() {
   exit 0
 }
 
+ensure_gitignore() {
+  local cwd="$1"
+  local gi="${cwd}/.gitignore"
+  [ -d "$cwd" ] || return 0
+  if [ ! -f "$gi" ] || ! grep -qxF ".agent-brain/" "$gi" 2>/dev/null; then
+    printf "\n.agent-brain/\n" >> "$gi" 2>/dev/null || true
+  fi
+}
+
+if [ -z "$CWD" ] || [ ! -d "$CWD" ]; then
+  emit_fallback "missing or invalid cwd"
+fi
+
 if ! curl -sf "${AGENT_BRAIN_URL}/health" >/dev/null 2>&1; then
   emit_fallback "server unreachable (${AGENT_BRAIN_URL}/health)"
 fi
 
-# -f makes curl exit non-zero on HTTP 4xx/5xx so error bodies don't leak into
-# additionalContext as fake "memories".
 RESPONSE=$(curl -sf -X POST "${AGENT_BRAIN_URL}/api/tools/memory_session_start" \
   -H 'Content-Type: application/json' \
   -d "{\"workspace_id\":\"${WORKSPACE_ID}\",\"user_id\":\"${USER_ID}\",\"limit\":10}") \
@@ -35,6 +47,12 @@ RESPONSE=$(curl -sf -X POST "${AGENT_BRAIN_URL}/api/tools/memory_session_start" 
 
 if [ -z "$RESPONSE" ]; then
   emit_fallback "memory_session_start returned empty body"
+fi
+
+PREVIEW=$(echo "$RESPONSE" | jq -r '.preview // ""')
+FULL=$(echo "$RESPONSE" | jq -r '.full // ""')
+if [ -z "$PREVIEW" ] || [ -z "$FULL" ]; then
+  emit_fallback "memory_session_start response missing preview/full fields"
 fi
 
 # Stash agent-brain session_id for the stop hook to read
@@ -45,8 +63,16 @@ if [ -n "$CLIENT_SESSION_ID" ]; then
   fi
 fi
 
-MEMORIES_ESCAPED=$(echo "$RESPONSE" | jq -Rs '.')
+DEST_DIR="${CWD}/.agent-brain"
+DEST_FILE="${DEST_DIR}/session.md"
+mkdir -p "$DEST_DIR" 2>/dev/null || emit_fallback "could not create ${DEST_DIR}"
+printf "%s" "$FULL" > "$DEST_FILE" 2>/dev/null || emit_fallback "could not write ${DEST_FILE}"
+ensure_gitignore "$CWD"
+
+# Substitute {{PATH}} placeholder with the absolute file path
+SUBSTITUTED_PREVIEW=$(printf "%s" "$PREVIEW" | sed "s|{{PATH}}|${DEST_FILE}|g")
+CTX_ESCAPED=$(printf "%s" "$SUBSTITUTED_PREVIEW" | jq -Rs '.')
 
 cat <<EOF
-{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": ${MEMORIES_ESCAPED}}}
+{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": ${CTX_ESCAPED}}}
 EOF

--- a/hooks/claude/memory-session-start.sh
+++ b/hooks/claude/memory-session-start.sh
@@ -69,8 +69,11 @@ mkdir -p "$DEST_DIR" 2>/dev/null || emit_fallback "could not create ${DEST_DIR}"
 printf "%s" "$FULL" > "$DEST_FILE" 2>/dev/null || emit_fallback "could not write ${DEST_FILE}"
 ensure_gitignore "$CWD"
 
-# Substitute {{PATH}} placeholder with the absolute file path
-SUBSTITUTED_PREVIEW=$(printf "%s" "$PREVIEW" | sed "s|{{PATH}}|${DEST_FILE}|g")
+# Substitute {{PATH}} placeholder with the absolute file path.
+# Escape sed-special chars (&, \, |) in the path so workspaces with
+# unusual names (e.g. "foo&bar") don't silently corrupt the substitution.
+ESCAPED_DEST=$(printf '%s' "$DEST_FILE" | sed 's/[&\\|]/\\&/g')
+SUBSTITUTED_PREVIEW=$(printf "%s" "$PREVIEW" | sed "s|{{PATH}}|${ESCAPED_DEST}|g")
 CTX_ESCAPED=$(printf "%s" "$SUBSTITUTED_PREVIEW" | jq -Rs '.')
 
 cat <<EOF

--- a/hooks/copilot/instructions-snippet.md
+++ b/hooks/copilot/instructions-snippet.md
@@ -4,9 +4,13 @@ Project use [agent-brain](https://github.com/feigi/agent-brain) (MCP server) for
 
 ## Session Start
 
-If `memory-session-start.sh` hook (Copilot CLI v1.0.11+) installed, recent memories inject as `additionalContext` at session start — no manual call needed.
+If `memory-session-start.sh` hook (Copilot CLI v1.0.24+) installed, SessionStart delivers a TITLE-ONLY index of available memories plus a forced read of `<workspace>/.agent-brain/session.md` for full bodies. Read that file before answering the first user message.
 
 If unsure hook active AND no memories appeared by first response, call `memory_session_start` yourself.
+
+## Working with Loaded Memories
+
+`<workspace>/.agent-brain/session.md` contains the full bodies of the memories indexed in the SessionStart preview. The preview lists `<id> [<scope>] <type> — <title>` per memory; full bodies are in the file. Read it once at session start; use it as your in-context reference until the next session.
 
 ## Identity Parameters
 
@@ -17,13 +21,17 @@ When `memory-pretool.sh` installed, auto-filled on every `mcp__agent-brain__*` c
 
 ## When to Call `memory_search`
 
-**Call `memory_search` before actions affecting shared systems.** Includes:
+Call `memory_search` whenever:
 
-1. **User asks about notes, context, team knowledge** — e.g. "any notes?", "what should I know?"
-2. **Before actions affecting shared infrastructure** — deploys, DB migrations, credential rotation, etc.
-3. **Before shared/integration tests** (e.g. E2E, load tests) — NOT local unit tests or builds
+1. **The user's task touches a topic that overlaps an index title** — the title alone may not be enough; pull the full memory or related ones.
+2. **You are reasoning about an unfamiliar area of the codebase or domain** — even if no index entry obviously matches.
+3. **You are about to take an action affecting shared systems** — deploys, DB migrations, credential rotation, integration tests, etc.
 
-**Do NOT search for purely local actions** like editing files, installing deps, local builds, linting, formatting.
+Prefer false positives over misses. Searches are cheap; missing a load-bearing memory is expensive.
+
+For a specific entry by id, use `memory_get`.
+
+**Do NOT search for purely local actions** (file edits, dependency installs, local builds, linting, formatting) UNLESS the index suggests a relevant memory.
 
 ## Saving Memories
 

--- a/hooks/copilot/memory-session-start.sh
+++ b/hooks/copilot/memory-session-start.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# Copilot CLI sessionStart Hook: inject agent-brain memories as additionalContext.
-# Requires Copilot CLI v1.0.22+: needs additionalContext honoring (v1.0.11+) AND
-# once-per-session firing (v1.0.22+).
-# On failure, emits a fallback additionalContext so the agent knows to call
-# memory_search explicitly instead of assuming no memories exist.
+# Copilot CLI SessionStart Hook: load agent-brain memories.
+# Writes full memories to <cwd>/.agent-brain/session.md and emits a preview
+# (title-only index + path) as additionalContext. Agent is instructed to Read
+# the file before responding.
+# Requires Copilot CLI v1.0.24+ (additionalContext + once-per-session firing).
 
 INPUT=$(cat)
 AGENT_BRAIN_URL="${AGENT_BRAIN_URL:-http://localhost:19898}"
@@ -17,10 +17,6 @@ WORKSPACE_ID=$(basename "$CWD")
 
 FALLBACK_MSG="Agent Brain session_start did not succeed — memories were not loaded this session. Call memory_search explicitly when team knowledge or prior context is relevant."
 
-# Emit both flat and wrapped envelopes. Copilot CLI docs currently disagree with
-# the changelog on the shape — flat matches the confirmed-working preToolUse
-# pattern; the hookSpecificOutput wrapper mirrors VS Code's shape. Extra keys are
-# harmless, so emit both and let whichever Copilot parses win.
 emit_envelope() {
   local ctx="$1"
   jq -cn --arg ctx "$ctx" \
@@ -35,12 +31,23 @@ emit_fallback() {
   exit 0
 }
 
+ensure_gitignore() {
+  local cwd="$1"
+  local gi="${cwd}/.gitignore"
+  [ -d "$cwd" ] || return 0
+  if [ ! -f "$gi" ] || ! grep -qxF ".agent-brain/" "$gi" 2>/dev/null; then
+    printf "\n.agent-brain/\n" >> "$gi" 2>/dev/null || true
+  fi
+}
+
+if [ -z "$CWD" ] || [ ! -d "$CWD" ]; then
+  emit_fallback "missing or invalid cwd"
+fi
+
 if ! curl -sf "${AGENT_BRAIN_URL}/health" >/dev/null 2>&1; then
   emit_fallback "server unreachable (${AGENT_BRAIN_URL}/health)"
 fi
 
-# -f makes curl exit non-zero on HTTP 4xx/5xx so error bodies don't leak into
-# additionalContext as fake "memories".
 RESPONSE=$(curl -sf -X POST "${AGENT_BRAIN_URL}/api/tools/memory_session_start" \
   -H 'Content-Type: application/json' \
   -d "{\"workspace_id\":\"${WORKSPACE_ID}\",\"user_id\":\"${USER_ID}\",\"limit\":10}") \
@@ -50,11 +57,24 @@ if [ -z "$RESPONSE" ]; then
   emit_fallback "memory_session_start returned empty body"
 fi
 
+PREVIEW=$(echo "$RESPONSE" | jq -r '.preview // ""')
+FULL=$(echo "$RESPONSE" | jq -r '.full // ""')
+if [ -z "$PREVIEW" ] || [ -z "$FULL" ]; then
+  emit_fallback "memory_session_start response missing preview/full fields"
+fi
+
 AB_SESSION_ID=$(echo "$RESPONSE" | jq -r '.meta.session_id // ""')
 if [ -n "$AB_SESSION_ID" ]; then
   echo "$AB_SESSION_ID" > "/tmp/agent-brain-sid-${SESSION_KEY}"
 fi
 
-emit_envelope "$RESPONSE"
+DEST_DIR="${CWD}/.agent-brain"
+DEST_FILE="${DEST_DIR}/session.md"
+mkdir -p "$DEST_DIR" 2>/dev/null || emit_fallback "could not create ${DEST_DIR}"
+printf "%s" "$FULL" > "$DEST_FILE" 2>/dev/null || emit_fallback "could not write ${DEST_FILE}"
+ensure_gitignore "$CWD"
+
+SUBSTITUTED_PREVIEW=$(printf "%s" "$PREVIEW" | sed "s|{{PATH}}|${DEST_FILE}|g")
+emit_envelope "$SUBSTITUTED_PREVIEW"
 
 exit 0

--- a/hooks/copilot/memory-session-start.sh
+++ b/hooks/copilot/memory-session-start.sh
@@ -74,7 +74,10 @@ mkdir -p "$DEST_DIR" 2>/dev/null || emit_fallback "could not create ${DEST_DIR}"
 printf "%s" "$FULL" > "$DEST_FILE" 2>/dev/null || emit_fallback "could not write ${DEST_FILE}"
 ensure_gitignore "$CWD"
 
-SUBSTITUTED_PREVIEW=$(printf "%s" "$PREVIEW" | sed "s|{{PATH}}|${DEST_FILE}|g")
+# Escape sed-special chars (&, \, |) in the path so workspaces with
+# unusual names (e.g. "foo&bar") don't silently corrupt the substitution.
+ESCAPED_DEST=$(printf '%s' "$DEST_FILE" | sed 's/[&\\|]/\\&/g')
+SUBSTITUTED_PREVIEW=$(printf "%s" "$PREVIEW" | sed "s|{{PATH}}|${ESCAPED_DEST}|g")
 emit_envelope "$SUBSTITUTED_PREVIEW"
 
 exit 0

--- a/src/routes/api-tools.ts
+++ b/src/routes/api-tools.ts
@@ -7,6 +7,7 @@ import { DomainError } from "../utils/errors.js";
 import { logger } from "../utils/logger.js";
 import { parseCursor } from "../utils/validation.js";
 import { toolSchemas, type ToolName } from "./api-schemas.js";
+import { renderPreview, renderFull } from "../utils/session-start-render.js";
 
 export function createApiToolsRouter(
   memoryService: MemoryService,
@@ -37,14 +38,23 @@ export function createApiToolsRouter(
       switch (toolName) {
         case "memory_session_start": {
           const b = body as z.infer<typeof toolSchemas.memory_session_start>;
-          const result = await memoryService.sessionStart(
+          const envelope = await memoryService.sessionStart(
             b.workspace_id,
             b.user_id,
             b.context,
             b.limit,
             b.project_limit,
           );
-          res.json(result);
+          const previewResult = renderPreview(envelope.data);
+          const full = renderFull(envelope.data, envelope.meta.flags);
+          res.json({
+            preview: previewResult.text,
+            full,
+            meta: {
+              ...envelope.meta,
+              index_truncated_count: previewResult.truncatedCount,
+            },
+          });
           break;
         }
 

--- a/src/tools/memory-session-start.ts
+++ b/src/tools/memory-session-start.ts
@@ -7,6 +7,7 @@ import {
   projectLimitSchema,
 } from "../utils/session-limits.js";
 import { toolResponse, withErrorHandling } from "./tool-utils.js";
+import { renderPreview, renderFull } from "../utils/session-start-render.js";
 
 export function registerMemorySessionStart(
   server: McpServer,
@@ -47,14 +48,23 @@ export function registerMemorySessionStart(
     },
     async (params) => {
       return withErrorHandling(async () => {
-        const result = await memoryService.sessionStart(
+        const envelope = await memoryService.sessionStart(
           params.workspace_id,
           params.user_id,
           params.context,
           params.limit,
           params.project_limit,
         );
-        return toolResponse(result);
+        const previewResult = renderPreview(envelope.data);
+        const full = renderFull(envelope.data, envelope.meta.flags);
+        return toolResponse({
+          preview: previewResult.text,
+          full,
+          meta: {
+            ...envelope.meta,
+            index_truncated_count: previewResult.truncatedCount,
+          },
+        } as unknown as import("../types/envelope.js").Envelope<never>);
       });
     },
   );

--- a/src/tools/memory-session-start.ts
+++ b/src/tools/memory-session-start.ts
@@ -64,7 +64,7 @@ export function registerMemorySessionStart(
             ...envelope.meta,
             index_truncated_count: previewResult.truncatedCount,
           },
-        } as unknown as import("../types/envelope.js").Envelope<never>);
+        });
       });
     },
   );

--- a/src/tools/tool-utils.ts
+++ b/src/tools/tool-utils.ts
@@ -1,14 +1,15 @@
-import type { Envelope } from "../types/envelope.js";
 import { DomainError } from "../utils/errors.js";
 import { stripNullsReplacer } from "../utils/json-replacer.js";
 
-/** Wrap an Envelope as MCP CallToolResult content */
-export function toolResponse<T>(envelope: Envelope<T>): {
+/** Wrap a serializable payload as MCP CallToolResult content. Accepts any
+ * object, not just Envelope<T> — memory_session_start's wire shape is
+ * { preview, full, meta } and is not envelope-shaped. */
+export function toolResponse<T>(payload: T): {
   content: { type: "text"; text: string }[];
 } {
   return {
     content: [
-      { type: "text", text: JSON.stringify(envelope, stripNullsReplacer) },
+      { type: "text", text: JSON.stringify(payload, stripNullsReplacer) },
     ],
   };
 }

--- a/src/types/envelope.ts
+++ b/src/types/envelope.ts
@@ -35,4 +35,5 @@ interface EnvelopeCoreMeta {
   omitted?: string[]; // IDs requested but not returned (inaccessible/not found)
   project_truncated?: boolean; // session_start only: true when project-scoped memories exceeded project_limit
   project_scope_status?: "ok" | "failed"; // session_start only: "failed" when listProjectScoped threw and ranked results were returned without project-scoped memories
+  index_truncated_count?: number; // session_start only: count of index rows dropped to fit preview budget
 }

--- a/src/utils/session-start-render.ts
+++ b/src/utils/session-start-render.ts
@@ -70,9 +70,70 @@ function byteLengthOfLines(lines: string[]): number {
   return lines.reduce((acc, l) => acc + l.length, 0) + (lines.length - 1);
 }
 
+const SECTION_HEADERS = {
+  project: "## project rules",
+  workspace: "## workspace memories",
+  user: "## user memories",
+} as const;
+
+function formatDate(d: Date | null | undefined): string {
+  if (!d) return "none";
+  return d.toISOString().slice(0, 10);
+}
+
+function memorySection(m: MemorySummaryWithRelevance): string {
+  const tags = m.tags && m.tags.length > 0 ? m.tags.join(", ") : "none";
+  const verified = formatDate(m.verified_at);
+  return `## ${m.title}
+
+- **id:** ${m.id}
+- **scope:** ${m.scope} · **type:** ${m.type} · **author:** ${m.author}
+- **created:** ${formatDate(m.created_at)} · **updated:** ${formatDate(m.updated_at)} · **verified:** ${verified}
+- **tags:** ${tags}
+
+${m.content}
+`;
+}
+
+function flagsSection(flags: FlagResponse[]): string {
+  const lines = flags.map(
+    (f) =>
+      `- **${f.flag_id}** (${f.flag_type}) on \`${f.memory.id}\` "${f.memory.title}" — ${f.reason}`,
+  );
+  return `## flags
+
+${lines.join("\n")}
+`;
+}
+
 export function renderFull(
-  _memories: MemorySummaryWithRelevance[], // eslint-disable-line @typescript-eslint/no-unused-vars
-  _flags?: FlagResponse[], // eslint-disable-line @typescript-eslint/no-unused-vars
+  memories: MemorySummaryWithRelevance[],
+  flags?: FlagResponse[],
 ): string {
-  return "";
+  const byScope = {
+    project: [] as MemorySummaryWithRelevance[],
+    workspace: [] as MemorySummaryWithRelevance[],
+    user: [] as MemorySummaryWithRelevance[],
+  };
+  for (const m of memories) {
+    byScope[m.scope].push(m);
+  }
+  for (const k of Object.keys(byScope) as Array<keyof typeof byScope>) {
+    byScope[k].sort((a, b) => b.relevance - a.relevance);
+  }
+
+  const parts: string[] = [];
+  for (const scope of ["project", "workspace", "user"] as const) {
+    if (byScope[scope].length === 0) continue;
+    parts.push(SECTION_HEADERS[scope]);
+    for (const m of byScope[scope]) {
+      parts.push(memorySection(m));
+    }
+  }
+
+  if (flags && flags.length > 0) {
+    parts.push(flagsSection(flags));
+  }
+
+  return parts.join("\n");
 }

--- a/src/utils/session-start-render.ts
+++ b/src/utils/session-start-render.ts
@@ -9,7 +9,7 @@ export interface RenderPreviewResult {
 const DEFAULT_INDEX_BUDGET_BYTES = 1500;
 
 const HEADER = `IMPORTANT — full memories are NOT in this preview.
-Index below shows %COUNT% memories. Full bodies at:
+%LOADED% memories loaded; %SHOWN% shown in index below. Full bodies at:
 {{PATH}}
 
 You MUST Read this file before responding to the user's
@@ -58,10 +58,15 @@ export function renderPreview(
   }
 
   const indexBlock = [...projectLines, ...keptNonProject].join("\n");
-  const totalCount =
-    projectRows.length + keptNonProject.length + truncatedCount;
+  const shownCount = projectLines.length + keptNonProject.length;
+  const loadedCount = shownCount + truncatedCount;
   const text =
-    HEADER.replace("%COUNT%", String(totalCount)) + indexBlock + FOOTER;
+    HEADER.replace("%LOADED%", String(loadedCount)).replace(
+      "%SHOWN%",
+      String(shownCount),
+    ) +
+    indexBlock +
+    FOOTER;
   return { text, truncatedCount };
 }
 

--- a/src/utils/session-start-render.ts
+++ b/src/utils/session-start-render.ts
@@ -29,13 +29,45 @@ function indexRow(m: MemorySummaryWithRelevance): string {
 
 export function renderPreview(
   memories: MemorySummaryWithRelevance[],
-  _indexBudget: number = DEFAULT_INDEX_BUDGET_BYTES, // eslint-disable-line @typescript-eslint/no-unused-vars
+  indexBudget: number = DEFAULT_INDEX_BUDGET_BYTES,
 ): RenderPreviewResult {
-  const rows = memories.map(indexRow);
-  const indexBlock = rows.join("\n");
+  const projectRows = memories.filter((m) => m.scope === "project");
+  const nonProjectRows = memories
+    .filter((m) => m.scope !== "project")
+    .slice()
+    .sort((a, b) => b.relevance - a.relevance);
+
+  const projectLines = projectRows.map(indexRow);
+  const projectBytes = byteLengthOfLines(projectLines);
+
+  let remaining = indexBudget - projectBytes;
+  const keptNonProject: string[] = [];
+  let truncatedCount = 0;
+  for (const m of nonProjectRows) {
+    const line = indexRow(m);
+    const cost =
+      keptNonProject.length === 0 && projectLines.length === 0
+        ? line.length
+        : line.length + 1; // +1 for joining newline
+    if (cost <= remaining) {
+      keptNonProject.push(line);
+      remaining -= cost;
+    } else {
+      truncatedCount++;
+    }
+  }
+
+  const indexBlock = [...projectLines, ...keptNonProject].join("\n");
+  const totalCount =
+    projectRows.length + keptNonProject.length + truncatedCount;
   const text =
-    HEADER.replace("%COUNT%", String(memories.length)) + indexBlock + FOOTER;
-  return { text, truncatedCount: 0 };
+    HEADER.replace("%COUNT%", String(totalCount)) + indexBlock + FOOTER;
+  return { text, truncatedCount };
+}
+
+function byteLengthOfLines(lines: string[]): number {
+  if (lines.length === 0) return 0;
+  return lines.reduce((acc, l) => acc + l.length, 0) + (lines.length - 1);
 }
 
 export function renderFull(

--- a/src/utils/session-start-render.ts
+++ b/src/utils/session-start-render.ts
@@ -1,0 +1,46 @@
+import type { MemorySummaryWithRelevance } from "../types/memory.js";
+import type { FlagResponse } from "../types/flag.js";
+
+export interface RenderPreviewResult {
+  text: string;
+  truncatedCount: number;
+}
+
+const DEFAULT_INDEX_BUDGET_BYTES = 1500;
+
+const HEADER = `IMPORTANT — full memories are NOT in this preview.
+Index below shows %COUNT% memories. Full bodies at:
+{{PATH}}
+
+You MUST Read this file before responding to the user's
+first message. Do not proceed without it.
+
+## Memory index
+`;
+
+const FOOTER = `
+Search guidance: see your memory instructions
+(CLAUDE.md / agent-brain snippet).
+`;
+
+function indexRow(m: MemorySummaryWithRelevance): string {
+  return `- ${m.id} [${m.scope}] ${m.type} — ${m.title}`;
+}
+
+export function renderPreview(
+  memories: MemorySummaryWithRelevance[],
+  _indexBudget: number = DEFAULT_INDEX_BUDGET_BYTES, // eslint-disable-line @typescript-eslint/no-unused-vars
+): RenderPreviewResult {
+  const rows = memories.map(indexRow);
+  const indexBlock = rows.join("\n");
+  const text =
+    HEADER.replace("%COUNT%", String(memories.length)) + indexBlock + FOOTER;
+  return { text, truncatedCount: 0 };
+}
+
+export function renderFull(
+  _memories: MemorySummaryWithRelevance[], // eslint-disable-line @typescript-eslint/no-unused-vars
+  _flags?: FlagResponse[], // eslint-disable-line @typescript-eslint/no-unused-vars
+): string {
+  return "";
+}

--- a/tests/unit/session-start-render.test.ts
+++ b/tests/unit/session-start-render.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from "vitest";
 import {
   renderPreview,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   renderFull,
 } from "../../src/utils/session-start-render.js";
 import type { MemorySummaryWithRelevance } from "../../src/types/memory.js";
+import type { FlagResponse } from "../../src/types/flag.js";
 
 function mem(
   overrides: Partial<MemorySummaryWithRelevance> = {},
@@ -87,5 +87,80 @@ describe("renderPreview", () => {
     expect(result.truncatedCount).toBeGreaterThan(0);
     expect(result.text).toContain("ws0 [workspace]");
     expect(result.text).not.toContain("ws44 [workspace]");
+  });
+});
+
+describe("renderFull", () => {
+  it("groups memories into sections by scope with relevance-descending order within group", () => {
+    const memories: MemorySummaryWithRelevance[] = [
+      mem({
+        id: "p1",
+        title: "Proj A",
+        scope: "project",
+        relevance: 0.5,
+        content: "Body P1",
+      }),
+      mem({
+        id: "w2",
+        title: "WS Low",
+        scope: "workspace",
+        relevance: 0.4,
+        content: "Body W2",
+      }),
+      mem({
+        id: "w1",
+        title: "WS High",
+        scope: "workspace",
+        relevance: 0.9,
+        content: "Body W1",
+      }),
+      mem({
+        id: "u1",
+        title: "User One",
+        scope: "user",
+        relevance: 0.7,
+        content: "Body U1",
+      }),
+    ];
+
+    const out = renderFull(memories);
+
+    expect(out).toContain("## project rules");
+    expect(out).toContain("## workspace memories");
+    expect(out).toContain("## user memories");
+
+    expect(out).toContain("## Proj A");
+    expect(out).toContain("## WS High");
+    expect(out).toContain("## WS Low");
+    expect(out).toContain("## User One");
+
+    expect(out).toContain("**id:** p1");
+    expect(out).toContain("**scope:** project");
+    expect(out).toContain("**type:** fact");
+
+    expect(out).toContain("Body P1");
+    expect(out).toContain("Body W1");
+
+    expect(out.indexOf("## WS High")).toBeLessThan(out.indexOf("## WS Low"));
+  });
+
+  it("emits a flags section when flags are non-empty, omits it otherwise", () => {
+    const m = mem({ id: "m1", title: "T1", scope: "workspace" });
+    const withoutFlags = renderFull([m]);
+    expect(withoutFlags).not.toContain("## flags");
+
+    const flags: FlagResponse[] = [
+      {
+        flag_id: "f1",
+        flag_type: "verify",
+        memory: { id: "m1", title: "T1", content: "C1", scope: "workspace" },
+        reason: "stale claim",
+      },
+    ];
+    const withFlags = renderFull([m], flags);
+    expect(withFlags).toContain("## flags");
+    expect(withFlags).toContain("f1");
+    expect(withFlags).toContain("verify");
+    expect(withFlags).toContain("stale claim");
   });
 });

--- a/tests/unit/session-start-render.test.ts
+++ b/tests/unit/session-start-render.test.ts
@@ -88,6 +88,44 @@ describe("renderPreview", () => {
     expect(result.text).toContain("ws0 [workspace]");
     expect(result.text).not.toContain("ws44 [workspace]");
   });
+
+  it("handles empty memory list without throwing", () => {
+    const result = renderPreview([]);
+    expect(result.truncatedCount).toBe(0);
+    expect(result.text).toContain("0 memories loaded");
+    expect(result.text).toContain("0 shown");
+    expect(result.text).toContain("{{PATH}}");
+    expect(result.text).toContain("MUST Read");
+  });
+
+  it("does not truncate when total bytes equal the budget exactly", () => {
+    const memories = [
+      mem({
+        id: "a",
+        title: "alpha",
+        scope: "workspace",
+        type: "fact",
+        relevance: 0.9,
+      }),
+      mem({
+        id: "b",
+        title: "beta",
+        scope: "workspace",
+        type: "fact",
+        relevance: 0.8,
+      }),
+    ];
+    // Compute exact byte cost of the two rows joined by one newline
+    const row1 = "- a [workspace] fact — alpha";
+    const row2 = "- b [workspace] fact — beta";
+    const exactBudget = row1.length + 1 + row2.length;
+
+    const result = renderPreview(memories, exactBudget);
+
+    expect(result.truncatedCount).toBe(0);
+    expect(result.text).toContain(row1);
+    expect(result.text).toContain(row2);
+  });
 });
 
 describe("renderFull", () => {
@@ -162,5 +200,9 @@ describe("renderFull", () => {
     expect(withFlags).toContain("f1");
     expect(withFlags).toContain("verify");
     expect(withFlags).toContain("stale claim");
+  });
+
+  it("returns empty string for an empty memory list with no flags", () => {
+    expect(renderFull([])).toBe("");
   });
 });

--- a/tests/unit/session-start-render.test.ts
+++ b/tests/unit/session-start-render.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import {
+  renderPreview,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  renderFull,
+} from "../../src/utils/session-start-render.js";
+import type { MemorySummaryWithRelevance } from "../../src/types/memory.js";
+
+function mem(
+  overrides: Partial<MemorySummaryWithRelevance> = {},
+): MemorySummaryWithRelevance {
+  return {
+    id: "abc123",
+    title: "Sample memory title",
+    content: "Sample content body",
+    type: "fact",
+    scope: "workspace",
+    author: "alice",
+    created_at: new Date("2026-04-25T00:00:00.000Z"),
+    updated_at: new Date("2026-04-25T00:00:00.000Z"),
+    comment_count: 0,
+    flag_count: 0,
+    relationship_count: 0,
+    relevance: 0.9,
+    ...overrides,
+  };
+}
+
+describe("renderPreview", () => {
+  it("emits header, index rows, and search-guidance footer with {{PATH}} placeholder", () => {
+    const memories = [
+      mem({
+        id: "id1",
+        title: "First memory",
+        scope: "project",
+        type: "pattern",
+      }),
+      mem({
+        id: "id2",
+        title: "Second memory",
+        scope: "workspace",
+        type: "fact",
+      }),
+    ];
+
+    const result = renderPreview(memories);
+
+    expect(result.text).toContain("{{PATH}}");
+    expect(result.text).toContain("MUST Read");
+    expect(result.text).toContain("- id1 [project] pattern — First memory");
+    expect(result.text).toContain("- id2 [workspace] fact — Second memory");
+    expect(result.text).toContain("Search guidance");
+    expect(result.truncatedCount).toBe(0);
+  });
+});

--- a/tests/unit/session-start-render.test.ts
+++ b/tests/unit/session-start-render.test.ts
@@ -52,4 +52,40 @@ describe("renderPreview", () => {
     expect(result.text).toContain("Search guidance");
     expect(result.truncatedCount).toBe(0);
   });
+
+  it("drops lowest-relevance non-project rows when index exceeds budget; never drops project rows", () => {
+    const longTitle = "x".repeat(60);
+    const memories: MemorySummaryWithRelevance[] = [];
+    for (let i = 0; i < 5; i++) {
+      memories.push(
+        mem({
+          id: `proj${i}`,
+          title: `${longTitle} project ${i}`,
+          scope: "project",
+          type: "pattern",
+          relevance: 0.1,
+        }),
+      );
+    }
+    for (let i = 0; i < 45; i++) {
+      memories.push(
+        mem({
+          id: `ws${i}`,
+          title: `${longTitle} workspace ${i}`,
+          scope: "workspace",
+          type: "fact",
+          relevance: 0.9 - i * 0.01,
+        }),
+      );
+    }
+
+    const result = renderPreview(memories, 1500);
+
+    for (let i = 0; i < 5; i++) {
+      expect(result.text).toContain(`proj${i} [project]`);
+    }
+    expect(result.truncatedCount).toBeGreaterThan(0);
+    expect(result.text).toContain("ws0 [workspace]");
+    expect(result.text).not.toContain("ws44 [workspace]");
+  });
 });


### PR DESCRIPTION
## Summary

- Replace `memory_session_start`'s 40KB verbatim response with a 2KB markdown index in `additionalContext` plus a full markdown body the hook writes to `<workspace>/.agent-brain/session.md`. Eliminates silent memory loss past Claude Code's preview cap.
- New module `src/utils/session-start-render.ts` hosts pure renderers (`renderPreview`, `renderFull`) wired in at the tool boundary; `MemoryService.sessionStart` shape unchanged so existing service-level tests stay green.
- Hook scripts (Claude + Copilot) write the file, ensure `.agent-brain/` is in `.gitignore`, substitute `{{PATH}}` (sed metachars escaped), and emit the substituted preview. CLAUDE.md / instructions snippets reframe `memory_search` from restrictive to liberal task-driven.

Spec: `docs/superpowers/specs/2026-04-25-session-start-payload-index-design.md`
Plan: `docs/superpowers/plans/2026-04-25-session-start-payload-index.md`

## Test plan

- [x] Unit suite: 605 tests pass (added 7 for renderers — basic shape, project-priority budget overflow, exact-fit boundary, empty list, scope-grouped sections, flags section, empty `renderFull`).
- [x] REST smoke: `POST /api/tools/memory_session_start` returns `{preview, full, meta}`; `meta.index_truncated_count` populated; `preview` contains `{{PATH}}` placeholder + `MUST Read` instruction.
- [x] Claude hook: writes `<cwd>/.agent-brain/session.md`, appends `.agent-brain/` to `.gitignore`, emits `hookSpecificOutput.additionalContext` with substituted absolute path.
- [x] Copilot hook: same flow, emits both flat + wrapped envelopes.
- [x] Sed escape: workspace path containing `&` (`/tmp/foo&bar/agent-brain`) substitutes correctly.
- [ ] Live Claude Code session: confirm agent reads `.agent-brain/session.md` before first response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)