### PR TITLE
build(docker): env-driven host ports for worktree isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,23 @@ npm run seed
 npm run migrate:flag-relationships
 ```
 
+### Working in a git worktree
+
+The default docker-compose stack binds `localhost:5432` (Postgres) and `localhost:11434` (Ollama). To run a worktree's docker stack alongside the parent's, override the host ports + project name in your worktree shell before `docker compose up`:
+
+```bash
+export COMPOSE_PROJECT_NAME=agent-brain-<worktree-slug>
+export POSTGRES_PORT=5433
+export OLLAMA_PORT=11435
+export DATABASE_URL=postgresql://agentic:agentic@localhost:5433/agent_brain
+export OLLAMA_BASE_URL=http://localhost:11435
+
+docker compose up -d
+npm test
+```
+
+Pick any free port pair. The parent repo keeps the defaults; the worktree picks alt values. `tests/global-setup.ts` reads `POSTGRES_PORT` so the test suite connects to the worktree's Postgres rather than the parent's.
+
 ### Project structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ npm run migrate:flag-relationships
 The default docker-compose stack binds `localhost:5432` (Postgres) and `localhost:11434` (Ollama). To run a worktree's docker stack alongside the parent's, override the host ports + project name in your worktree shell before `docker compose up`:
 
 ```bash
-export COMPOSE_PROJECT_NAME=agent-brain-<worktree-slug>
+export COMPOSE_PROJECT_NAME=agent-brain-phase5
 export POSTGRES_PORT=5433
 export OLLAMA_PORT=11435
 export DATABASE_URL=postgresql://agentic:agentic@localhost:5433/agent_brain
@@ -428,9 +428,14 @@ export OLLAMA_BASE_URL=http://localhost:11435
 
 docker compose up -d
 npm test
+
+# When done with the worktree:
+docker compose down -v
 ```
 
-Pick any free port pair. The parent repo keeps the defaults; the worktree picks alt values. `tests/global-setup.ts` reads `POSTGRES_PORT` so the test suite connects to the worktree's Postgres rather than the parent's.
+Pick any free port pair. The parent repo keeps the defaults; the worktree picks alt values. `POSTGRES_PORT` / `OLLAMA_PORT` only control the host-side port binding in `docker-compose.yml`; application code reads `DATABASE_URL` and `OLLAMA_BASE_URL`, so both sets must be exported. `tests/global-setup.ts` reads `POSTGRES_PORT` so the test suite connects to the worktree's Postgres rather than the parent's.
+
+**Data-loss warning:** if you forget these exports, `npm test` and `npm run seed` fall back to `localhost:5432` and operate on the **parent's** Postgres — `npm test` will drop and recreate `agent_brain_test` there. Verify your shell with `echo $POSTGRES_PORT` before running tests in a worktree.
 
 ### Project structure
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   postgres:
     image: pgvector/pgvector:pg17
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT:-5432}:5432"
     environment:
       POSTGRES_USER: agentic
       POSTGRES_PASSWORD: agentic
@@ -19,7 +19,7 @@ services:
   ollama:
     image: ollama/ollama:latest
     ports:
-      - "11434:11434"
+      - "${OLLAMA_PORT:-11434}:11434"
     volumes:
       - ollama_data:/root/.ollama
     healthcheck:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "agent-brain-merge-memory": "./dist/src/cli/merge-memory.js"
   },
   "scripts": {
-    "dev": "docker compose up -d --wait && npx drizzle-kit migrate && EMBEDDING_PROVIDER=ollama EMBEDDING_DIMENSIONS=768 OLLAMA_BASE_URL=http://localhost:11434 tsx watch src/server.ts",
+    "dev": "docker compose up -d --wait && npx drizzle-kit migrate && EMBEDDING_PROVIDER=ollama EMBEDDING_DIMENSIONS=768 OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://localhost:11434} tsx watch src/server.ts",
     "start": "tsx src/server.ts",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -2,8 +2,9 @@ import { spawn } from "child_process";
 import postgres from "postgres";
 
 const TEST_DB = "agent_brain_test";
-const MAINTENANCE_URL = "postgresql://agentic:agentic@localhost:5432/postgres";
-export const TEST_DB_URL = `postgresql://agentic:agentic@localhost:5432/${TEST_DB}`;
+const PG_PORT = process.env.POSTGRES_PORT ?? "5432";
+const MAINTENANCE_URL = `postgresql://agentic:agentic@localhost:${PG_PORT}/postgres`;
+export const TEST_DB_URL = `postgresql://agentic:agentic@localhost:${PG_PORT}/${TEST_DB}`;
 
 export async function setup() {
   // Ensure Postgres container is running


### PR DESCRIPTION
## Summary

- `docker-compose.yml` host ports become `${POSTGRES_PORT:-5432}:5432` / `${OLLAMA_PORT:-11434}:11434` so a `git worktree` can run an isolated docker stack alongside the parent's without bind collisions.
- `tests/global-setup.ts` derives `MAINTENANCE_URL` and `TEST_DB_URL` from `process.env.POSTGRES_PORT` (default 5432).
- README gains a `### Working in a git worktree` subsection documenting the operator workflow (`COMPOSE_PROJECT_NAME` / `POSTGRES_PORT` / `OLLAMA_PORT` / `DATABASE_URL` / `OLLAMA_BASE_URL` exports).

Defaults preserve all existing behavior (parent shells, CI). Spec: `docs/superpowers/specs/2026-04-25-docker-compose-worktree-isolation-design.md`. Plan: `docs/superpowers/plans/2026-04-25-docker-compose-worktree-isolation.md`.

Driver: unblocks Phase 5 vault watcher work, which needs to run in a dedicated worktree per `superpowers:subagent-driven-development`.

## Test Plan

- [x] `docker compose config` shows `published: "5432"` / `published: "11434"` with no env vars set
- [x] `POSTGRES_PORT=5433 OLLAMA_PORT=11435 docker compose config` shows `published: "5433"` / `published: "11435"`
- [x] `npx tsc --noEmit -p .` clean
- [x] Unit suite: 605/605 pass against default port
- [x] E2E smoke: parent stack on 5432/11434 + sibling worktree stack on 5433/11435 coexist; full `npm test` (1105 tests) green against alt-port stack with `POSTGRES_PORT=5433`
- [x] Iso teardown leaves parent stack untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)